### PR TITLE
Remove treesitter highlights

### DIFF
--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-apprentice.vim
+++ b/colors/base16-apprentice.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-colors.vim
+++ b/colors/base16-colors.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-danqing.vim
+++ b/colors/base16-danqing.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-darcula.vim
+++ b/colors/base16-darcula.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-harmonic-dark.vim
+++ b/colors/base16-harmonic-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-harmonic-light.vim
+++ b/colors/base16-harmonic-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-pinky.vim
+++ b/colors/base16-pinky.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-qualia.vim
+++ b/colors/base16-qualia.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-rose-pine-dawn.vim
+++ b/colors/base16-rose-pine-dawn.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-rose-pine-moon.vim
+++ b/colors/base16-rose-pine-moon.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-rose-pine.vim
+++ b/colors/base16-rose-pine.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-sakura.vim
+++ b/colors/base16-sakura.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-shades-of-purple.vim
+++ b/colors/base16-shades-of-purple.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-tender.vim
+++ b/colors/base16-tender.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-10-light.vim
+++ b/colors/base16-windows-10-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-10.vim
+++ b/colors/base16-windows-10.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-95-light.vim
+++ b/colors/base16-windows-95-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-95.vim
+++ b/colors/base16-windows-95.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-highcontrast-light.vim
+++ b/colors/base16-windows-highcontrast-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-highcontrast.vim
+++ b/colors/base16-windows-highcontrast.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-nt-light.vim
+++ b/colors/base16-windows-nt-light.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-windows-nt.vim
+++ b/colors/base16-windows-nt.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -523,16 +523,8 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Neovim Treesitter highlighting
+" Treesitter-refactor highlighting
 if has("nvim")
-  call <sid>hi("TSFunction",        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSKeywordFunction", s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("TSMethod",          s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("TSProperty",        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("TSPunctBracket",    s:gui0C, "", s:cterm0C, "", "", "")
-  call <sid>hi("TSType",            s:gui08, "", s:cterm08, "", "none", "")
-
-  " Treesitter-refactor highlighting
   call <sid>hi("TSDefinition",       "", s:gui03, "", s:cterm03, "", "")
   call <sid>hi("TSDefinitionUsage",  "", s:gui02, "", s:cterm02, "none", "")
 endif


### PR DESCRIPTION
# Description

Treesitter provides highlights out of the box, which link to vims default highlights.

# Checklist

- [x] I have built the project after my changes following [the build instructions](https://github.com/fnune/base16-vim#building) using `make`
- [x] I have confirmed that my changes produce no regressions after building
- [x] I have pushed the built files to this pull request
