### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/vim
+* @tinted-theming/vim

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 title: "[Bug report] "
 labels: ["bug"]
 assignees: 
-  - base16-project/vim
+  - tinted-theming/vim
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: "[Feature request] "
 labels: ["feature"]
 assignees: 
-  - base16-project/vim
+  - tinted-theming/vim
 ---
 
 ## Is your feature request related to a problem? Please describe.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Fixes #ISSUE_NUMBER
 # Checklist
 
 - [ ] I have built the project after my changes following [the build
-  instructions](https://github.com/base16-project/base16-vim/blob/main/CONTRIBUTING.md#building)
+  instructions](https://github.com/tinted-theming/base16-vim/blob/main/CONTRIBUTING.md#building)
   using `make`
 - [ ] I have confirmed that my changes produce no regressions after building
 - [ ] I have pushed the built files to this pull request

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16-project/base16-schemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -15,16 +15,16 @@ jobs:
       - name: Fetch the schemes repository
         uses: actions/checkout@v3
         with:
-          repository: base16-project/base16-schemes
+          repository: tinted-theming/base16-schemes
           path: schemes
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,10 @@ Please follow the instructions in the issue templates:
 - [Issue template for bug reports]
 - [Issue template for feature requests]
 
-[base16-builder-go]: https://github.com/base16-project/base16-builder-go
-[base16-schemes]: https://github.com/base16-project/base16-schemes
+[base16-builder-go]: https://github.com/tinted-theming/base16-builder-go
+[base16-schemes]: https://github.com/tinted-theming/base16-schemes
 [GitHub Action]: .github/workflows/update.yml
-[latest base16-builder-go binary]: https://github.com/base16-project/base16-builder-go/releases
+[latest base16-builder-go binary]: https://github.com/tinted-theming/base16-builder-go/releases
 [PR template]: .github/pull_request_template.md
 [Issue template for bug reports]: .github/ISSUE_TEMPLATE/bug_report.md
 [Issue template for feature requests]: .github/ISSUE_TEMPLATE/feature_request.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,7 @@ Base16 Vim is released under the MIT License:
 
 > Copyright (C) 2012 [Chris Kempson](http://chriskempson.com)
 > Copyright (C) 2021 [Fausto Núñez Alberro](https://fnune.com/)
+> Copyright (C) 2022 [Tinted Theming](https://github.com/tinted-theming)
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add `colorscheme base16-default-dark` to your `~/.vimrc`.
 Add the following to your `~/.vimrc` file and run `PluginInstall` in Vim.
 
 ```vim
-Plugin 'base16-project/base16-vim'
+Plugin 'tinted-theming/base16-vim'
 ```
 
 ### vim-plug
@@ -40,21 +40,21 @@ Plugin 'base16-project/base16-vim'
 Add the following to your `~/.vimrc` file and run `PlugInstall` in Vim.
 
 ```vim
-Plug 'base16-project/base16-vim'
+Plug 'tinted-theming/base16-vim'
 ```
 
 ### Pathogen
 
 ```bash
 cd ~/.vim/bundle
-git clone https://github.com/base16-project/base16-vim.git
+git clone https://github.com/tinted-theming/base16-vim.git
 ```
 
 ### Manual
 
 ```bash
 cd ~/.vim/colors
-git clone git://github.com/base16-project/base16-vim.git base16
+git clone git://github.com/tinted-theming/base16-vim.git base16
 cp base16/colors/*.vim .
 ```
 
@@ -62,7 +62,7 @@ cp base16/colors/*.vim .
 
 ```bash
 cd ~/.config/nvim/colors
-git clone git://github.com/base16-project/base16-vim.git base16
+git clone git://github.com/tinted-theming/base16-vim.git base16
 cp base16/colors/*.vim .
 ```
 
@@ -137,10 +137,10 @@ instructions.
 
 [1]: https://github.com/vim/vim
 [2]: https://github.com/neovim/neovim
-[3]: https://github.com/base16-project/base16-schemes
-[4]: https://github.com/base16-project/home#official-templates
-[5]: https://github.com/base16-project/home#unofficial-templates
-[6]: https://github.com/base16-project/base16-shell
+[3]: https://github.com/tinted-theming/base16-schemes
+[4]: https://github.com/tinted-theming/home#official-templates
+[5]: https://github.com/tinted-theming/home#unofficial-templates
+[6]: https://github.com/tinted-theming/base16-shell
 [7]: https://github.com/vim/vim/blob/23c1b2b018c8121ca5fcc247e37966428bf8ca66/runtime/doc/options.txt#L7876
 [8]: https://neovim.io/doc/user/options.html#'termguicolors'
 [9]: CONTRIBUTING.md

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/chriskempson/base16-vim)
+" base16-vim (https://github.com/tinted-theming/base16-vim)
 " Scheme name: {{scheme-name}}
 " Scheme author: {{scheme-author}}
 " Template author: Tinted Theming (https://github.com/tinted-theming)

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,8 +1,9 @@
 " vi:syntax=vim
 
 " base16-vim (https://github.com/chriskempson/base16-vim)
-" by Chris Kempson (http://chriskempson.com)
-" {{scheme-name}} scheme by {{scheme-author}}
+" Scheme name: {{scheme-name}}
+" Scheme author: {{scheme-author}}
+" Template author: Tinted Theming (https://github.com/tinted-theming)
 
 " This enables the coresponding base16-shell script to run so that
 " :colorscheme works in terminals supported by base16-shell scripts


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.