### PR TITLE
Add missing Treesitter highlights

### DIFF
--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-apprentice.vim
+++ b/colors/base16-apprentice.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ayu-dark.vim
+++ b/colors/base16-ayu-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ayu-light.vim
+++ b/colors/base16-ayu-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ayu-mirage.vim
+++ b/colors/base16-ayu-mirage.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-blueforest.vim
+++ b/colors/base16-blueforest.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-blueish.vim
+++ b/colors/base16-blueish.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-caroline.vim
+++ b/colors/base16-caroline.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-catppuccin-frappe.vim
+++ b/colors/base16-catppuccin-frappe.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-catppuccin-latte.vim
+++ b/colors/base16-catppuccin-latte.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-catppuccin-macchiato.vim
+++ b/colors/base16-catppuccin-macchiato.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-catppuccin-mocha.vim
+++ b/colors/base16-catppuccin-mocha.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-colors.vim
+++ b/colors/base16-colors.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-da-one-black.vim
+++ b/colors/base16-da-one-black.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-da-one-gray.vim
+++ b/colors/base16-da-one-gray.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-da-one-ocean.vim
+++ b/colors/base16-da-one-ocean.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-da-one-paper.vim
+++ b/colors/base16-da-one-paper.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-da-one-sea.vim
+++ b/colors/base16-da-one-sea.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-da-one-white.vim
+++ b/colors/base16-da-one-white.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-danqing-light.vim
+++ b/colors/base16-danqing-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-danqing.vim
+++ b/colors/base16-danqing.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-darcula.vim
+++ b/colors/base16-darcula.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-embers-light.vim
+++ b/colors/base16-embers-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-emil.vim
+++ b/colors/base16-emil.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-eris.vim
+++ b/colors/base16-eris.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-evenok-dark.vim
+++ b/colors/base16-evenok-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-everforest-dark-hard.vim
+++ b/colors/base16-everforest-dark-hard.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-everforest.vim
+++ b/colors/base16-everforest.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gotham.vim
+++ b/colors/base16-gotham.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruber.vim
+++ b/colors/base16-gruber.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-material-dark-hard.vim
+++ b/colors/base16-gruvbox-material-dark-hard.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-material-dark-medium.vim
+++ b/colors/base16-gruvbox-material-dark-medium.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-material-dark-soft.vim
+++ b/colors/base16-gruvbox-material-dark-soft.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-material-light-hard.vim
+++ b/colors/base16-gruvbox-material-light-hard.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-material-light-medium.vim
+++ b/colors/base16-gruvbox-material-light-medium.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-gruvbox-material-light-soft.vim
+++ b/colors/base16-gruvbox-material-light-soft.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-harmonic16-dark.vim
+++ b/colors/base16-harmonic16-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-harmonic16-light.vim
+++ b/colors/base16-harmonic16-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-jabuti.vim
+++ b/colors/base16-jabuti.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-kanagawa.vim
+++ b/colors/base16-kanagawa.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-katy.vim
+++ b/colors/base16-katy.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-lime.vim
+++ b/colors/base16-lime.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-measured-dark.vim
+++ b/colors/base16-measured-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-measured-light.vim
+++ b/colors/base16-measured-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-mountain.vim
+++ b/colors/base16-mountain.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-nord-light.vim
+++ b/colors/base16-nord-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-oxocarbon-dark.vim
+++ b/colors/base16-oxocarbon-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-oxocarbon-light.vim
+++ b/colors/base16-oxocarbon-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-pandora.vim
+++ b/colors/base16-pandora.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-pinky.vim
+++ b/colors/base16-pinky.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-primer-dark-dimmed.vim
+++ b/colors/base16-primer-dark-dimmed.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-primer-dark.vim
+++ b/colors/base16-primer-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-primer-light.vim
+++ b/colors/base16-primer-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-purpledream.vim
+++ b/colors/base16-purpledream.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-qualia.vim
+++ b/colors/base16-qualia.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-rose-pine-dawn.vim
+++ b/colors/base16-rose-pine-dawn.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-rose-pine-moon.vim
+++ b/colors/base16-rose-pine-moon.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-rose-pine.vim
+++ b/colors/base16-rose-pine.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-saga.vim
+++ b/colors/base16-saga.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-sakura.vim
+++ b/colors/base16-sakura.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-selenized-black.vim
+++ b/colors/base16-selenized-black.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-selenized-dark.vim
+++ b/colors/base16-selenized-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-selenized-light.vim
+++ b/colors/base16-selenized-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-selenized-white.vim
+++ b/colors/base16-selenized-white.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-shades-of-purple.vim
+++ b/colors/base16-shades-of-purple.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-shadesmear-dark.vim
+++ b/colors/base16-shadesmear-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-shadesmear-light.vim
+++ b/colors/base16-shadesmear-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-spaceduck.vim
+++ b/colors/base16-spaceduck.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-standardized-dark.vim
+++ b/colors/base16-standardized-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-standardized-light.vim
+++ b/colors/base16-standardized-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-stella.vim
+++ b/colors/base16-stella.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-still-alive.vim
+++ b/colors/base16-still-alive.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tarot.vim
+++ b/colors/base16-tarot.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tender.vim
+++ b/colors/base16-tender.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-city-dark.vim
+++ b/colors/base16-tokyo-city-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-city-light.vim
+++ b/colors/base16-tokyo-city-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-city-terminal-dark.vim
+++ b/colors/base16-tokyo-city-terminal-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-city-terminal-light.vim
+++ b/colors/base16-tokyo-city-terminal-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-night-dark.vim
+++ b/colors/base16-tokyo-night-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-night-light.vim
+++ b/colors/base16-tokyo-night-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-night-storm.vim
+++ b/colors/base16-tokyo-night-storm.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-night-terminal-dark.vim
+++ b/colors/base16-tokyo-night-terminal-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-night-terminal-light.vim
+++ b/colors/base16-tokyo-night-terminal-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyo-night-terminal-storm.vim
+++ b/colors/base16-tokyo-night-terminal-storm.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyodark-terminal.vim
+++ b/colors/base16-tokyodark-terminal.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tokyodark.vim
+++ b/colors/base16-tokyodark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-unikitty-reversible.vim
+++ b/colors/base16-unikitty-reversible.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-uwunicorn.vim
+++ b/colors/base16-uwunicorn.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-vesper.vim
+++ b/colors/base16-vesper.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-vice.vim
+++ b/colors/base16-vice.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-10-light.vim
+++ b/colors/base16-windows-10-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-10.vim
+++ b/colors/base16-windows-10.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-95-light.vim
+++ b/colors/base16-windows-95-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-95.vim
+++ b/colors/base16-windows-95.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-highcontrast-light.vim
+++ b/colors/base16-windows-highcontrast-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-highcontrast.vim
+++ b/colors/base16-windows-highcontrast.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-nt-light.vim
+++ b/colors/base16-windows-nt-light.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-windows-nt.vim
+++ b/colors/base16-windows-nt.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-zenbones.vim
+++ b/colors/base16-zenbones.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -293,6 +293,86 @@ if has("nvim-0.8.0")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -288,11 +288,91 @@ call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
 " Treesitter
 if has("nvim-0.8.0")
   call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
-  call <sid>hi("@property",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
 endif
 
 " Standard highlights to be used by plugins
@@ -614,16 +694,36 @@ if has("nvim")
   hi! link DiagnosticUnderlineHint   HintHighlight
   hi! link DiagnosticUnderlineOk     OkHighlight
 
-  hi! link DiagnosticVirtualTextError    ErrorSign
-  hi! link DiagnosticVirtualTextWarning  WarningSign
-  hi! link DiagnosticVirtualTextInfo     InfoSign
-  hi! link DiagnosticVirtualTextHint     HintSign
-  hi! link DiagnosticVirtualTextOk       OkSign
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
 
-  hi! link DiagnosticSignError  ErrorSign
-  hi! link DiagnosticSignWarn   WarningSign
-  hi! link DiagnosticSignInfo   InfoSign
-  hi! link DiagnosticSignHint   HintSign
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
 endif
 
 " Java


### PR DESCRIPTION
# Description

There are basically no Treesitter highlights. This PR adds missing definitions, including for markdown which was mentioned as missing here: https://github.com/tinted-theming/base16-vim/issues/77