### PR TITLE
Neovim 0.10

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -290,6 +290,7 @@ if has("nvim-0.8.0")
   call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
   call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
   call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
@@ -373,7 +374,53 @@ if has("nvim-0.8.0")
   call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
   call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
   call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
 endif
+
 
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
@@ -729,6 +776,13 @@ if has("nvim")
   hi! link LspReferenceText   ReferenceText
   hi! link LspReferenceRead   ReferenceRead
   hi! link LspReferenceWrite  ReferenceWrite
+
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
 endif
 
 " Java


### PR DESCRIPTION
# Description

This keeps the theme working with neovim 0.10.
The changes are mostly inspired by suggestion in https://www.reddit.com/r/neovim/comments/19aratu/psa_nvimtreesitter_breaking_changes_on_highlight/.

Fixes #81

# Checklist

- [x] I have built the project after my changes following [the build
  instructions](https://github.com/tinted-theming/base16-vim/blob/main/CONTRIBUTING.md#building)
  using a [base16 builder](https://github.com/tinted-theming/base16-builder-go)
- [x] I have confirmed that my changes produce no regressions after building
- [x] My changes don't include the built files `./colors/*.sh`
