### PR TITLE
Support Neovim built-in LSP highlight groups

### DIFF
--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-harmonic-dark.vim
+++ b/colors/base16-harmonic-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-harmonic-light.vim
+++ b/colors/base16-harmonic-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -425,6 +425,14 @@ call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
 
+" LSP highlighting
+if has("nvim")
+  call <sid>hi("LspDiagnosticsDefaultError",       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultWarning",     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultInformation", s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("LspDiagnosticsDefaultHint",        s:gui03, "", s:cterm03, "", "", "")
+endif
+
 " Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 


### PR DESCRIPTION
# Description

Neovim is coming out with built-in support for language servers (v0.5). This addition sets default colors for the diagnostics output (errors and warnings and such provided by the language server).

# Checklist

- [x] I have built the project after my changes following [the build instructions](https://github.com/fnune/base16-vim#building) using `make build`
- [x] I have confirmed that my changes produce no regressions after building
- [x] I have pushed the built files to this pull request
