### PR TITLE
Use new, combined schemes repository

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,17 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Fetch the schemes repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          repository: tinted-theming/base16-schemes
+          repository: tinted-theming/schemes
           path: schemes
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
         uses: tinted-theming/base16-builder-go@latest
+        with:
+          path: schemes/base16
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,16 +12,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
-      - name: Fetch the schemes repository
-        uses: actions/checkout@v4
-        with:
-          repository: tinted-theming/schemes
-          path: schemes
-          token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
         uses: tinted-theming/base16-builder-go@latest
-        with:
-          path: schemes/base16
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ automatically.
 ### Usage for template editing
 
 1. Clone the template repository onto your system
-1. Download the [latest base16-builder-go binary]
-1. Execute the binary with the `-template-dir` arg and provide
+2. Download the [latest base16-builder-go binary]
+3. Execute the binary with the `-template-dir` arg and provide
    `/path/to/base16-vim` 
 
 Or the above steps represented in shell commands:
@@ -27,16 +27,16 @@ Or the above steps represented in shell commands:
 ### Usage for adding or editing a colorscheme
 
 1. Clone the base16-vim
-1. Clone [base16-schemes]
-1. Download the [latest base16-builder-go binary]
-1. Execute the binary with 
-  - `-schemes-dir` arg - provide `/path/to/base16-scehemes`
+2. Clone [schemes]
+3. Download the [latest base16-builder-go binary]
+4. Execute the binary with 
+  - `-schemes-dir` arg - provide `/path/to/schemes/base16`
   - `-template-dir` arg - provide `/path/to/base16-vim`
-    `base16-vim` repository)
+    (`base16-vim` repository)
 
 ```shell
 /path/to/base16-builder-go-binary \
-  -schemes-dir "/path/to/base16-schemes" \
+  -schemes-dir "/path/to/schemes/base16" \
   -template-dir "/path/to/base16-vim"
 ```
 
@@ -58,7 +58,7 @@ Please follow the instructions in the issue templates:
 - [Issue template for feature requests]
 
 [base16-builder-go]: https://github.com/tinted-theming/base16-builder-go
-[base16-schemes]: https://github.com/tinted-theming/base16-schemes
+[schemes]: https://github.com/tinted-theming/schemes
 [GitHub Action]: .github/workflows/update.yml
 [latest base16-builder-go binary]: https://github.com/tinted-theming/base16-builder-go/releases
 [PR template]: .github/pull_request_template.md

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ instructions.
 
 [1]: https://github.com/vim/vim
 [2]: https://github.com/neovim/neovim
-[3]: https://github.com/tinted-theming/base16-schemes
+[3]: https://github.com/tinted-theming/schemes
 [4]: https://github.com/tinted-theming/home#official-templates
 [5]: https://github.com/tinted-theming/home#unofficial-templates
 [6]: https://github.com/tinted-theming/base16-shell


### PR DESCRIPTION
# Description

Simplifies the GitHub workflow given `base16-builder-go` references the new, combined schemes repository. Updates documentation references. Updates GitHub core actions while modifying.

---

Fixes #N/A

Motivation: I came across this project and wanted to add color scheme. I noticed that this repo’s instructions were out of date, so I figured I would update them.

NOTE! This repo already has the latest schemes, likely because of the builder logic. Therefore, the workflow action doesn’t necessarily need updating, so let me know if I should reduce this to contributing update only. (Although, in this case, I think the checkout action is not needed, either.)

# Checklist

- [X] I have built the project after my changes following [the build
  instructions](https://github.com/tinted-theming/base16-vim/blob/main/CONTRIBUTING.md#building)
  using a [base16 builder](https://github.com/tinted-theming/base16-builder-go)
- [X] I have confirmed that my changes produce no regressions after building
- [X] My changes don't include the built files `./colors/*.sh`
