### PR TITLE
Remove duplicate line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Supports console [Vim][1], graphical Vim and [Neovim][2].
 
-Supports graphical Vim and console Vim.
-
 Over [200 themes][3] plus light/dark variations are available. Here are
 some of our favorites:
 


### PR DESCRIPTION
# Description

Removes the duplicate supported applications line from the README.md

# Checklist

- [ ] I have built the project after my changes following [the build
  instructions](https://github.com/base16-project/base16-vim/blob/main/CONTRIBUTING.md#building)
  using `make`
- [ ] I have confirmed that my changes produce no regressions after building
- [ ] I have pushed the built files to this pull request
