### PR TITLE
Remove outdated highlights and adjust missing highlights

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -600,36 +600,16 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticsVirtualTextError    ErrorSign
-  hi! link DiagnosticsVirtualTextWarning  WarningSign
-  hi! link DiagnosticsVirtualTextInfo     InfoSign
-  hi! link DiagnosticsVirtualTextHint     HintSign
-  hi! link DiagnosticsVirtualTextOk       OkSign
+  hi! link DiagnosticVirtualTextError    ErrorSign
+  hi! link DiagnosticVirtualTextWarning  WarningSign
+  hi! link DiagnosticVirtualTextInfo     InfoSign
+  hi! link DiagnosticVirtualTextHint     HintSign
+  hi! link DiagnosticVirtualTextOk       OkSign
 
-  " Remove untill endif on next nvim release
-  hi! link LspDiagnosticsSignError    ErrorSign
-  hi! link LspDiagnosticsSignWarning  WarningSign
-  hi! link LspDiagnosticsSignInfo     InfoSign
-  hi! link LspDiagnosticsSignHint     HintSign
-
-  hi! link LspDiagnosticsVirtualTextError    ErrorSign
-  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
-  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
-  hi! link LspDiagnosticsVirtualTextHint     HintSign
-
-  hi! link LspDiagnosticsFloatingError    ErrorFloat
-  hi! link LspDiagnosticsFloatingWarning  WarningFloat
-  hi! link LspDiagnosticsFloatingInfo     InfoFloat
-  hi! link LspDiagnosticsFloatingHint     HintFloat
-
-  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
-  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
-  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
-  hi! link LspDiagnosticsUnderlineHint     HintHighlight
-
-  hi! link LspReferenceText   ReferenceText
-  hi! link LspReferenceRead   ReferenceRead
-  hi! link LspReferenceWrite  ReferenceWrite
+  hi! link DiagnosticSignError  ErrorSign
+  hi! link DiagnosticSignWarn   WarningSign
+  hi! link DiagnosticSignInfo   InfoSign
+  hi! link DiagnosticSignHint   HintSign
 endif
 
 " Java


### PR DESCRIPTION
# Description

Remove outdated highlights as mentioned in https://github.com/tinted-theming/base16-vim/issues/36

I found a bug in these highlights while doing the edit. Several highlights were incorrectly named, for example `DiagnosticsVirtualTextError` should have been `DiagnosticVirtualTextError`. Also I noticed that the legacy highlights included highlights currently missing, namely `DiagnosticSignError`, `DiagnosticSignWarn`, `DiagnosticSignInfo` and `DiagnosticSignHint`.