### PR TITLE
Fix LspReference highlight groups typo

### DIFF
--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-apprentice.vim
+++ b/colors/base16-apprentice.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-colors.vim
+++ b/colors/base16-colors.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-danqing.vim
+++ b/colors/base16-danqing.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-darcula.vim
+++ b/colors/base16-darcula.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-harmonic-dark.vim
+++ b/colors/base16-harmonic-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-harmonic-light.vim
+++ b/colors/base16-harmonic-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-pinky.vim
+++ b/colors/base16-pinky.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-qualia.vim
+++ b/colors/base16-qualia.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-rose-pine-dawn.vim
+++ b/colors/base16-rose-pine-dawn.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-rose-pine-moon.vim
+++ b/colors/base16-rose-pine-moon.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-rose-pine.vim
+++ b/colors/base16-rose-pine.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-sakura.vim
+++ b/colors/base16-sakura.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-shades-of-purple.vim
+++ b/colors/base16-shades-of-purple.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-tender.vim
+++ b/colors/base16-tender.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-10-light.vim
+++ b/colors/base16-windows-10-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-10.vim
+++ b/colors/base16-windows-10.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-95-light.vim
+++ b/colors/base16-windows-95-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-95.vim
+++ b/colors/base16-windows-95.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-highcontrast-light.vim
+++ b/colors/base16-windows-highcontrast-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-highcontrast.vim
+++ b/colors/base16-windows-highcontrast.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-nt-light.vim
+++ b/colors/base16-windows-nt-light.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-windows-nt.vim
+++ b/colors/base16-windows-nt.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -551,9 +551,9 @@ if has("nvim")
   hi default link LspDiagnosticsUnderlineInfo     InfoHighlight
   hi default link LspDiagnosticsUnderlineHint     HintHighlight
 
-  hi default link LsoReferenceText   ReferenceText
-  hi default link LsoReferenceRead   ReferenceRead
-  hi default link LsoReferenceWrite  ReferenceWrite
+  hi default link LspReferenceText   ReferenceText
+  hi default link LspReferenceRead   ReferenceRead
+  hi default link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java highlighting


### PR DESCRIPTION
# Description

Fix typos for LspReference highlight groups.

# Checklist

- [x] I have built the project after my changes following [the build instructions](https://github.com/fnune/base16-vim/blob/master/CONTRIBUTING.md#building) using `make`
- [x] I have confirmed that my changes produce no regressions after building
- [x] I have pushed the built files to this pull request
