### PR TITLE
Add install instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ git clone git://github.com/tinted-theming/base16-vim.git base16
 cp base16/colors/*.vim .
 ```
 
+### Lazy.nvim
+```lua
+{
+    "tinted-theming/base16-vim",
+}
+```
+
 ### Manual neovim
 
 ```bash


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Added a small section in the README describing how to install using [`lazy.nvim`](https://github.com/folke/lazy.nvim)

# Checklist

- [ ] I have built the project after my changes following [the build
  instructions](https://github.com/tinted-theming/base16-vim/blob/main/CONTRIBUTING.md#building)
  using a [base16 builder](https://github.com/tinted-theming/base16-builder-go)
- [ ] I have confirmed that my changes produce no regressions after building
- [x] My changes don't include the built files `./colors/*.sh`
