### PR TITLE
Replace TS* highlight groups

### DIFF
--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-apprentice.vim
+++ b/colors/base16-apprentice.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ayu-dark.vim
+++ b/colors/base16-ayu-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ayu-light.vim
+++ b/colors/base16-ayu-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ayu-mirage.vim
+++ b/colors/base16-ayu-mirage.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-blueforest.vim
+++ b/colors/base16-blueforest.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-blueish.vim
+++ b/colors/base16-blueish.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-catppuccin.vim
+++ b/colors/base16-catppuccin.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-colors.vim
+++ b/colors/base16-colors.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-da-one-black.vim
+++ b/colors/base16-da-one-black.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-da-one-gray.vim
+++ b/colors/base16-da-one-gray.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-da-one-ocean.vim
+++ b/colors/base16-da-one-ocean.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-da-one-paper.vim
+++ b/colors/base16-da-one-paper.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-da-one-sea.vim
+++ b/colors/base16-da-one-sea.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-da-one-white.vim
+++ b/colors/base16-da-one-white.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-danqing-light.vim
+++ b/colors/base16-danqing-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-danqing.vim
+++ b/colors/base16-danqing.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-darcula.vim
+++ b/colors/base16-darcula.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-emil.vim
+++ b/colors/base16-emil.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-everforest.vim
+++ b/colors/base16-everforest.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gotham.vim
+++ b/colors/base16-gotham.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruber.vim
+++ b/colors/base16-gruber.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-material-dark-hard.vim
+++ b/colors/base16-gruvbox-material-dark-hard.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-material-dark-medium.vim
+++ b/colors/base16-gruvbox-material-dark-medium.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-material-dark-soft.vim
+++ b/colors/base16-gruvbox-material-dark-soft.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-material-light-hard.vim
+++ b/colors/base16-gruvbox-material-light-hard.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-material-light-medium.vim
+++ b/colors/base16-gruvbox-material-light-medium.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-gruvbox-material-light-soft.vim
+++ b/colors/base16-gruvbox-material-light-soft.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-harmonic16-dark.vim
+++ b/colors/base16-harmonic16-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-harmonic16-light.vim
+++ b/colors/base16-harmonic16-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-kanagawa.vim
+++ b/colors/base16-kanagawa.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-katy.vim
+++ b/colors/base16-katy.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-lime.vim
+++ b/colors/base16-lime.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-pandora.vim
+++ b/colors/base16-pandora.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-pinky.vim
+++ b/colors/base16-pinky.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-primer-dark-dimmed.vim
+++ b/colors/base16-primer-dark-dimmed.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-primer-dark.vim
+++ b/colors/base16-primer-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-primer-light.vim
+++ b/colors/base16-primer-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-purpledream.vim
+++ b/colors/base16-purpledream.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-qualia.vim
+++ b/colors/base16-qualia.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-rose-pine-dawn.vim
+++ b/colors/base16-rose-pine-dawn.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-rose-pine-moon.vim
+++ b/colors/base16-rose-pine-moon.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-rose-pine.vim
+++ b/colors/base16-rose-pine.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-sakura.vim
+++ b/colors/base16-sakura.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-shades-of-purple.vim
+++ b/colors/base16-shades-of-purple.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-shadesmear-dark.vim
+++ b/colors/base16-shadesmear-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-shadesmear-light.vim
+++ b/colors/base16-shadesmear-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-spaceduck.vim
+++ b/colors/base16-spaceduck.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-stella.vim
+++ b/colors/base16-stella.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-still-alive.vim
+++ b/colors/base16-still-alive.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tender.vim
+++ b/colors/base16-tender.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-city-dark.vim
+++ b/colors/base16-tokyo-city-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-city-light.vim
+++ b/colors/base16-tokyo-city-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-city-terminal-dark.vim
+++ b/colors/base16-tokyo-city-terminal-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-city-terminal-light.vim
+++ b/colors/base16-tokyo-city-terminal-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-night-dark.vim
+++ b/colors/base16-tokyo-night-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-night-light.vim
+++ b/colors/base16-tokyo-night-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-night-storm.vim
+++ b/colors/base16-tokyo-night-storm.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-night-terminal-dark.vim
+++ b/colors/base16-tokyo-night-terminal-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-night-terminal-light.vim
+++ b/colors/base16-tokyo-night-terminal-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyo-night-terminal-storm.vim
+++ b/colors/base16-tokyo-night-terminal-storm.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyodark-terminal.vim
+++ b/colors/base16-tokyodark-terminal.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tokyodark.vim
+++ b/colors/base16-tokyodark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-unikitty-reversible.vim
+++ b/colors/base16-unikitty-reversible.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-uwunicorn.vim
+++ b/colors/base16-uwunicorn.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-vice.vim
+++ b/colors/base16-vice.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-10-light.vim
+++ b/colors/base16-windows-10-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-10.vim
+++ b/colors/base16-windows-10.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-95-light.vim
+++ b/colors/base16-windows-95-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-95.vim
+++ b/colors/base16-windows-95.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-highcontrast-light.vim
+++ b/colors/base16-windows-highcontrast-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-highcontrast.vim
+++ b/colors/base16-windows-highcontrast.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-nt-light.vim
+++ b/colors/base16-windows-nt-light.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-windows-nt.vim
+++ b/colors/base16-windows-nt.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-zenbones.vim
+++ b/colors/base16-zenbones.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -405,34 +405,34 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -405,7 +405,7 @@ call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 
 " CMP
-hi! link CmpItemAbbrDeprecated  Deprecated 
+hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
 hi! link CmpItemKindText TSText
@@ -464,7 +464,7 @@ call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
 
 " GitGutter
 hi! link GitGutterAdd            GitAddSign
-hi! link GitGutterChange         GitChangeSign  
+hi! link GitGutterChange         GitChangeSign
 hi! link GitGutterDelete         GitDeleteSign
 hi! link GitGutterChangeDelete   GitChangeDeleteSign
 

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -408,31 +408,31 @@ call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
 hi! link CmpItemAbbrDeprecated  Deprecated
 hi! link CmpItemAbbrMatch       SearchMatch
 hi! link CmpItemAbbrMatchFuzzy  SearchMatch
-hi! link CmpItemKindText TSText
-hi! link CmpItemKindMethod TSMethod
-hi! link CmpItemKindFunction TSFunction
-hi! link CmpItemKindConstructor TSConstructor
-hi! link CmpItemKindField TSField
-hi! link CmpItemKindVariable TSVariable
-" hi! link CmpItemKindClass TS
-hi! link CmpItemKindInterface TSText
-" hi! link CmpItemKindModule TS
-hi! link CmpItemKindProperty TSProperty
-hi! link CmpItemKindUnit TSKeyword
-" hi! link CmpItemKindValue TS
-" hi! link CmpItemKindEnum TS
-hi! link CmpItemKindKeyword TSKeyword
-" hi! link CmpItemKindSnippet TS
-" hi! link CmpItemKindColor TS
-" hi! link CmpItemKindFile TS
-" hi! link CmpItemKindReference TS
-" hi! link CmpItemKindFolder TS
-" hi! link CmpItemKindEnumMember TS
-hi! link CmpItemKindConstant TSConstant
-" hi! link CmpItemKindStruct TS
-" hi! link CmpItemKindEvent TS
-hi! link CmpItemKindOperator TSOperator
-hi! link CmpItemKindTypeParameter TSType
+hi! link CmpItemKindText @text
+hi! link CmpItemKindMethod @method
+hi! link CmpItemKindFunction @function
+hi! link CmpItemKindConstructor @constructor
+hi! link CmpItemKindField @field
+hi! link CmpItemKindVariable @variable
+" hi! link CmpItemKindClass @
+hi! link CmpItemKindInterface @text
+" hi! link CmpItemKindModule @
+hi! link CmpItemKindProperty @property
+hi! link CmpItemKindUnit @keyword
+" hi! link CmpItemKindValue @
+" hi! link CmpItemKindEnum @
+hi! link CmpItemKindKeyword @keyword
+" hi! link CmpItemKindSnippet @
+" hi! link CmpItemKindColor @
+" hi! link CmpItemKindFile @
+" hi! link CmpItemKindReference @
+" hi! link CmpItemKindFolder @
+" hi! link CmpItemKindEnumMember @
+hi! link CmpItemKindConstant @constant
+" hi! link CmpItemKindStruct @
+" hi! link CmpItemKindEvent @
+hi! link CmpItemKindOperator @operator
+hi! link CmpItemKindTypeParameter @type
 
 " Diff
 call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
@@ -561,9 +561,6 @@ call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
-
-" Treesitter
-hi! link TSVariable Identifier
 
 " Treesitter-refactor
 if has("nvim")


### PR DESCRIPTION
# Description

This PR removes all of the `TS` highlight groups that were removed from nvim-treesitter in https://github.com/nvim-treesitter/nvim-treesitter/pull/3656.

I've also removed the link for `TSVariable` all together as neovim does the same thing as this plugin ([source](https://github.com/neovim/neovim/blob/90138d5ed87cc8dde49ee74e422a5de2191a3f76/src/nvim/highlight_group.c#L232)).

Fixes #65

# Checklist

- [x] I have built the project after my changes following [the build instructions](https://github.com/tinted-theming/base16-vim/blob/main/CONTRIBUTING.md#building) using `make`
- [x] I have confirmed that my changes produce no regressions after building
- [x] I have pushed the built files to this pull request
