### PR TITLE
Require a minimal vimrc in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,5 +21,11 @@ Vim or Neovim:
 Vim or Neovim version:
 Any other plugins you may consider relevant:
 
+**Minimal configuration file**
+```vim
+" Add a minimal configuration file to dramatically increase
+" your chances of receiving help from a maintainer.
+```
+
 **Additional context**
 <!-- Add any other context about the problem here. -->


### PR DESCRIPTION
# Description

Fixes #30 

# Checklist

- [x] I have built the project after my changes following [the build instructions](https://github.com/fnune/base16-vim#building) using `make`
- [x] I have confirmed that my changes produce no regressions after building
- [x] I have pushed the built files to this pull request
