### PR TITLE
Add Base24 template support and rename repo to tinted-vim

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,10 @@
-# Description
+## Description
 
 <!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
 
 Fixes #ISSUE_NUMBER
 
-# Checklist
+## Checklist
 
-- [ ] I have built the project after my changes following [the build
-  instructions](https://github.com/tinted-theming/base16-vim/blob/main/CONTRIBUTING.md#building)
-  using a [base16 builder](https://github.com/tinted-theming/tinted-builder-rust)
+- [ ] I have included the built files `./colors/*.vim` in a separate commit and followed [the build instructions](https://github.com/tinted-theming/tinted-vim/blob/main/CONTRIBUTING.md)
 - [ ] I have confirmed that my changes produce no regressions after building
-- [ ] My changes don't include the built files `./colors/*.sh`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,23 +1,15 @@
-name: Check that running `make` does not produce additional changes
+name: Check that building template does not produce additional changes
 on:
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-      - name: Install pybase16
-        run: pip install pybase16-builder
       - name: Fetch the repository code
-        uses: actions/checkout@v2
-      - name: Run make
-        run: make
+        uses: actions/checkout@v4
+      - name: Update schemes
+        uses: tinted-theming/tinted-builder-rust@latest
       - name: Check if there are changes
         run: git diff --exit-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,16 +13,16 @@ automatically.
 ### Usage for template editing
 
 1. Install [tinted-builder-rust]
-1. `tinted-builder-rust build path/to/base16-vim`
+1. `tinted-builder-rust build path/to/tinted-vim`
 
 ### Usage for adding or editing a colorscheme
 
-1. Clone base16-vim
+1. Clone tinted-vim
 1. Install [tinted-builder-rust]
-1. Execute `tinted-builder-rust build path/to/base16-vim`
+1. Execute `tinted-builder-rust build path/to/tinted-vim`
 
 ```shell
-tinted-builder-rust build /path/to/base16-vim \
+tinted-builder-rust build /path/to/tinted-vim \
   --schemes-dir /path/to/tinted-schemes
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,36 @@
-# Base16 Vim
+# Tinted Vim
 
 [![Matrix Chat](https://img.shields.io/matrix/tinted-theming:matrix.org)](https://matrix.to/#/#tinted-theming:matrix.org)
 
-Supports console [Vim][1], graphical Vim and [Neovim][2].
+Supports console [Vim], graphical Vim and [Neovim].
 
-Over [200 themes][3] plus light/dark variations are available. Here are
+Over [250 themes] plus light/dark variations are available. Here are
 some of our favorites:
 
 The `classic-dark` theme:
 
-![base16-vim classic-dark][10]
+![tinted-vim classic-dark]
 
 The `horizon-dark` theme:
 
-![base16-vim horizon-dark][11]
+![tinted-vim horizon-dark]
 
 The `onedark` theme:
 
-![base16-vim onedark][12]
+![tinted-vim onedark]
 
 ## Terminal Themes
 
-For terminal Vim (non-gui) please ensure you are using a base16 terminal
-theme. Have a look at the list of [official][4] and [unofficial][5]
-themes for your terminal of choice.
+For terminal Vim (non-gui) please ensure you are using a terminal theme.
+Have a look at the list of [official] and [unofficial] themes for your
+terminal of choice.
 
 ## Installation
 
-Add `colorscheme base16-ayu-dark` to your `~/.vimrc`.
-
 ### Lazy.nvim
-
 ```lua
 {
-  "tinted-theming/tinted-vim",
-  config = function()
-    vim.cmd.colorscheme 'base16-ayu-dark'
-  end,
+    "tinted-theming/tinted-vim",
 }
 ```
 
@@ -55,7 +49,11 @@ use {
 
 ```sh
 cd ~/.vim/bundle
-git clone https://github.com/tinted-theming/base16-vim.git
+git clone https://github.com/tinted-theming/tinted-vim.git
+```
+
+```vim
+Plugin 'tinted-theming/tinted-vim'
 ```
 
 ### vim-plug
@@ -63,30 +61,19 @@ git clone https://github.com/tinted-theming/base16-vim.git
 Add the following to your `~/.vimrc` file and run `PlugInstall` in Vim.
 
 ```vim
-Plug 'tinted-theming/base16-vim'
+Plug 'tinted-theming/tinted-vim'
 ```
 
 ### Vundle
 
 Add the following to your `~/.vimrc` file and run `PluginInstall` in Vim.
 
+```sh
+git clone https://github.com/tinted-theming/tinted-vim.git ~/.vim/bundle/tinted-vim
+```
+
 ```vim
-Plugin 'tinted-theming/base16-vim'
-```
-
-### Manual
-
-```bash
-cd ~/.vim/colors
-git clone git://github.com/tinted-theming/base16-vim.git base16
-cp base16/colors/*.vim .
-```
-
-### Lazy.nvim
-```lua
-{
-    "tinted-theming/base16-vim",
-}
+Plugin 'tinted-theming/tinted-vim'
 ```
 
 #### Symlink
@@ -96,40 +83,50 @@ colors every time you do a `git pull` on the `tinted-vim` repo.
 
 1. Clone `tinted-vim` somewhere:
 
-```sh
-git clone git://github.com/tinted-theming/base16-vim.git ~/projects/base16-vim
-```
+  ```sh
+  git clone git://github.com/tinted-theming/tinted-vim.git ~/projects/tinted-vim
+  ```
 
-2. Remove your old vim/nvim `colors/` directory:
+2. Remove your old vim/nvim `colors/` directory if it exists:
 
-```sh
-rm -r ~/.vim/colors # Or ~/.config/nvim/colors for Neovim
-```
+  ```sh
+  rm -r ~/.vim/colors # Or ~/.config/nvim/colors for Neovim
+  ```
 
 3. Symlink the colors directory:
 
-```sh 
-ln -s ~/projects/base16-vim/colors ~/.vim/colors
-# Or for Neovim
-# ln -s ~/projects/base16-vim/colors ~/.config/nvim/colors
+  ```sh 
+  ln -s ~/projects/tinted-vim/colors ~/.vim/colors
+  # Or for Neovim
+  # ln -s ~/projects/tinted-vim/colors ~/.config/nvim/colors
+  ```
+
+### Manual
+
+#### Vim
+
+```sh
+cd ~/.vim/colors
+git clone git://github.com/tinted-theming/tinted-vim.git tinted-vim
+cp tinted-vim/colors/*.vim .
 ```
 
-### Manual neovim
+#### Neovim
 
-```bash
+```sh
 cd ~/.config/nvim/colors
-git clone git://github.com/tinted-theming/base16-vim.git base16-vim
-cp base16/colors/*.vim .
+git clone git://github.com/tinted-theming/tinted-vim.git tinted-vim
+cp tinted-vim/colors/*.vim .
 ```
 
 ## 256 colorspace
 
-If using a Base16 terminal theme designed to keep the 16 ANSI colors
+If using a tinted terminal theme designed to keep the 16 ANSI colors
 intact (a "256" variation) **and** have sucessfully modified your 256
-colorspace with [tinted-shell][6].This will cause vim to access the
-colours in the modified 256 colorspace. Please **do not** enable this
-simply because you have a 256 color terminal as this will cause colors
-to be displayed incorrectly.
+colorspace with [tinted-shell].This will cause vim to access the colors
+in the modified 256 colorspace. Please **do not** enable this simply
+because you have a 256 color terminal as this will cause colors to be
+displayed incorrectly.
 
 you'll need to add the following to your `~/.vimrc` **before** the
 colorsheme declaration.
@@ -137,22 +134,21 @@ colorsheme declaration.
 ### Vim
 
 ```vim
-let base16_colorspace=256 " Access colors present in 256 colorspace
+let tinted_colorspace=256 " Access colors present in 256 colorspace
 ```
 
 ### Neovim (lua)
 
 ```lua
 -- Access colors present in 256 colorspace
-vim.g.base16_colorspace = 256
+vim.g.tinted_colorspace = 256
 ```
-
 
 ## Background transparency
 
 If you're using a terminal with an opacity of `< 1`, you'll notice that
-base16-vim doesn't respect this transparency by default. You can enable
-transparent backgrounds with base16-vim by adding the following settings
+tinted-vim doesn't respect this transparency by default. You can enable
+transparent backgrounds with tinted-vim by adding the following settings
 to your vim/neovim setup.
 
 ### Vim
@@ -161,7 +157,7 @@ Add the following variable to your `~/.vimrc` before your colorscheme
 declaration.
 
 ```vim
-let base16_background_transparent=1 " Make vim background transparent to work alongside transparent terminal backgrounds
+let tinted_background_transparent=1 " Make vim background transparent to work alongside transparent terminal backgrounds
 ```
 
 ### Neovim (lua)
@@ -170,16 +166,16 @@ Add the following to your lua setup before your colorscheme declaration.
 
 ```lua
 -- Make vim background transparent to work alongside transparent terminal backgrounds
-vim.g.base16_background_transparent = 1
+vim.g.tinted_background_transparent = 1
 ```
 
 ## Troubleshooting
 
 There is a script to help troubleshoot colour issues called `colortest`
-available in the [Base16 Shell][6] repository.
+available in the [tinted-shell] repository.
 
-If you are using a ISO-8613-3 compatible terminal ([vim docs][7],
-[neovim docs][8]), and you see a green or blue line, try to enable
+If you are using a ISO-8613-3 compatible terminal ([vim docs],
+[neovim docs]), and you see a green or blue line, try to enable
 `termguicolors`:
 
 ```vim
@@ -188,23 +184,23 @@ set termguicolors
 
 ### Green line numbers
 
-![green line numbers screenshot][13]
+![green line numbers screenshot]
 
 If your Vim looks like the above image you are using a 256 terminal
-theme without setting `let base16_colorspace=256` in your `~/.vimrc`.
-Either set `let base16_colorspace=256` in your `~/.vimrc` or use a non
+theme without setting `let tinted_colorspace=256` in your `~/.vimrc`.
+Either set `let tinted_colorspace=256` in your `~/.vimrc` or use a non
 256 terminal theme.
 
 ### Blue line numbers
 
-![blue line numbers screenshot][14]
+![blue line numbers screenshot]
 
 If your Vim looks like the above image you are setting `let
-base16_colorspace=256` in your `~/.vimrc` but either not running [Base16
-Shell][6] or [Base16 Shell][6] is not working for your terminal. Either
-ensure [Base16 Shell][6] is working by running the `colortest` available
-in the [Base16 Shell][6] repository or not setting `let
-base16_colorspace=256` in your `~/.vimrc`.
+tinted_colorspace=256` in your `~/.vimrc` but either not running
+[tinted-shell] or [tinted-shell] is not working for your terminal. Either
+ensure [tinted-shell] is working by running the `colortest` available
+in the [tinted-shell] repository or not setting `let
+tinted_colorspace=256` in your `~/.vimrc`.
 
 ## Customization
 
@@ -212,32 +208,33 @@ If you want to do some local customization, you can add something like
 this to your `~/.vimrc`:
 
 ```vim
-function! s:base16_customize() abort
+function! s:tinted_customize() abort
   call Base16hi("MatchParen", g:base16_gui05, g:base16_gui03, g:base16_cterm05, g:base16_cterm03, "bold,italic", "")
+  " Or Base24hi for base24 themes
 endfunction
 
 augroup on_change_colorschema
   autocmd!
-  autocmd ColorScheme * call s:base16_customize()
+  autocmd ColorScheme * call s:tinted_customize()
 augroup END
 ```
 
 ## Contributing
 
-See [`CONTRIBUTING.md`][9], which contains building and contributing
+See [CONTRIBUTING.md], which contains building and contributing
 instructions.
 
-[1]: https://github.com/vim/vim
-[2]: https://github.com/neovim/neovim
-[3]: https://github.com/tinted-theming/schemes
-[4]: https://github.com/tinted-theming/home#official-templates
-[5]: https://github.com/tinted-theming/home#unofficial-templates
-[6]: https://github.com/tinted-theming/tinted-shell
-[7]: https://github.com/vim/vim/blob/23c1b2b018c8121ca5fcc247e37966428bf8ca66/runtime/doc/options.txt#L7876
-[8]: https://neovim.io/doc/user/options.html#'termguicolors'
-[9]: CONTRIBUTING.md
-[10]: screenshots/base16-vim-screenshot-classic-dark.png
-[11]: screenshots/base16-vim-screenshot-horizon-dark.png
-[12]: screenshots/base16-vim-screenshot-onedark.png
-[13]: screenshots/without-base16colorspace-256-with-256-terminal-theme.png
-[14]: screenshots/with-base16colorspace-256-without-base16-shell.png
+[Vim]: https://github.com/vim/vim
+[Neovim]: https://github.com/neovim/neovim
+[250 themes]: https://github.com/tinted-theming/schemes
+[official]: https://github.com/tinted-theming/home#official-templates
+[unofficial]: https://github.com/tinted-theming/home#unofficial-templates
+[tinted-shell]: https://github.com/tinted-theming/tinted-shell
+[vim docs]: https://github.com/vim/vim/blob/23c1b2b018c8121ca5fcc247e37966428bf8ca66/runtime/doc/options.txt#L7876
+[neovim docs]: https://neovim.io/doc/user/options.html#'termguicolors'
+[CONTRIBUTING.md]: CONTRIBUTING.md
+[tinted-vim classic-dark]: screenshots/tinted-vim-screenshot-classic-dark.png
+[tinted-vim horizon-dark]: screenshots/tinted-vim-screenshot-horizon-dark.png
+[tinted-vim onedark]: screenshots/tinted-vim-screenshot-onedark.png
+[green line numbers screenshot]: screenshots/without-tintedcolorspace-256-with-256-terminal-theme.png
+[blue line numbers screenshot]: screenshots/with-tintedcolorspace-256-without-tinted-shell.png

--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: 3024
 " Scheme author: Jan T. Sott (http://github.com/idleberg)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-3024.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/3024.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/3024.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "090300"
-let g:base16_gui00 = "090300"
+let g:tinted_gui00 = "090300"
 let s:gui01        = "3a3432"
-let g:base16_gui01 = "3a3432"
+let g:tinted_gui01 = "3a3432"
 let s:gui02        = "4a4543"
-let g:base16_gui02 = "4a4543"
+let g:tinted_gui02 = "4a4543"
 let s:gui03        = "5c5855"
-let g:base16_gui03 = "5c5855"
+let g:tinted_gui03 = "5c5855"
 let s:gui04        = "807d7c"
-let g:base16_gui04 = "807d7c"
+let g:tinted_gui04 = "807d7c"
 let s:gui05        = "a5a2a2"
-let g:base16_gui05 = "a5a2a2"
+let g:tinted_gui05 = "a5a2a2"
 let s:gui06        = "d6d5d4"
-let g:base16_gui06 = "d6d5d4"
+let g:tinted_gui06 = "d6d5d4"
 let s:gui07        = "f7f7f7"
-let g:base16_gui07 = "f7f7f7"
+let g:tinted_gui07 = "f7f7f7"
 let s:gui08        = "db2d20"
-let g:base16_gui08 = "db2d20"
+let g:tinted_gui08 = "db2d20"
 let s:gui09        = "e8bbd0"
-let g:base16_gui09 = "e8bbd0"
+let g:tinted_gui09 = "e8bbd0"
 let s:gui0A        = "fded02"
-let g:base16_gui0A = "fded02"
+let g:tinted_gui0A = "fded02"
 let s:gui0B        = "01a252"
-let g:base16_gui0B = "01a252"
+let g:tinted_gui0B = "01a252"
 let s:gui0C        = "b5e4f4"
-let g:base16_gui0C = "b5e4f4"
+let g:tinted_gui0C = "b5e4f4"
 let s:gui0D        = "01a0e4"
-let g:base16_gui0D = "01a0e4"
+let g:tinted_gui0D = "01a0e4"
 let s:gui0E        = "a16a94"
-let g:base16_gui0E = "a16a94"
+let g:tinted_gui0E = "a16a94"
 let s:gui0F        = "cdab53"
+let g:tinted_gui0F = "cdab53"
+
+" Legacy
+let g:base16_gui00 = "090300"
+let g:base16_gui01 = "3a3432"
+let g:base16_gui02 = "4a4543"
+let g:base16_gui03 = "5c5855"
+let g:base16_gui04 = "807d7c"
+let g:base16_gui05 = "a5a2a2"
+let g:base16_gui06 = "d6d5d4"
+let g:base16_gui07 = "f7f7f7"
+let g:base16_gui08 = "db2d20"
+let g:base16_gui09 = "e8bbd0"
+let g:base16_gui0A = "fded02"
+let g:base16_gui0B = "01a252"
+let g:base16_gui0C = "b5e4f4"
+let g:base16_gui0D = "01a0e4"
+let g:base16_gui0E = "a16a94"
 let g:base16_gui0F = "cdab53"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f7f7f7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Apathy
 " Scheme author: Jannik Siebert (https://github.com/janniks)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-apathy.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/apathy.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/apathy.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "031a16"
-let g:base16_gui00 = "031a16"
+let g:tinted_gui00 = "031a16"
 let s:gui01        = "0b342d"
-let g:base16_gui01 = "0b342d"
+let g:tinted_gui01 = "0b342d"
 let s:gui02        = "184e45"
-let g:base16_gui02 = "184e45"
+let g:tinted_gui02 = "184e45"
 let s:gui03        = "2b685e"
-let g:base16_gui03 = "2b685e"
+let g:tinted_gui03 = "2b685e"
 let s:gui04        = "5f9c92"
-let g:base16_gui04 = "5f9c92"
+let g:tinted_gui04 = "5f9c92"
 let s:gui05        = "81b5ac"
-let g:base16_gui05 = "81b5ac"
+let g:tinted_gui05 = "81b5ac"
 let s:gui06        = "a7cec8"
-let g:base16_gui06 = "a7cec8"
+let g:tinted_gui06 = "a7cec8"
 let s:gui07        = "d2e7e4"
-let g:base16_gui07 = "d2e7e4"
+let g:tinted_gui07 = "d2e7e4"
 let s:gui08        = "3e9688"
-let g:base16_gui08 = "3e9688"
+let g:tinted_gui08 = "3e9688"
 let s:gui09        = "3e7996"
-let g:base16_gui09 = "3e7996"
+let g:tinted_gui09 = "3e7996"
 let s:gui0A        = "3e4c96"
-let g:base16_gui0A = "3e4c96"
+let g:tinted_gui0A = "3e4c96"
 let s:gui0B        = "883e96"
-let g:base16_gui0B = "883e96"
+let g:tinted_gui0B = "883e96"
 let s:gui0C        = "963e4c"
-let g:base16_gui0C = "963e4c"
+let g:tinted_gui0C = "963e4c"
 let s:gui0D        = "96883e"
-let g:base16_gui0D = "96883e"
+let g:tinted_gui0D = "96883e"
 let s:gui0E        = "4c963e"
-let g:base16_gui0E = "4c963e"
+let g:tinted_gui0E = "4c963e"
 let s:gui0F        = "3e965b"
+let g:tinted_gui0F = "3e965b"
+
+" Legacy
+let g:base16_gui00 = "031a16"
+let g:base16_gui01 = "0b342d"
+let g:base16_gui02 = "184e45"
+let g:base16_gui03 = "2b685e"
+let g:base16_gui04 = "5f9c92"
+let g:base16_gui05 = "81b5ac"
+let g:base16_gui06 = "a7cec8"
+let g:base16_gui07 = "d2e7e4"
+let g:base16_gui08 = "3e9688"
+let g:base16_gui09 = "3e7996"
+let g:base16_gui0A = "3e4c96"
+let g:base16_gui0B = "883e96"
+let g:base16_gui0C = "963e4c"
+let g:base16_gui0D = "96883e"
+let g:base16_gui0E = "4c963e"
 let g:base16_gui0F = "3e965b"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d2e7e4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-apprentice.vim
+++ b/colors/base16-apprentice.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Apprentice
 " Scheme author: romainl
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-apprentice.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/apprentice.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/apprentice.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "262626"
-let g:base16_gui00 = "262626"
+let g:tinted_gui00 = "262626"
 let s:gui01        = "af5f5f"
-let g:base16_gui01 = "af5f5f"
+let g:tinted_gui01 = "af5f5f"
 let s:gui02        = "5f875f"
-let g:base16_gui02 = "5f875f"
+let g:tinted_gui02 = "5f875f"
 let s:gui03        = "87875f"
-let g:base16_gui03 = "87875f"
+let g:tinted_gui03 = "87875f"
 let s:gui04        = "5f87af"
-let g:base16_gui04 = "5f87af"
+let g:tinted_gui04 = "5f87af"
 let s:gui05        = "5f5f87"
-let g:base16_gui05 = "5f5f87"
+let g:tinted_gui05 = "5f5f87"
 let s:gui06        = "5f8787"
-let g:base16_gui06 = "5f8787"
+let g:tinted_gui06 = "5f8787"
 let s:gui07        = "6c6c6c"
-let g:base16_gui07 = "6c6c6c"
+let g:tinted_gui07 = "6c6c6c"
 let s:gui08        = "444444"
-let g:base16_gui08 = "444444"
+let g:tinted_gui08 = "444444"
 let s:gui09        = "ff8700"
-let g:base16_gui09 = "ff8700"
+let g:tinted_gui09 = "ff8700"
 let s:gui0A        = "87af87"
-let g:base16_gui0A = "87af87"
+let g:tinted_gui0A = "87af87"
 let s:gui0B        = "ffffaf"
-let g:base16_gui0B = "ffffaf"
+let g:tinted_gui0B = "ffffaf"
 let s:gui0C        = "87afd7"
-let g:base16_gui0C = "87afd7"
+let g:tinted_gui0C = "87afd7"
 let s:gui0D        = "8787af"
-let g:base16_gui0D = "8787af"
+let g:tinted_gui0D = "8787af"
 let s:gui0E        = "5fafaf"
-let g:base16_gui0E = "5fafaf"
+let g:tinted_gui0E = "5fafaf"
 let s:gui0F        = "bcbcbc"
+let g:tinted_gui0F = "bcbcbc"
+
+" Legacy
+let g:base16_gui00 = "262626"
+let g:base16_gui01 = "af5f5f"
+let g:base16_gui02 = "5f875f"
+let g:base16_gui03 = "87875f"
+let g:base16_gui04 = "5f87af"
+let g:base16_gui05 = "5f5f87"
+let g:base16_gui06 = "5f8787"
+let g:base16_gui07 = "6c6c6c"
+let g:base16_gui08 = "444444"
+let g:base16_gui09 = "ff8700"
+let g:base16_gui0A = "87af87"
+let g:base16_gui0B = "ffffaf"
+let g:base16_gui0C = "87afd7"
+let g:base16_gui0D = "8787af"
+let g:base16_gui0E = "5fafaf"
 let g:base16_gui0F = "bcbcbc"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#6c6c6c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Ashes
 " Scheme author: Jannik Siebert (https://github.com/janniks)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ashes.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ashes.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ashes.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c2023"
-let g:base16_gui00 = "1c2023"
+let g:tinted_gui00 = "1c2023"
 let s:gui01        = "393f45"
-let g:base16_gui01 = "393f45"
+let g:tinted_gui01 = "393f45"
 let s:gui02        = "565e65"
-let g:base16_gui02 = "565e65"
+let g:tinted_gui02 = "565e65"
 let s:gui03        = "747c84"
-let g:base16_gui03 = "747c84"
+let g:tinted_gui03 = "747c84"
 let s:gui04        = "adb3ba"
-let g:base16_gui04 = "adb3ba"
+let g:tinted_gui04 = "adb3ba"
 let s:gui05        = "c7ccd1"
-let g:base16_gui05 = "c7ccd1"
+let g:tinted_gui05 = "c7ccd1"
 let s:gui06        = "dfe2e5"
-let g:base16_gui06 = "dfe2e5"
+let g:tinted_gui06 = "dfe2e5"
 let s:gui07        = "f3f4f5"
-let g:base16_gui07 = "f3f4f5"
+let g:tinted_gui07 = "f3f4f5"
 let s:gui08        = "c7ae95"
-let g:base16_gui08 = "c7ae95"
+let g:tinted_gui08 = "c7ae95"
 let s:gui09        = "c7c795"
-let g:base16_gui09 = "c7c795"
+let g:tinted_gui09 = "c7c795"
 let s:gui0A        = "aec795"
-let g:base16_gui0A = "aec795"
+let g:tinted_gui0A = "aec795"
 let s:gui0B        = "95c7ae"
-let g:base16_gui0B = "95c7ae"
+let g:tinted_gui0B = "95c7ae"
 let s:gui0C        = "95aec7"
-let g:base16_gui0C = "95aec7"
+let g:tinted_gui0C = "95aec7"
 let s:gui0D        = "ae95c7"
-let g:base16_gui0D = "ae95c7"
+let g:tinted_gui0D = "ae95c7"
 let s:gui0E        = "c795ae"
-let g:base16_gui0E = "c795ae"
+let g:tinted_gui0E = "c795ae"
 let s:gui0F        = "c79595"
+let g:tinted_gui0F = "c79595"
+
+" Legacy
+let g:base16_gui00 = "1c2023"
+let g:base16_gui01 = "393f45"
+let g:base16_gui02 = "565e65"
+let g:base16_gui03 = "747c84"
+let g:base16_gui04 = "adb3ba"
+let g:base16_gui05 = "c7ccd1"
+let g:base16_gui06 = "dfe2e5"
+let g:base16_gui07 = "f3f4f5"
+let g:base16_gui08 = "c7ae95"
+let g:base16_gui09 = "c7c795"
+let g:base16_gui0A = "aec795"
+let g:base16_gui0B = "95c7ae"
+let g:base16_gui0C = "95aec7"
+let g:base16_gui0D = "ae95c7"
+let g:base16_gui0E = "c795ae"
 let g:base16_gui0F = "c79595"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f3f4f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Cave Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-cave-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-cave-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-cave-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "efecf4"
-let g:base16_gui00 = "efecf4"
+let g:tinted_gui00 = "efecf4"
 let s:gui01        = "e2dfe7"
-let g:base16_gui01 = "e2dfe7"
+let g:tinted_gui01 = "e2dfe7"
 let s:gui02        = "8b8792"
-let g:base16_gui02 = "8b8792"
+let g:tinted_gui02 = "8b8792"
 let s:gui03        = "7e7887"
-let g:base16_gui03 = "7e7887"
+let g:tinted_gui03 = "7e7887"
 let s:gui04        = "655f6d"
-let g:base16_gui04 = "655f6d"
+let g:tinted_gui04 = "655f6d"
 let s:gui05        = "585260"
-let g:base16_gui05 = "585260"
+let g:tinted_gui05 = "585260"
 let s:gui06        = "26232a"
-let g:base16_gui06 = "26232a"
+let g:tinted_gui06 = "26232a"
 let s:gui07        = "19171c"
-let g:base16_gui07 = "19171c"
+let g:tinted_gui07 = "19171c"
 let s:gui08        = "be4678"
-let g:base16_gui08 = "be4678"
+let g:tinted_gui08 = "be4678"
 let s:gui09        = "aa573c"
-let g:base16_gui09 = "aa573c"
+let g:tinted_gui09 = "aa573c"
 let s:gui0A        = "a06e3b"
-let g:base16_gui0A = "a06e3b"
+let g:tinted_gui0A = "a06e3b"
 let s:gui0B        = "2a9292"
-let g:base16_gui0B = "2a9292"
+let g:tinted_gui0B = "2a9292"
 let s:gui0C        = "398bc6"
-let g:base16_gui0C = "398bc6"
+let g:tinted_gui0C = "398bc6"
 let s:gui0D        = "576ddb"
-let g:base16_gui0D = "576ddb"
+let g:tinted_gui0D = "576ddb"
 let s:gui0E        = "955ae7"
-let g:base16_gui0E = "955ae7"
+let g:tinted_gui0E = "955ae7"
 let s:gui0F        = "bf40bf"
+let g:tinted_gui0F = "bf40bf"
+
+" Legacy
+let g:base16_gui00 = "efecf4"
+let g:base16_gui01 = "e2dfe7"
+let g:base16_gui02 = "8b8792"
+let g:base16_gui03 = "7e7887"
+let g:base16_gui04 = "655f6d"
+let g:base16_gui05 = "585260"
+let g:base16_gui06 = "26232a"
+let g:base16_gui07 = "19171c"
+let g:base16_gui08 = "be4678"
+let g:base16_gui09 = "aa573c"
+let g:base16_gui0A = "a06e3b"
+let g:base16_gui0B = "2a9292"
+let g:base16_gui0C = "398bc6"
+let g:base16_gui0D = "576ddb"
+let g:base16_gui0E = "955ae7"
 let g:base16_gui0F = "bf40bf"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#19171c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Cave
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-cave.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-cave.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-cave.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "19171c"
-let g:base16_gui00 = "19171c"
+let g:tinted_gui00 = "19171c"
 let s:gui01        = "26232a"
-let g:base16_gui01 = "26232a"
+let g:tinted_gui01 = "26232a"
 let s:gui02        = "585260"
-let g:base16_gui02 = "585260"
+let g:tinted_gui02 = "585260"
 let s:gui03        = "655f6d"
-let g:base16_gui03 = "655f6d"
+let g:tinted_gui03 = "655f6d"
 let s:gui04        = "7e7887"
-let g:base16_gui04 = "7e7887"
+let g:tinted_gui04 = "7e7887"
 let s:gui05        = "8b8792"
-let g:base16_gui05 = "8b8792"
+let g:tinted_gui05 = "8b8792"
 let s:gui06        = "e2dfe7"
-let g:base16_gui06 = "e2dfe7"
+let g:tinted_gui06 = "e2dfe7"
 let s:gui07        = "efecf4"
-let g:base16_gui07 = "efecf4"
+let g:tinted_gui07 = "efecf4"
 let s:gui08        = "be4678"
-let g:base16_gui08 = "be4678"
+let g:tinted_gui08 = "be4678"
 let s:gui09        = "aa573c"
-let g:base16_gui09 = "aa573c"
+let g:tinted_gui09 = "aa573c"
 let s:gui0A        = "a06e3b"
-let g:base16_gui0A = "a06e3b"
+let g:tinted_gui0A = "a06e3b"
 let s:gui0B        = "2a9292"
-let g:base16_gui0B = "2a9292"
+let g:tinted_gui0B = "2a9292"
 let s:gui0C        = "398bc6"
-let g:base16_gui0C = "398bc6"
+let g:tinted_gui0C = "398bc6"
 let s:gui0D        = "576ddb"
-let g:base16_gui0D = "576ddb"
+let g:tinted_gui0D = "576ddb"
 let s:gui0E        = "955ae7"
-let g:base16_gui0E = "955ae7"
+let g:tinted_gui0E = "955ae7"
 let s:gui0F        = "bf40bf"
+let g:tinted_gui0F = "bf40bf"
+
+" Legacy
+let g:base16_gui00 = "19171c"
+let g:base16_gui01 = "26232a"
+let g:base16_gui02 = "585260"
+let g:base16_gui03 = "655f6d"
+let g:base16_gui04 = "7e7887"
+let g:base16_gui05 = "8b8792"
+let g:base16_gui06 = "e2dfe7"
+let g:base16_gui07 = "efecf4"
+let g:base16_gui08 = "be4678"
+let g:base16_gui09 = "aa573c"
+let g:base16_gui0A = "a06e3b"
+let g:base16_gui0B = "2a9292"
+let g:base16_gui0C = "398bc6"
+let g:base16_gui0D = "576ddb"
+let g:base16_gui0E = "955ae7"
 let g:base16_gui0F = "bf40bf"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#efecf4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Dune Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-dune-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-dune-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-dune-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fefbec"
-let g:base16_gui00 = "fefbec"
+let g:tinted_gui00 = "fefbec"
 let s:gui01        = "e8e4cf"
-let g:base16_gui01 = "e8e4cf"
+let g:tinted_gui01 = "e8e4cf"
 let s:gui02        = "a6a28c"
-let g:base16_gui02 = "a6a28c"
+let g:tinted_gui02 = "a6a28c"
 let s:gui03        = "999580"
-let g:base16_gui03 = "999580"
+let g:tinted_gui03 = "999580"
 let s:gui04        = "7d7a68"
-let g:base16_gui04 = "7d7a68"
+let g:tinted_gui04 = "7d7a68"
 let s:gui05        = "6e6b5e"
-let g:base16_gui05 = "6e6b5e"
+let g:tinted_gui05 = "6e6b5e"
 let s:gui06        = "292824"
-let g:base16_gui06 = "292824"
+let g:tinted_gui06 = "292824"
 let s:gui07        = "20201d"
-let g:base16_gui07 = "20201d"
+let g:tinted_gui07 = "20201d"
 let s:gui08        = "d73737"
-let g:base16_gui08 = "d73737"
+let g:tinted_gui08 = "d73737"
 let s:gui09        = "b65611"
-let g:base16_gui09 = "b65611"
+let g:tinted_gui09 = "b65611"
 let s:gui0A        = "ae9513"
-let g:base16_gui0A = "ae9513"
+let g:tinted_gui0A = "ae9513"
 let s:gui0B        = "60ac39"
-let g:base16_gui0B = "60ac39"
+let g:tinted_gui0B = "60ac39"
 let s:gui0C        = "1fad83"
-let g:base16_gui0C = "1fad83"
+let g:tinted_gui0C = "1fad83"
 let s:gui0D        = "6684e1"
-let g:base16_gui0D = "6684e1"
+let g:tinted_gui0D = "6684e1"
 let s:gui0E        = "b854d4"
-let g:base16_gui0E = "b854d4"
+let g:tinted_gui0E = "b854d4"
 let s:gui0F        = "d43552"
+let g:tinted_gui0F = "d43552"
+
+" Legacy
+let g:base16_gui00 = "fefbec"
+let g:base16_gui01 = "e8e4cf"
+let g:base16_gui02 = "a6a28c"
+let g:base16_gui03 = "999580"
+let g:base16_gui04 = "7d7a68"
+let g:base16_gui05 = "6e6b5e"
+let g:base16_gui06 = "292824"
+let g:base16_gui07 = "20201d"
+let g:base16_gui08 = "d73737"
+let g:base16_gui09 = "b65611"
+let g:base16_gui0A = "ae9513"
+let g:base16_gui0B = "60ac39"
+let g:base16_gui0C = "1fad83"
+let g:base16_gui0D = "6684e1"
+let g:base16_gui0E = "b854d4"
 let g:base16_gui0F = "d43552"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#20201d",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Dune
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-dune.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-dune.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-dune.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "20201d"
-let g:base16_gui00 = "20201d"
+let g:tinted_gui00 = "20201d"
 let s:gui01        = "292824"
-let g:base16_gui01 = "292824"
+let g:tinted_gui01 = "292824"
 let s:gui02        = "6e6b5e"
-let g:base16_gui02 = "6e6b5e"
+let g:tinted_gui02 = "6e6b5e"
 let s:gui03        = "7d7a68"
-let g:base16_gui03 = "7d7a68"
+let g:tinted_gui03 = "7d7a68"
 let s:gui04        = "999580"
-let g:base16_gui04 = "999580"
+let g:tinted_gui04 = "999580"
 let s:gui05        = "a6a28c"
-let g:base16_gui05 = "a6a28c"
+let g:tinted_gui05 = "a6a28c"
 let s:gui06        = "e8e4cf"
-let g:base16_gui06 = "e8e4cf"
+let g:tinted_gui06 = "e8e4cf"
 let s:gui07        = "fefbec"
-let g:base16_gui07 = "fefbec"
+let g:tinted_gui07 = "fefbec"
 let s:gui08        = "d73737"
-let g:base16_gui08 = "d73737"
+let g:tinted_gui08 = "d73737"
 let s:gui09        = "b65611"
-let g:base16_gui09 = "b65611"
+let g:tinted_gui09 = "b65611"
 let s:gui0A        = "ae9513"
-let g:base16_gui0A = "ae9513"
+let g:tinted_gui0A = "ae9513"
 let s:gui0B        = "60ac39"
-let g:base16_gui0B = "60ac39"
+let g:tinted_gui0B = "60ac39"
 let s:gui0C        = "1fad83"
-let g:base16_gui0C = "1fad83"
+let g:tinted_gui0C = "1fad83"
 let s:gui0D        = "6684e1"
-let g:base16_gui0D = "6684e1"
+let g:tinted_gui0D = "6684e1"
 let s:gui0E        = "b854d4"
-let g:base16_gui0E = "b854d4"
+let g:tinted_gui0E = "b854d4"
 let s:gui0F        = "d43552"
+let g:tinted_gui0F = "d43552"
+
+" Legacy
+let g:base16_gui00 = "20201d"
+let g:base16_gui01 = "292824"
+let g:base16_gui02 = "6e6b5e"
+let g:base16_gui03 = "7d7a68"
+let g:base16_gui04 = "999580"
+let g:base16_gui05 = "a6a28c"
+let g:base16_gui06 = "e8e4cf"
+let g:base16_gui07 = "fefbec"
+let g:base16_gui08 = "d73737"
+let g:base16_gui09 = "b65611"
+let g:base16_gui0A = "ae9513"
+let g:base16_gui0B = "60ac39"
+let g:base16_gui0C = "1fad83"
+let g:base16_gui0D = "6684e1"
+let g:base16_gui0E = "b854d4"
 let g:base16_gui0F = "d43552"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fefbec",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Estuary Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-estuary-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-estuary-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-estuary-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f4f3ec"
-let g:base16_gui00 = "f4f3ec"
+let g:tinted_gui00 = "f4f3ec"
 let s:gui01        = "e7e6df"
-let g:base16_gui01 = "e7e6df"
+let g:tinted_gui01 = "e7e6df"
 let s:gui02        = "929181"
-let g:base16_gui02 = "929181"
+let g:tinted_gui02 = "929181"
 let s:gui03        = "878573"
-let g:base16_gui03 = "878573"
+let g:tinted_gui03 = "878573"
 let s:gui04        = "6c6b5a"
-let g:base16_gui04 = "6c6b5a"
+let g:tinted_gui04 = "6c6b5a"
 let s:gui05        = "5f5e4e"
-let g:base16_gui05 = "5f5e4e"
+let g:tinted_gui05 = "5f5e4e"
 let s:gui06        = "302f27"
-let g:base16_gui06 = "302f27"
+let g:tinted_gui06 = "302f27"
 let s:gui07        = "22221b"
-let g:base16_gui07 = "22221b"
+let g:tinted_gui07 = "22221b"
 let s:gui08        = "ba6236"
-let g:base16_gui08 = "ba6236"
+let g:tinted_gui08 = "ba6236"
 let s:gui09        = "ae7313"
-let g:base16_gui09 = "ae7313"
+let g:tinted_gui09 = "ae7313"
 let s:gui0A        = "a5980d"
-let g:base16_gui0A = "a5980d"
+let g:tinted_gui0A = "a5980d"
 let s:gui0B        = "7d9726"
-let g:base16_gui0B = "7d9726"
+let g:tinted_gui0B = "7d9726"
 let s:gui0C        = "5b9d48"
-let g:base16_gui0C = "5b9d48"
+let g:tinted_gui0C = "5b9d48"
 let s:gui0D        = "36a166"
-let g:base16_gui0D = "36a166"
+let g:tinted_gui0D = "36a166"
 let s:gui0E        = "5f9182"
-let g:base16_gui0E = "5f9182"
+let g:tinted_gui0E = "5f9182"
 let s:gui0F        = "9d6c7c"
+let g:tinted_gui0F = "9d6c7c"
+
+" Legacy
+let g:base16_gui00 = "f4f3ec"
+let g:base16_gui01 = "e7e6df"
+let g:base16_gui02 = "929181"
+let g:base16_gui03 = "878573"
+let g:base16_gui04 = "6c6b5a"
+let g:base16_gui05 = "5f5e4e"
+let g:base16_gui06 = "302f27"
+let g:base16_gui07 = "22221b"
+let g:base16_gui08 = "ba6236"
+let g:base16_gui09 = "ae7313"
+let g:base16_gui0A = "a5980d"
+let g:base16_gui0B = "7d9726"
+let g:base16_gui0C = "5b9d48"
+let g:base16_gui0D = "36a166"
+let g:base16_gui0E = "5f9182"
 let g:base16_gui0F = "9d6c7c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#22221b",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Estuary
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-estuary.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-estuary.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-estuary.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "22221b"
-let g:base16_gui00 = "22221b"
+let g:tinted_gui00 = "22221b"
 let s:gui01        = "302f27"
-let g:base16_gui01 = "302f27"
+let g:tinted_gui01 = "302f27"
 let s:gui02        = "5f5e4e"
-let g:base16_gui02 = "5f5e4e"
+let g:tinted_gui02 = "5f5e4e"
 let s:gui03        = "6c6b5a"
-let g:base16_gui03 = "6c6b5a"
+let g:tinted_gui03 = "6c6b5a"
 let s:gui04        = "878573"
-let g:base16_gui04 = "878573"
+let g:tinted_gui04 = "878573"
 let s:gui05        = "929181"
-let g:base16_gui05 = "929181"
+let g:tinted_gui05 = "929181"
 let s:gui06        = "e7e6df"
-let g:base16_gui06 = "e7e6df"
+let g:tinted_gui06 = "e7e6df"
 let s:gui07        = "f4f3ec"
-let g:base16_gui07 = "f4f3ec"
+let g:tinted_gui07 = "f4f3ec"
 let s:gui08        = "ba6236"
-let g:base16_gui08 = "ba6236"
+let g:tinted_gui08 = "ba6236"
 let s:gui09        = "ae7313"
-let g:base16_gui09 = "ae7313"
+let g:tinted_gui09 = "ae7313"
 let s:gui0A        = "a5980d"
-let g:base16_gui0A = "a5980d"
+let g:tinted_gui0A = "a5980d"
 let s:gui0B        = "7d9726"
-let g:base16_gui0B = "7d9726"
+let g:tinted_gui0B = "7d9726"
 let s:gui0C        = "5b9d48"
-let g:base16_gui0C = "5b9d48"
+let g:tinted_gui0C = "5b9d48"
 let s:gui0D        = "36a166"
-let g:base16_gui0D = "36a166"
+let g:tinted_gui0D = "36a166"
 let s:gui0E        = "5f9182"
-let g:base16_gui0E = "5f9182"
+let g:tinted_gui0E = "5f9182"
 let s:gui0F        = "9d6c7c"
+let g:tinted_gui0F = "9d6c7c"
+
+" Legacy
+let g:base16_gui00 = "22221b"
+let g:base16_gui01 = "302f27"
+let g:base16_gui02 = "5f5e4e"
+let g:base16_gui03 = "6c6b5a"
+let g:base16_gui04 = "878573"
+let g:base16_gui05 = "929181"
+let g:base16_gui06 = "e7e6df"
+let g:base16_gui07 = "f4f3ec"
+let g:base16_gui08 = "ba6236"
+let g:base16_gui09 = "ae7313"
+let g:base16_gui0A = "a5980d"
+let g:base16_gui0B = "7d9726"
+let g:base16_gui0C = "5b9d48"
+let g:base16_gui0D = "36a166"
+let g:base16_gui0E = "5f9182"
 let g:base16_gui0F = "9d6c7c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f4f3ec",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Forest Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-forest-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-forest-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-forest-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f1efee"
-let g:base16_gui00 = "f1efee"
+let g:tinted_gui00 = "f1efee"
 let s:gui01        = "e6e2e0"
-let g:base16_gui01 = "e6e2e0"
+let g:tinted_gui01 = "e6e2e0"
 let s:gui02        = "a8a19f"
-let g:base16_gui02 = "a8a19f"
+let g:tinted_gui02 = "a8a19f"
 let s:gui03        = "9c9491"
-let g:base16_gui03 = "9c9491"
+let g:tinted_gui03 = "9c9491"
 let s:gui04        = "766e6b"
-let g:base16_gui04 = "766e6b"
+let g:tinted_gui04 = "766e6b"
 let s:gui05        = "68615e"
-let g:base16_gui05 = "68615e"
+let g:tinted_gui05 = "68615e"
 let s:gui06        = "2c2421"
-let g:base16_gui06 = "2c2421"
+let g:tinted_gui06 = "2c2421"
 let s:gui07        = "1b1918"
-let g:base16_gui07 = "1b1918"
+let g:tinted_gui07 = "1b1918"
 let s:gui08        = "f22c40"
-let g:base16_gui08 = "f22c40"
+let g:tinted_gui08 = "f22c40"
 let s:gui09        = "df5320"
-let g:base16_gui09 = "df5320"
+let g:tinted_gui09 = "df5320"
 let s:gui0A        = "c38418"
-let g:base16_gui0A = "c38418"
+let g:tinted_gui0A = "c38418"
 let s:gui0B        = "7b9726"
-let g:base16_gui0B = "7b9726"
+let g:tinted_gui0B = "7b9726"
 let s:gui0C        = "3d97b8"
-let g:base16_gui0C = "3d97b8"
+let g:tinted_gui0C = "3d97b8"
 let s:gui0D        = "407ee7"
-let g:base16_gui0D = "407ee7"
+let g:tinted_gui0D = "407ee7"
 let s:gui0E        = "6666ea"
-let g:base16_gui0E = "6666ea"
+let g:tinted_gui0E = "6666ea"
 let s:gui0F        = "c33ff3"
+let g:tinted_gui0F = "c33ff3"
+
+" Legacy
+let g:base16_gui00 = "f1efee"
+let g:base16_gui01 = "e6e2e0"
+let g:base16_gui02 = "a8a19f"
+let g:base16_gui03 = "9c9491"
+let g:base16_gui04 = "766e6b"
+let g:base16_gui05 = "68615e"
+let g:base16_gui06 = "2c2421"
+let g:base16_gui07 = "1b1918"
+let g:base16_gui08 = "f22c40"
+let g:base16_gui09 = "df5320"
+let g:base16_gui0A = "c38418"
+let g:base16_gui0B = "7b9726"
+let g:base16_gui0C = "3d97b8"
+let g:base16_gui0D = "407ee7"
+let g:base16_gui0E = "6666ea"
 let g:base16_gui0F = "c33ff3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1b1918",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Forest
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-forest.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-forest.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-forest.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1b1918"
-let g:base16_gui00 = "1b1918"
+let g:tinted_gui00 = "1b1918"
 let s:gui01        = "2c2421"
-let g:base16_gui01 = "2c2421"
+let g:tinted_gui01 = "2c2421"
 let s:gui02        = "68615e"
-let g:base16_gui02 = "68615e"
+let g:tinted_gui02 = "68615e"
 let s:gui03        = "766e6b"
-let g:base16_gui03 = "766e6b"
+let g:tinted_gui03 = "766e6b"
 let s:gui04        = "9c9491"
-let g:base16_gui04 = "9c9491"
+let g:tinted_gui04 = "9c9491"
 let s:gui05        = "a8a19f"
-let g:base16_gui05 = "a8a19f"
+let g:tinted_gui05 = "a8a19f"
 let s:gui06        = "e6e2e0"
-let g:base16_gui06 = "e6e2e0"
+let g:tinted_gui06 = "e6e2e0"
 let s:gui07        = "f1efee"
-let g:base16_gui07 = "f1efee"
+let g:tinted_gui07 = "f1efee"
 let s:gui08        = "f22c40"
-let g:base16_gui08 = "f22c40"
+let g:tinted_gui08 = "f22c40"
 let s:gui09        = "df5320"
-let g:base16_gui09 = "df5320"
+let g:tinted_gui09 = "df5320"
 let s:gui0A        = "c38418"
-let g:base16_gui0A = "c38418"
+let g:tinted_gui0A = "c38418"
 let s:gui0B        = "7b9726"
-let g:base16_gui0B = "7b9726"
+let g:tinted_gui0B = "7b9726"
 let s:gui0C        = "3d97b8"
-let g:base16_gui0C = "3d97b8"
+let g:tinted_gui0C = "3d97b8"
 let s:gui0D        = "407ee7"
-let g:base16_gui0D = "407ee7"
+let g:tinted_gui0D = "407ee7"
 let s:gui0E        = "6666ea"
-let g:base16_gui0E = "6666ea"
+let g:tinted_gui0E = "6666ea"
 let s:gui0F        = "c33ff3"
+let g:tinted_gui0F = "c33ff3"
+
+" Legacy
+let g:base16_gui00 = "1b1918"
+let g:base16_gui01 = "2c2421"
+let g:base16_gui02 = "68615e"
+let g:base16_gui03 = "766e6b"
+let g:base16_gui04 = "9c9491"
+let g:base16_gui05 = "a8a19f"
+let g:base16_gui06 = "e6e2e0"
+let g:base16_gui07 = "f1efee"
+let g:base16_gui08 = "f22c40"
+let g:base16_gui09 = "df5320"
+let g:base16_gui0A = "c38418"
+let g:base16_gui0B = "7b9726"
+let g:base16_gui0C = "3d97b8"
+let g:base16_gui0D = "407ee7"
+let g:base16_gui0E = "6666ea"
 let g:base16_gui0F = "c33ff3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f1efee",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Heath Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-heath-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-heath-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-heath-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f7f3f7"
-let g:base16_gui00 = "f7f3f7"
+let g:tinted_gui00 = "f7f3f7"
 let s:gui01        = "d8cad8"
-let g:base16_gui01 = "d8cad8"
+let g:tinted_gui01 = "d8cad8"
 let s:gui02        = "ab9bab"
-let g:base16_gui02 = "ab9bab"
+let g:tinted_gui02 = "ab9bab"
 let s:gui03        = "9e8f9e"
-let g:base16_gui03 = "9e8f9e"
+let g:tinted_gui03 = "9e8f9e"
 let s:gui04        = "776977"
-let g:base16_gui04 = "776977"
+let g:tinted_gui04 = "776977"
 let s:gui05        = "695d69"
-let g:base16_gui05 = "695d69"
+let g:tinted_gui05 = "695d69"
 let s:gui06        = "292329"
-let g:base16_gui06 = "292329"
+let g:tinted_gui06 = "292329"
 let s:gui07        = "1b181b"
-let g:base16_gui07 = "1b181b"
+let g:tinted_gui07 = "1b181b"
 let s:gui08        = "ca402b"
-let g:base16_gui08 = "ca402b"
+let g:tinted_gui08 = "ca402b"
 let s:gui09        = "a65926"
-let g:base16_gui09 = "a65926"
+let g:tinted_gui09 = "a65926"
 let s:gui0A        = "bb8a35"
-let g:base16_gui0A = "bb8a35"
+let g:tinted_gui0A = "bb8a35"
 let s:gui0B        = "918b3b"
-let g:base16_gui0B = "918b3b"
+let g:tinted_gui0B = "918b3b"
 let s:gui0C        = "159393"
-let g:base16_gui0C = "159393"
+let g:tinted_gui0C = "159393"
 let s:gui0D        = "516aec"
-let g:base16_gui0D = "516aec"
+let g:tinted_gui0D = "516aec"
 let s:gui0E        = "7b59c0"
-let g:base16_gui0E = "7b59c0"
+let g:tinted_gui0E = "7b59c0"
 let s:gui0F        = "cc33cc"
+let g:tinted_gui0F = "cc33cc"
+
+" Legacy
+let g:base16_gui00 = "f7f3f7"
+let g:base16_gui01 = "d8cad8"
+let g:base16_gui02 = "ab9bab"
+let g:base16_gui03 = "9e8f9e"
+let g:base16_gui04 = "776977"
+let g:base16_gui05 = "695d69"
+let g:base16_gui06 = "292329"
+let g:base16_gui07 = "1b181b"
+let g:base16_gui08 = "ca402b"
+let g:base16_gui09 = "a65926"
+let g:base16_gui0A = "bb8a35"
+let g:base16_gui0B = "918b3b"
+let g:base16_gui0C = "159393"
+let g:base16_gui0D = "516aec"
+let g:base16_gui0E = "7b59c0"
 let g:base16_gui0F = "cc33cc"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1b181b",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Heath
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-heath.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-heath.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-heath.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1b181b"
-let g:base16_gui00 = "1b181b"
+let g:tinted_gui00 = "1b181b"
 let s:gui01        = "292329"
-let g:base16_gui01 = "292329"
+let g:tinted_gui01 = "292329"
 let s:gui02        = "695d69"
-let g:base16_gui02 = "695d69"
+let g:tinted_gui02 = "695d69"
 let s:gui03        = "776977"
-let g:base16_gui03 = "776977"
+let g:tinted_gui03 = "776977"
 let s:gui04        = "9e8f9e"
-let g:base16_gui04 = "9e8f9e"
+let g:tinted_gui04 = "9e8f9e"
 let s:gui05        = "ab9bab"
-let g:base16_gui05 = "ab9bab"
+let g:tinted_gui05 = "ab9bab"
 let s:gui06        = "d8cad8"
-let g:base16_gui06 = "d8cad8"
+let g:tinted_gui06 = "d8cad8"
 let s:gui07        = "f7f3f7"
-let g:base16_gui07 = "f7f3f7"
+let g:tinted_gui07 = "f7f3f7"
 let s:gui08        = "ca402b"
-let g:base16_gui08 = "ca402b"
+let g:tinted_gui08 = "ca402b"
 let s:gui09        = "a65926"
-let g:base16_gui09 = "a65926"
+let g:tinted_gui09 = "a65926"
 let s:gui0A        = "bb8a35"
-let g:base16_gui0A = "bb8a35"
+let g:tinted_gui0A = "bb8a35"
 let s:gui0B        = "918b3b"
-let g:base16_gui0B = "918b3b"
+let g:tinted_gui0B = "918b3b"
 let s:gui0C        = "159393"
-let g:base16_gui0C = "159393"
+let g:tinted_gui0C = "159393"
 let s:gui0D        = "516aec"
-let g:base16_gui0D = "516aec"
+let g:tinted_gui0D = "516aec"
 let s:gui0E        = "7b59c0"
-let g:base16_gui0E = "7b59c0"
+let g:tinted_gui0E = "7b59c0"
 let s:gui0F        = "cc33cc"
+let g:tinted_gui0F = "cc33cc"
+
+" Legacy
+let g:base16_gui00 = "1b181b"
+let g:base16_gui01 = "292329"
+let g:base16_gui02 = "695d69"
+let g:base16_gui03 = "776977"
+let g:base16_gui04 = "9e8f9e"
+let g:base16_gui05 = "ab9bab"
+let g:base16_gui06 = "d8cad8"
+let g:base16_gui07 = "f7f3f7"
+let g:base16_gui08 = "ca402b"
+let g:base16_gui09 = "a65926"
+let g:base16_gui0A = "bb8a35"
+let g:base16_gui0B = "918b3b"
+let g:base16_gui0C = "159393"
+let g:base16_gui0D = "516aec"
+let g:base16_gui0E = "7b59c0"
 let g:base16_gui0F = "cc33cc"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f7f3f7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Lakeside Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-lakeside-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-lakeside-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-lakeside-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ebf8ff"
-let g:base16_gui00 = "ebf8ff"
+let g:tinted_gui00 = "ebf8ff"
 let s:gui01        = "c1e4f6"
-let g:base16_gui01 = "c1e4f6"
+let g:tinted_gui01 = "c1e4f6"
 let s:gui02        = "7ea2b4"
-let g:base16_gui02 = "7ea2b4"
+let g:tinted_gui02 = "7ea2b4"
 let s:gui03        = "7195a8"
-let g:base16_gui03 = "7195a8"
+let g:tinted_gui03 = "7195a8"
 let s:gui04        = "5a7b8c"
-let g:base16_gui04 = "5a7b8c"
+let g:tinted_gui04 = "5a7b8c"
 let s:gui05        = "516d7b"
-let g:base16_gui05 = "516d7b"
+let g:tinted_gui05 = "516d7b"
 let s:gui06        = "1f292e"
-let g:base16_gui06 = "1f292e"
+let g:tinted_gui06 = "1f292e"
 let s:gui07        = "161b1d"
-let g:base16_gui07 = "161b1d"
+let g:tinted_gui07 = "161b1d"
 let s:gui08        = "d22d72"
-let g:base16_gui08 = "d22d72"
+let g:tinted_gui08 = "d22d72"
 let s:gui09        = "935c25"
-let g:base16_gui09 = "935c25"
+let g:tinted_gui09 = "935c25"
 let s:gui0A        = "8a8a0f"
-let g:base16_gui0A = "8a8a0f"
+let g:tinted_gui0A = "8a8a0f"
 let s:gui0B        = "568c3b"
-let g:base16_gui0B = "568c3b"
+let g:tinted_gui0B = "568c3b"
 let s:gui0C        = "2d8f6f"
-let g:base16_gui0C = "2d8f6f"
+let g:tinted_gui0C = "2d8f6f"
 let s:gui0D        = "257fad"
-let g:base16_gui0D = "257fad"
+let g:tinted_gui0D = "257fad"
 let s:gui0E        = "6b6bb8"
-let g:base16_gui0E = "6b6bb8"
+let g:tinted_gui0E = "6b6bb8"
 let s:gui0F        = "b72dd2"
+let g:tinted_gui0F = "b72dd2"
+
+" Legacy
+let g:base16_gui00 = "ebf8ff"
+let g:base16_gui01 = "c1e4f6"
+let g:base16_gui02 = "7ea2b4"
+let g:base16_gui03 = "7195a8"
+let g:base16_gui04 = "5a7b8c"
+let g:base16_gui05 = "516d7b"
+let g:base16_gui06 = "1f292e"
+let g:base16_gui07 = "161b1d"
+let g:base16_gui08 = "d22d72"
+let g:base16_gui09 = "935c25"
+let g:base16_gui0A = "8a8a0f"
+let g:base16_gui0B = "568c3b"
+let g:base16_gui0C = "2d8f6f"
+let g:base16_gui0D = "257fad"
+let g:base16_gui0E = "6b6bb8"
 let g:base16_gui0F = "b72dd2"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#161b1d",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Lakeside
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-lakeside.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-lakeside.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-lakeside.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "161b1d"
-let g:base16_gui00 = "161b1d"
+let g:tinted_gui00 = "161b1d"
 let s:gui01        = "1f292e"
-let g:base16_gui01 = "1f292e"
+let g:tinted_gui01 = "1f292e"
 let s:gui02        = "516d7b"
-let g:base16_gui02 = "516d7b"
+let g:tinted_gui02 = "516d7b"
 let s:gui03        = "5a7b8c"
-let g:base16_gui03 = "5a7b8c"
+let g:tinted_gui03 = "5a7b8c"
 let s:gui04        = "7195a8"
-let g:base16_gui04 = "7195a8"
+let g:tinted_gui04 = "7195a8"
 let s:gui05        = "7ea2b4"
-let g:base16_gui05 = "7ea2b4"
+let g:tinted_gui05 = "7ea2b4"
 let s:gui06        = "c1e4f6"
-let g:base16_gui06 = "c1e4f6"
+let g:tinted_gui06 = "c1e4f6"
 let s:gui07        = "ebf8ff"
-let g:base16_gui07 = "ebf8ff"
+let g:tinted_gui07 = "ebf8ff"
 let s:gui08        = "d22d72"
-let g:base16_gui08 = "d22d72"
+let g:tinted_gui08 = "d22d72"
 let s:gui09        = "935c25"
-let g:base16_gui09 = "935c25"
+let g:tinted_gui09 = "935c25"
 let s:gui0A        = "8a8a0f"
-let g:base16_gui0A = "8a8a0f"
+let g:tinted_gui0A = "8a8a0f"
 let s:gui0B        = "568c3b"
-let g:base16_gui0B = "568c3b"
+let g:tinted_gui0B = "568c3b"
 let s:gui0C        = "2d8f6f"
-let g:base16_gui0C = "2d8f6f"
+let g:tinted_gui0C = "2d8f6f"
 let s:gui0D        = "257fad"
-let g:base16_gui0D = "257fad"
+let g:tinted_gui0D = "257fad"
 let s:gui0E        = "6b6bb8"
-let g:base16_gui0E = "6b6bb8"
+let g:tinted_gui0E = "6b6bb8"
 let s:gui0F        = "b72dd2"
+let g:tinted_gui0F = "b72dd2"
+
+" Legacy
+let g:base16_gui00 = "161b1d"
+let g:base16_gui01 = "1f292e"
+let g:base16_gui02 = "516d7b"
+let g:base16_gui03 = "5a7b8c"
+let g:base16_gui04 = "7195a8"
+let g:base16_gui05 = "7ea2b4"
+let g:base16_gui06 = "c1e4f6"
+let g:base16_gui07 = "ebf8ff"
+let g:base16_gui08 = "d22d72"
+let g:base16_gui09 = "935c25"
+let g:base16_gui0A = "8a8a0f"
+let g:base16_gui0B = "568c3b"
+let g:base16_gui0C = "2d8f6f"
+let g:base16_gui0D = "257fad"
+let g:base16_gui0E = "6b6bb8"
 let g:base16_gui0F = "b72dd2"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ebf8ff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Plateau Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-plateau-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-plateau-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-plateau-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f4ecec"
-let g:base16_gui00 = "f4ecec"
+let g:tinted_gui00 = "f4ecec"
 let s:gui01        = "e7dfdf"
-let g:base16_gui01 = "e7dfdf"
+let g:tinted_gui01 = "e7dfdf"
 let s:gui02        = "8a8585"
-let g:base16_gui02 = "8a8585"
+let g:tinted_gui02 = "8a8585"
 let s:gui03        = "7e7777"
-let g:base16_gui03 = "7e7777"
+let g:tinted_gui03 = "7e7777"
 let s:gui04        = "655d5d"
-let g:base16_gui04 = "655d5d"
+let g:tinted_gui04 = "655d5d"
 let s:gui05        = "585050"
-let g:base16_gui05 = "585050"
+let g:tinted_gui05 = "585050"
 let s:gui06        = "292424"
-let g:base16_gui06 = "292424"
+let g:tinted_gui06 = "292424"
 let s:gui07        = "1b1818"
-let g:base16_gui07 = "1b1818"
+let g:tinted_gui07 = "1b1818"
 let s:gui08        = "ca4949"
-let g:base16_gui08 = "ca4949"
+let g:tinted_gui08 = "ca4949"
 let s:gui09        = "b45a3c"
-let g:base16_gui09 = "b45a3c"
+let g:tinted_gui09 = "b45a3c"
 let s:gui0A        = "a06e3b"
-let g:base16_gui0A = "a06e3b"
+let g:tinted_gui0A = "a06e3b"
 let s:gui0B        = "4b8b8b"
-let g:base16_gui0B = "4b8b8b"
+let g:tinted_gui0B = "4b8b8b"
 let s:gui0C        = "5485b6"
-let g:base16_gui0C = "5485b6"
+let g:tinted_gui0C = "5485b6"
 let s:gui0D        = "7272ca"
-let g:base16_gui0D = "7272ca"
+let g:tinted_gui0D = "7272ca"
 let s:gui0E        = "8464c4"
-let g:base16_gui0E = "8464c4"
+let g:tinted_gui0E = "8464c4"
 let s:gui0F        = "bd5187"
+let g:tinted_gui0F = "bd5187"
+
+" Legacy
+let g:base16_gui00 = "f4ecec"
+let g:base16_gui01 = "e7dfdf"
+let g:base16_gui02 = "8a8585"
+let g:base16_gui03 = "7e7777"
+let g:base16_gui04 = "655d5d"
+let g:base16_gui05 = "585050"
+let g:base16_gui06 = "292424"
+let g:base16_gui07 = "1b1818"
+let g:base16_gui08 = "ca4949"
+let g:base16_gui09 = "b45a3c"
+let g:base16_gui0A = "a06e3b"
+let g:base16_gui0B = "4b8b8b"
+let g:base16_gui0C = "5485b6"
+let g:base16_gui0D = "7272ca"
+let g:base16_gui0E = "8464c4"
 let g:base16_gui0F = "bd5187"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1b1818",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Plateau
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-plateau.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-plateau.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-plateau.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1b1818"
-let g:base16_gui00 = "1b1818"
+let g:tinted_gui00 = "1b1818"
 let s:gui01        = "292424"
-let g:base16_gui01 = "292424"
+let g:tinted_gui01 = "292424"
 let s:gui02        = "585050"
-let g:base16_gui02 = "585050"
+let g:tinted_gui02 = "585050"
 let s:gui03        = "655d5d"
-let g:base16_gui03 = "655d5d"
+let g:tinted_gui03 = "655d5d"
 let s:gui04        = "7e7777"
-let g:base16_gui04 = "7e7777"
+let g:tinted_gui04 = "7e7777"
 let s:gui05        = "8a8585"
-let g:base16_gui05 = "8a8585"
+let g:tinted_gui05 = "8a8585"
 let s:gui06        = "e7dfdf"
-let g:base16_gui06 = "e7dfdf"
+let g:tinted_gui06 = "e7dfdf"
 let s:gui07        = "f4ecec"
-let g:base16_gui07 = "f4ecec"
+let g:tinted_gui07 = "f4ecec"
 let s:gui08        = "ca4949"
-let g:base16_gui08 = "ca4949"
+let g:tinted_gui08 = "ca4949"
 let s:gui09        = "b45a3c"
-let g:base16_gui09 = "b45a3c"
+let g:tinted_gui09 = "b45a3c"
 let s:gui0A        = "a06e3b"
-let g:base16_gui0A = "a06e3b"
+let g:tinted_gui0A = "a06e3b"
 let s:gui0B        = "4b8b8b"
-let g:base16_gui0B = "4b8b8b"
+let g:tinted_gui0B = "4b8b8b"
 let s:gui0C        = "5485b6"
-let g:base16_gui0C = "5485b6"
+let g:tinted_gui0C = "5485b6"
 let s:gui0D        = "7272ca"
-let g:base16_gui0D = "7272ca"
+let g:tinted_gui0D = "7272ca"
 let s:gui0E        = "8464c4"
-let g:base16_gui0E = "8464c4"
+let g:tinted_gui0E = "8464c4"
 let s:gui0F        = "bd5187"
+let g:tinted_gui0F = "bd5187"
+
+" Legacy
+let g:base16_gui00 = "1b1818"
+let g:base16_gui01 = "292424"
+let g:base16_gui02 = "585050"
+let g:base16_gui03 = "655d5d"
+let g:base16_gui04 = "7e7777"
+let g:base16_gui05 = "8a8585"
+let g:base16_gui06 = "e7dfdf"
+let g:base16_gui07 = "f4ecec"
+let g:base16_gui08 = "ca4949"
+let g:base16_gui09 = "b45a3c"
+let g:base16_gui0A = "a06e3b"
+let g:base16_gui0B = "4b8b8b"
+let g:base16_gui0C = "5485b6"
+let g:base16_gui0D = "7272ca"
+let g:base16_gui0E = "8464c4"
 let g:base16_gui0F = "bd5187"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f4ecec",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Savanna Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-savanna-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-savanna-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-savanna-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ecf4ee"
-let g:base16_gui00 = "ecf4ee"
+let g:tinted_gui00 = "ecf4ee"
 let s:gui01        = "dfe7e2"
-let g:base16_gui01 = "dfe7e2"
+let g:tinted_gui01 = "dfe7e2"
 let s:gui02        = "87928a"
-let g:base16_gui02 = "87928a"
+let g:tinted_gui02 = "87928a"
 let s:gui03        = "78877d"
-let g:base16_gui03 = "78877d"
+let g:tinted_gui03 = "78877d"
 let s:gui04        = "5f6d64"
-let g:base16_gui04 = "5f6d64"
+let g:tinted_gui04 = "5f6d64"
 let s:gui05        = "526057"
-let g:base16_gui05 = "526057"
+let g:tinted_gui05 = "526057"
 let s:gui06        = "232a25"
-let g:base16_gui06 = "232a25"
+let g:tinted_gui06 = "232a25"
 let s:gui07        = "171c19"
-let g:base16_gui07 = "171c19"
+let g:tinted_gui07 = "171c19"
 let s:gui08        = "b16139"
-let g:base16_gui08 = "b16139"
+let g:tinted_gui08 = "b16139"
 let s:gui09        = "9f713c"
-let g:base16_gui09 = "9f713c"
+let g:tinted_gui09 = "9f713c"
 let s:gui0A        = "a07e3b"
-let g:base16_gui0A = "a07e3b"
+let g:tinted_gui0A = "a07e3b"
 let s:gui0B        = "489963"
-let g:base16_gui0B = "489963"
+let g:tinted_gui0B = "489963"
 let s:gui0C        = "1c9aa0"
-let g:base16_gui0C = "1c9aa0"
+let g:tinted_gui0C = "1c9aa0"
 let s:gui0D        = "478c90"
-let g:base16_gui0D = "478c90"
+let g:tinted_gui0D = "478c90"
 let s:gui0E        = "55859b"
-let g:base16_gui0E = "55859b"
+let g:tinted_gui0E = "55859b"
 let s:gui0F        = "867469"
+let g:tinted_gui0F = "867469"
+
+" Legacy
+let g:base16_gui00 = "ecf4ee"
+let g:base16_gui01 = "dfe7e2"
+let g:base16_gui02 = "87928a"
+let g:base16_gui03 = "78877d"
+let g:base16_gui04 = "5f6d64"
+let g:base16_gui05 = "526057"
+let g:base16_gui06 = "232a25"
+let g:base16_gui07 = "171c19"
+let g:base16_gui08 = "b16139"
+let g:base16_gui09 = "9f713c"
+let g:base16_gui0A = "a07e3b"
+let g:base16_gui0B = "489963"
+let g:base16_gui0C = "1c9aa0"
+let g:base16_gui0D = "478c90"
+let g:base16_gui0E = "55859b"
 let g:base16_gui0F = "867469"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#171c19",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Savanna
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-savanna.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-savanna.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-savanna.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171c19"
-let g:base16_gui00 = "171c19"
+let g:tinted_gui00 = "171c19"
 let s:gui01        = "232a25"
-let g:base16_gui01 = "232a25"
+let g:tinted_gui01 = "232a25"
 let s:gui02        = "526057"
-let g:base16_gui02 = "526057"
+let g:tinted_gui02 = "526057"
 let s:gui03        = "5f6d64"
-let g:base16_gui03 = "5f6d64"
+let g:tinted_gui03 = "5f6d64"
 let s:gui04        = "78877d"
-let g:base16_gui04 = "78877d"
+let g:tinted_gui04 = "78877d"
 let s:gui05        = "87928a"
-let g:base16_gui05 = "87928a"
+let g:tinted_gui05 = "87928a"
 let s:gui06        = "dfe7e2"
-let g:base16_gui06 = "dfe7e2"
+let g:tinted_gui06 = "dfe7e2"
 let s:gui07        = "ecf4ee"
-let g:base16_gui07 = "ecf4ee"
+let g:tinted_gui07 = "ecf4ee"
 let s:gui08        = "b16139"
-let g:base16_gui08 = "b16139"
+let g:tinted_gui08 = "b16139"
 let s:gui09        = "9f713c"
-let g:base16_gui09 = "9f713c"
+let g:tinted_gui09 = "9f713c"
 let s:gui0A        = "a07e3b"
-let g:base16_gui0A = "a07e3b"
+let g:tinted_gui0A = "a07e3b"
 let s:gui0B        = "489963"
-let g:base16_gui0B = "489963"
+let g:tinted_gui0B = "489963"
 let s:gui0C        = "1c9aa0"
-let g:base16_gui0C = "1c9aa0"
+let g:tinted_gui0C = "1c9aa0"
 let s:gui0D        = "478c90"
-let g:base16_gui0D = "478c90"
+let g:tinted_gui0D = "478c90"
 let s:gui0E        = "55859b"
-let g:base16_gui0E = "55859b"
+let g:tinted_gui0E = "55859b"
 let s:gui0F        = "867469"
+let g:tinted_gui0F = "867469"
+
+" Legacy
+let g:base16_gui00 = "171c19"
+let g:base16_gui01 = "232a25"
+let g:base16_gui02 = "526057"
+let g:base16_gui03 = "5f6d64"
+let g:base16_gui04 = "78877d"
+let g:base16_gui05 = "87928a"
+let g:base16_gui06 = "dfe7e2"
+let g:base16_gui07 = "ecf4ee"
+let g:base16_gui08 = "b16139"
+let g:base16_gui09 = "9f713c"
+let g:base16_gui0A = "a07e3b"
+let g:base16_gui0B = "489963"
+let g:base16_gui0C = "1c9aa0"
+let g:base16_gui0D = "478c90"
+let g:base16_gui0E = "55859b"
 let g:base16_gui0F = "867469"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ecf4ee",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Seaside Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-seaside-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-seaside-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-seaside-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f4fbf4"
-let g:base16_gui00 = "f4fbf4"
+let g:tinted_gui00 = "f4fbf4"
 let s:gui01        = "cfe8cf"
-let g:base16_gui01 = "cfe8cf"
+let g:tinted_gui01 = "cfe8cf"
 let s:gui02        = "8ca68c"
-let g:base16_gui02 = "8ca68c"
+let g:tinted_gui02 = "8ca68c"
 let s:gui03        = "809980"
-let g:base16_gui03 = "809980"
+let g:tinted_gui03 = "809980"
 let s:gui04        = "687d68"
-let g:base16_gui04 = "687d68"
+let g:tinted_gui04 = "687d68"
 let s:gui05        = "5e6e5e"
-let g:base16_gui05 = "5e6e5e"
+let g:tinted_gui05 = "5e6e5e"
 let s:gui06        = "242924"
-let g:base16_gui06 = "242924"
+let g:tinted_gui06 = "242924"
 let s:gui07        = "131513"
-let g:base16_gui07 = "131513"
+let g:tinted_gui07 = "131513"
 let s:gui08        = "e6193c"
-let g:base16_gui08 = "e6193c"
+let g:tinted_gui08 = "e6193c"
 let s:gui09        = "87711d"
-let g:base16_gui09 = "87711d"
+let g:tinted_gui09 = "87711d"
 let s:gui0A        = "98981b"
-let g:base16_gui0A = "98981b"
+let g:tinted_gui0A = "98981b"
 let s:gui0B        = "29a329"
-let g:base16_gui0B = "29a329"
+let g:tinted_gui0B = "29a329"
 let s:gui0C        = "1999b3"
-let g:base16_gui0C = "1999b3"
+let g:tinted_gui0C = "1999b3"
 let s:gui0D        = "3d62f5"
-let g:base16_gui0D = "3d62f5"
+let g:tinted_gui0D = "3d62f5"
 let s:gui0E        = "ad2bee"
-let g:base16_gui0E = "ad2bee"
+let g:tinted_gui0E = "ad2bee"
 let s:gui0F        = "e619c3"
+let g:tinted_gui0F = "e619c3"
+
+" Legacy
+let g:base16_gui00 = "f4fbf4"
+let g:base16_gui01 = "cfe8cf"
+let g:base16_gui02 = "8ca68c"
+let g:base16_gui03 = "809980"
+let g:base16_gui04 = "687d68"
+let g:base16_gui05 = "5e6e5e"
+let g:base16_gui06 = "242924"
+let g:base16_gui07 = "131513"
+let g:base16_gui08 = "e6193c"
+let g:base16_gui09 = "87711d"
+let g:base16_gui0A = "98981b"
+let g:base16_gui0B = "29a329"
+let g:base16_gui0C = "1999b3"
+let g:base16_gui0D = "3d62f5"
+let g:base16_gui0E = "ad2bee"
 let g:base16_gui0F = "e619c3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#131513",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Seaside
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-seaside.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-seaside.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-seaside.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "131513"
-let g:base16_gui00 = "131513"
+let g:tinted_gui00 = "131513"
 let s:gui01        = "242924"
-let g:base16_gui01 = "242924"
+let g:tinted_gui01 = "242924"
 let s:gui02        = "5e6e5e"
-let g:base16_gui02 = "5e6e5e"
+let g:tinted_gui02 = "5e6e5e"
 let s:gui03        = "687d68"
-let g:base16_gui03 = "687d68"
+let g:tinted_gui03 = "687d68"
 let s:gui04        = "809980"
-let g:base16_gui04 = "809980"
+let g:tinted_gui04 = "809980"
 let s:gui05        = "8ca68c"
-let g:base16_gui05 = "8ca68c"
+let g:tinted_gui05 = "8ca68c"
 let s:gui06        = "cfe8cf"
-let g:base16_gui06 = "cfe8cf"
+let g:tinted_gui06 = "cfe8cf"
 let s:gui07        = "f4fbf4"
-let g:base16_gui07 = "f4fbf4"
+let g:tinted_gui07 = "f4fbf4"
 let s:gui08        = "e6193c"
-let g:base16_gui08 = "e6193c"
+let g:tinted_gui08 = "e6193c"
 let s:gui09        = "87711d"
-let g:base16_gui09 = "87711d"
+let g:tinted_gui09 = "87711d"
 let s:gui0A        = "98981b"
-let g:base16_gui0A = "98981b"
+let g:tinted_gui0A = "98981b"
 let s:gui0B        = "29a329"
-let g:base16_gui0B = "29a329"
+let g:tinted_gui0B = "29a329"
 let s:gui0C        = "1999b3"
-let g:base16_gui0C = "1999b3"
+let g:tinted_gui0C = "1999b3"
 let s:gui0D        = "3d62f5"
-let g:base16_gui0D = "3d62f5"
+let g:tinted_gui0D = "3d62f5"
 let s:gui0E        = "ad2bee"
-let g:base16_gui0E = "ad2bee"
+let g:tinted_gui0E = "ad2bee"
 let s:gui0F        = "e619c3"
+let g:tinted_gui0F = "e619c3"
+
+" Legacy
+let g:base16_gui00 = "131513"
+let g:base16_gui01 = "242924"
+let g:base16_gui02 = "5e6e5e"
+let g:base16_gui03 = "687d68"
+let g:base16_gui04 = "809980"
+let g:base16_gui05 = "8ca68c"
+let g:base16_gui06 = "cfe8cf"
+let g:base16_gui07 = "f4fbf4"
+let g:base16_gui08 = "e6193c"
+let g:base16_gui09 = "87711d"
+let g:base16_gui0A = "98981b"
+let g:base16_gui0B = "29a329"
+let g:base16_gui0C = "1999b3"
+let g:base16_gui0D = "3d62f5"
+let g:base16_gui0E = "ad2bee"
 let g:base16_gui0F = "e619c3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f4fbf4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Sulphurpool Light
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-sulphurpool-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-sulphurpool-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-sulphurpool-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f5f7ff"
-let g:base16_gui00 = "f5f7ff"
+let g:tinted_gui00 = "f5f7ff"
 let s:gui01        = "dfe2f1"
-let g:base16_gui01 = "dfe2f1"
+let g:tinted_gui01 = "dfe2f1"
 let s:gui02        = "979db4"
-let g:base16_gui02 = "979db4"
+let g:tinted_gui02 = "979db4"
 let s:gui03        = "898ea4"
-let g:base16_gui03 = "898ea4"
+let g:tinted_gui03 = "898ea4"
 let s:gui04        = "6b7394"
-let g:base16_gui04 = "6b7394"
+let g:tinted_gui04 = "6b7394"
 let s:gui05        = "5e6687"
-let g:base16_gui05 = "5e6687"
+let g:tinted_gui05 = "5e6687"
 let s:gui06        = "293256"
-let g:base16_gui06 = "293256"
+let g:tinted_gui06 = "293256"
 let s:gui07        = "202746"
-let g:base16_gui07 = "202746"
+let g:tinted_gui07 = "202746"
 let s:gui08        = "c94922"
-let g:base16_gui08 = "c94922"
+let g:tinted_gui08 = "c94922"
 let s:gui09        = "c76b29"
-let g:base16_gui09 = "c76b29"
+let g:tinted_gui09 = "c76b29"
 let s:gui0A        = "c08b30"
-let g:base16_gui0A = "c08b30"
+let g:tinted_gui0A = "c08b30"
 let s:gui0B        = "ac9739"
-let g:base16_gui0B = "ac9739"
+let g:tinted_gui0B = "ac9739"
 let s:gui0C        = "22a2c9"
-let g:base16_gui0C = "22a2c9"
+let g:tinted_gui0C = "22a2c9"
 let s:gui0D        = "3d8fd1"
-let g:base16_gui0D = "3d8fd1"
+let g:tinted_gui0D = "3d8fd1"
 let s:gui0E        = "6679cc"
-let g:base16_gui0E = "6679cc"
+let g:tinted_gui0E = "6679cc"
 let s:gui0F        = "9c637a"
+let g:tinted_gui0F = "9c637a"
+
+" Legacy
+let g:base16_gui00 = "f5f7ff"
+let g:base16_gui01 = "dfe2f1"
+let g:base16_gui02 = "979db4"
+let g:base16_gui03 = "898ea4"
+let g:base16_gui04 = "6b7394"
+let g:base16_gui05 = "5e6687"
+let g:base16_gui06 = "293256"
+let g:base16_gui07 = "202746"
+let g:base16_gui08 = "c94922"
+let g:base16_gui09 = "c76b29"
+let g:base16_gui0A = "c08b30"
+let g:base16_gui0B = "ac9739"
+let g:base16_gui0C = "22a2c9"
+let g:base16_gui0D = "3d8fd1"
+let g:base16_gui0E = "6679cc"
 let g:base16_gui0F = "9c637a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#202746",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atelier Sulphurpool
 " Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atelier-sulphurpool.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atelier-sulphurpool.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atelier-sulphurpool.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "202746"
-let g:base16_gui00 = "202746"
+let g:tinted_gui00 = "202746"
 let s:gui01        = "293256"
-let g:base16_gui01 = "293256"
+let g:tinted_gui01 = "293256"
 let s:gui02        = "5e6687"
-let g:base16_gui02 = "5e6687"
+let g:tinted_gui02 = "5e6687"
 let s:gui03        = "6b7394"
-let g:base16_gui03 = "6b7394"
+let g:tinted_gui03 = "6b7394"
 let s:gui04        = "898ea4"
-let g:base16_gui04 = "898ea4"
+let g:tinted_gui04 = "898ea4"
 let s:gui05        = "979db4"
-let g:base16_gui05 = "979db4"
+let g:tinted_gui05 = "979db4"
 let s:gui06        = "dfe2f1"
-let g:base16_gui06 = "dfe2f1"
+let g:tinted_gui06 = "dfe2f1"
 let s:gui07        = "f5f7ff"
-let g:base16_gui07 = "f5f7ff"
+let g:tinted_gui07 = "f5f7ff"
 let s:gui08        = "c94922"
-let g:base16_gui08 = "c94922"
+let g:tinted_gui08 = "c94922"
 let s:gui09        = "c76b29"
-let g:base16_gui09 = "c76b29"
+let g:tinted_gui09 = "c76b29"
 let s:gui0A        = "c08b30"
-let g:base16_gui0A = "c08b30"
+let g:tinted_gui0A = "c08b30"
 let s:gui0B        = "ac9739"
-let g:base16_gui0B = "ac9739"
+let g:tinted_gui0B = "ac9739"
 let s:gui0C        = "22a2c9"
-let g:base16_gui0C = "22a2c9"
+let g:tinted_gui0C = "22a2c9"
 let s:gui0D        = "3d8fd1"
-let g:base16_gui0D = "3d8fd1"
+let g:tinted_gui0D = "3d8fd1"
 let s:gui0E        = "6679cc"
-let g:base16_gui0E = "6679cc"
+let g:tinted_gui0E = "6679cc"
 let s:gui0F        = "9c637a"
+let g:tinted_gui0F = "9c637a"
+
+" Legacy
+let g:base16_gui00 = "202746"
+let g:base16_gui01 = "293256"
+let g:base16_gui02 = "5e6687"
+let g:base16_gui03 = "6b7394"
+let g:base16_gui04 = "898ea4"
+let g:base16_gui05 = "979db4"
+let g:base16_gui06 = "dfe2f1"
+let g:base16_gui07 = "f5f7ff"
+let g:base16_gui08 = "c94922"
+let g:base16_gui09 = "c76b29"
+let g:base16_gui0A = "c08b30"
+let g:base16_gui0B = "ac9739"
+let g:base16_gui0C = "22a2c9"
+let g:base16_gui0D = "3d8fd1"
+let g:base16_gui0E = "6679cc"
 let g:base16_gui0F = "9c637a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f7ff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Atlas
 " Scheme author: Alex Lende (https://ajlende.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-atlas.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/atlas.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/atlas.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "002635"
-let g:base16_gui00 = "002635"
+let g:tinted_gui00 = "002635"
 let s:gui01        = "00384d"
-let g:base16_gui01 = "00384d"
+let g:tinted_gui01 = "00384d"
 let s:gui02        = "517f8d"
-let g:base16_gui02 = "517f8d"
+let g:tinted_gui02 = "517f8d"
 let s:gui03        = "6c8b91"
-let g:base16_gui03 = "6c8b91"
+let g:tinted_gui03 = "6c8b91"
 let s:gui04        = "869696"
-let g:base16_gui04 = "869696"
+let g:tinted_gui04 = "869696"
 let s:gui05        = "a1a19a"
-let g:base16_gui05 = "a1a19a"
+let g:tinted_gui05 = "a1a19a"
 let s:gui06        = "e6e6dc"
-let g:base16_gui06 = "e6e6dc"
+let g:tinted_gui06 = "e6e6dc"
 let s:gui07        = "fafaf8"
-let g:base16_gui07 = "fafaf8"
+let g:tinted_gui07 = "fafaf8"
 let s:gui08        = "ff5a67"
-let g:base16_gui08 = "ff5a67"
+let g:tinted_gui08 = "ff5a67"
 let s:gui09        = "f08e48"
-let g:base16_gui09 = "f08e48"
+let g:tinted_gui09 = "f08e48"
 let s:gui0A        = "ffcc1b"
-let g:base16_gui0A = "ffcc1b"
+let g:tinted_gui0A = "ffcc1b"
 let s:gui0B        = "7fc06e"
-let g:base16_gui0B = "7fc06e"
+let g:tinted_gui0B = "7fc06e"
 let s:gui0C        = "5dd7b9"
-let g:base16_gui0C = "5dd7b9"
+let g:tinted_gui0C = "5dd7b9"
 let s:gui0D        = "14747e"
-let g:base16_gui0D = "14747e"
+let g:tinted_gui0D = "14747e"
 let s:gui0E        = "9a70a4"
-let g:base16_gui0E = "9a70a4"
+let g:tinted_gui0E = "9a70a4"
 let s:gui0F        = "c43060"
+let g:tinted_gui0F = "c43060"
+
+" Legacy
+let g:base16_gui00 = "002635"
+let g:base16_gui01 = "00384d"
+let g:base16_gui02 = "517f8d"
+let g:base16_gui03 = "6c8b91"
+let g:base16_gui04 = "869696"
+let g:base16_gui05 = "a1a19a"
+let g:base16_gui06 = "e6e6dc"
+let g:base16_gui07 = "fafaf8"
+let g:base16_gui08 = "ff5a67"
+let g:base16_gui09 = "f08e48"
+let g:base16_gui0A = "ffcc1b"
+let g:base16_gui0B = "7fc06e"
+let g:base16_gui0C = "5dd7b9"
+let g:base16_gui0D = "14747e"
+let g:base16_gui0E = "9a70a4"
 let g:base16_gui0F = "c43060"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fafaf8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ayu-dark.vim
+++ b/colors/base16-ayu-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Ayu Dark
 " Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ayu-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ayu-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ayu-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0f1419"
-let g:base16_gui00 = "0f1419"
+let g:tinted_gui00 = "0f1419"
 let s:gui01        = "131721"
-let g:base16_gui01 = "131721"
+let g:tinted_gui01 = "131721"
 let s:gui02        = "272d38"
-let g:base16_gui02 = "272d38"
+let g:tinted_gui02 = "272d38"
 let s:gui03        = "3e4b59"
-let g:base16_gui03 = "3e4b59"
+let g:tinted_gui03 = "3e4b59"
 let s:gui04        = "bfbdb6"
-let g:base16_gui04 = "bfbdb6"
+let g:tinted_gui04 = "bfbdb6"
 let s:gui05        = "e6e1cf"
-let g:base16_gui05 = "e6e1cf"
+let g:tinted_gui05 = "e6e1cf"
 let s:gui06        = "e6e1cf"
-let g:base16_gui06 = "e6e1cf"
+let g:tinted_gui06 = "e6e1cf"
 let s:gui07        = "f3f4f5"
-let g:base16_gui07 = "f3f4f5"
+let g:tinted_gui07 = "f3f4f5"
 let s:gui08        = "f07178"
-let g:base16_gui08 = "f07178"
+let g:tinted_gui08 = "f07178"
 let s:gui09        = "ff8f40"
-let g:base16_gui09 = "ff8f40"
+let g:tinted_gui09 = "ff8f40"
 let s:gui0A        = "ffb454"
-let g:base16_gui0A = "ffb454"
+let g:tinted_gui0A = "ffb454"
 let s:gui0B        = "b8cc52"
-let g:base16_gui0B = "b8cc52"
+let g:tinted_gui0B = "b8cc52"
 let s:gui0C        = "95e6cb"
-let g:base16_gui0C = "95e6cb"
+let g:tinted_gui0C = "95e6cb"
 let s:gui0D        = "59c2ff"
-let g:base16_gui0D = "59c2ff"
+let g:tinted_gui0D = "59c2ff"
 let s:gui0E        = "d2a6ff"
-let g:base16_gui0E = "d2a6ff"
+let g:tinted_gui0E = "d2a6ff"
 let s:gui0F        = "e6b673"
+let g:tinted_gui0F = "e6b673"
+
+" Legacy
+let g:base16_gui00 = "0f1419"
+let g:base16_gui01 = "131721"
+let g:base16_gui02 = "272d38"
+let g:base16_gui03 = "3e4b59"
+let g:base16_gui04 = "bfbdb6"
+let g:base16_gui05 = "e6e1cf"
+let g:base16_gui06 = "e6e1cf"
+let g:base16_gui07 = "f3f4f5"
+let g:base16_gui08 = "f07178"
+let g:base16_gui09 = "ff8f40"
+let g:base16_gui0A = "ffb454"
+let g:base16_gui0B = "b8cc52"
+let g:base16_gui0C = "95e6cb"
+let g:base16_gui0D = "59c2ff"
+let g:base16_gui0E = "d2a6ff"
 let g:base16_gui0F = "e6b673"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f3f4f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ayu-light.vim
+++ b/colors/base16-ayu-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Ayu Light
 " Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ayu-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ayu-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ayu-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fafafa"
-let g:base16_gui00 = "fafafa"
+let g:tinted_gui00 = "fafafa"
 let s:gui01        = "f3f4f5"
-let g:base16_gui01 = "f3f4f5"
+let g:tinted_gui01 = "f3f4f5"
 let s:gui02        = "f8f9fa"
-let g:base16_gui02 = "f8f9fa"
+let g:tinted_gui02 = "f8f9fa"
 let s:gui03        = "abb0b6"
-let g:base16_gui03 = "abb0b6"
+let g:tinted_gui03 = "abb0b6"
 let s:gui04        = "828c99"
-let g:base16_gui04 = "828c99"
+let g:tinted_gui04 = "828c99"
 let s:gui05        = "5c6773"
-let g:base16_gui05 = "5c6773"
+let g:tinted_gui05 = "5c6773"
 let s:gui06        = "242936"
-let g:base16_gui06 = "242936"
+let g:tinted_gui06 = "242936"
 let s:gui07        = "1a1f29"
-let g:base16_gui07 = "1a1f29"
+let g:tinted_gui07 = "1a1f29"
 let s:gui08        = "f07178"
-let g:base16_gui08 = "f07178"
+let g:tinted_gui08 = "f07178"
 let s:gui09        = "fa8d3e"
-let g:base16_gui09 = "fa8d3e"
+let g:tinted_gui09 = "fa8d3e"
 let s:gui0A        = "f2ae49"
-let g:base16_gui0A = "f2ae49"
+let g:tinted_gui0A = "f2ae49"
 let s:gui0B        = "86b300"
-let g:base16_gui0B = "86b300"
+let g:tinted_gui0B = "86b300"
 let s:gui0C        = "4cbf99"
-let g:base16_gui0C = "4cbf99"
+let g:tinted_gui0C = "4cbf99"
 let s:gui0D        = "36a3d9"
-let g:base16_gui0D = "36a3d9"
+let g:tinted_gui0D = "36a3d9"
 let s:gui0E        = "a37acc"
-let g:base16_gui0E = "a37acc"
+let g:tinted_gui0E = "a37acc"
 let s:gui0F        = "e6ba7e"
+let g:tinted_gui0F = "e6ba7e"
+
+" Legacy
+let g:base16_gui00 = "fafafa"
+let g:base16_gui01 = "f3f4f5"
+let g:base16_gui02 = "f8f9fa"
+let g:base16_gui03 = "abb0b6"
+let g:base16_gui04 = "828c99"
+let g:base16_gui05 = "5c6773"
+let g:base16_gui06 = "242936"
+let g:base16_gui07 = "1a1f29"
+let g:base16_gui08 = "f07178"
+let g:base16_gui09 = "fa8d3e"
+let g:base16_gui0A = "f2ae49"
+let g:base16_gui0B = "86b300"
+let g:base16_gui0C = "4cbf99"
+let g:base16_gui0D = "36a3d9"
+let g:base16_gui0E = "a37acc"
 let g:base16_gui0F = "e6ba7e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1a1f29",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ayu-mirage.vim
+++ b/colors/base16-ayu-mirage.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Ayu Mirage
 " Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ayu-mirage.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ayu-mirage.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ayu-mirage.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171b24"
-let g:base16_gui00 = "171b24"
+let g:tinted_gui00 = "171b24"
 let s:gui01        = "1f2430"
-let g:base16_gui01 = "1f2430"
+let g:tinted_gui01 = "1f2430"
 let s:gui02        = "242936"
-let g:base16_gui02 = "242936"
+let g:tinted_gui02 = "242936"
 let s:gui03        = "707a8c"
-let g:base16_gui03 = "707a8c"
+let g:tinted_gui03 = "707a8c"
 let s:gui04        = "8a9199"
-let g:base16_gui04 = "8a9199"
+let g:tinted_gui04 = "8a9199"
 let s:gui05        = "cccac2"
-let g:base16_gui05 = "cccac2"
+let g:tinted_gui05 = "cccac2"
 let s:gui06        = "d9d7ce"
-let g:base16_gui06 = "d9d7ce"
+let g:tinted_gui06 = "d9d7ce"
 let s:gui07        = "f3f4f5"
-let g:base16_gui07 = "f3f4f5"
+let g:tinted_gui07 = "f3f4f5"
 let s:gui08        = "f28779"
-let g:base16_gui08 = "f28779"
+let g:tinted_gui08 = "f28779"
 let s:gui09        = "ffad66"
-let g:base16_gui09 = "ffad66"
+let g:tinted_gui09 = "ffad66"
 let s:gui0A        = "ffd173"
-let g:base16_gui0A = "ffd173"
+let g:tinted_gui0A = "ffd173"
 let s:gui0B        = "d5ff80"
-let g:base16_gui0B = "d5ff80"
+let g:tinted_gui0B = "d5ff80"
 let s:gui0C        = "95e6cb"
-let g:base16_gui0C = "95e6cb"
+let g:tinted_gui0C = "95e6cb"
 let s:gui0D        = "5ccfe6"
-let g:base16_gui0D = "5ccfe6"
+let g:tinted_gui0D = "5ccfe6"
 let s:gui0E        = "d4bfff"
-let g:base16_gui0E = "d4bfff"
+let g:tinted_gui0E = "d4bfff"
 let s:gui0F        = "f29e74"
+let g:tinted_gui0F = "f29e74"
+
+" Legacy
+let g:base16_gui00 = "171b24"
+let g:base16_gui01 = "1f2430"
+let g:base16_gui02 = "242936"
+let g:base16_gui03 = "707a8c"
+let g:base16_gui04 = "8a9199"
+let g:base16_gui05 = "cccac2"
+let g:base16_gui06 = "d9d7ce"
+let g:base16_gui07 = "f3f4f5"
+let g:base16_gui08 = "f28779"
+let g:base16_gui09 = "ffad66"
+let g:base16_gui0A = "ffd173"
+let g:base16_gui0B = "d5ff80"
+let g:base16_gui0C = "95e6cb"
+let g:base16_gui0D = "5ccfe6"
+let g:base16_gui0E = "d4bfff"
 let g:base16_gui0F = "f29e74"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f3f4f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-aztec.vim
+++ b/colors/base16-aztec.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Aztec
 " Scheme author: TheNeverMan (github.com/TheNeverMan)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-aztec.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/aztec.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/aztec.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "101600"
-let g:base16_gui00 = "101600"
+let g:tinted_gui00 = "101600"
 let s:gui01        = "1a1e01"
-let g:base16_gui01 = "1a1e01"
+let g:tinted_gui01 = "1a1e01"
 let s:gui02        = "242604"
-let g:base16_gui02 = "242604"
+let g:tinted_gui02 = "242604"
 let s:gui03        = "2e2e05"
-let g:base16_gui03 = "2e2e05"
+let g:tinted_gui03 = "2e2e05"
 let s:gui04        = "ffd129"
-let g:base16_gui04 = "ffd129"
+let g:tinted_gui04 = "ffd129"
 let s:gui05        = "ffda51"
-let g:base16_gui05 = "ffda51"
+let g:tinted_gui05 = "ffda51"
 let s:gui06        = "ffe178"
-let g:base16_gui06 = "ffe178"
+let g:tinted_gui06 = "ffe178"
 let s:gui07        = "ffeba0"
-let g:base16_gui07 = "ffeba0"
+let g:tinted_gui07 = "ffeba0"
 let s:gui08        = "ee2e00"
-let g:base16_gui08 = "ee2e00"
+let g:tinted_gui08 = "ee2e00"
 let s:gui09        = "ee8800"
-let g:base16_gui09 = "ee8800"
+let g:tinted_gui09 = "ee8800"
 let s:gui0A        = "eebb00"
-let g:base16_gui0A = "eebb00"
+let g:tinted_gui0A = "eebb00"
 let s:gui0B        = "63d932"
-let g:base16_gui0B = "63d932"
+let g:tinted_gui0B = "63d932"
 let s:gui0C        = "3d94a5"
-let g:base16_gui0C = "3d94a5"
+let g:tinted_gui0C = "3d94a5"
 let s:gui0D        = "5b4a9f"
-let g:base16_gui0D = "5b4a9f"
+let g:tinted_gui0D = "5b4a9f"
 let s:gui0E        = "883e9f"
-let g:base16_gui0E = "883e9f"
+let g:tinted_gui0E = "883e9f"
 let s:gui0F        = "a928b9"
+let g:tinted_gui0F = "a928b9"
+
+" Legacy
+let g:base16_gui00 = "101600"
+let g:base16_gui01 = "1a1e01"
+let g:base16_gui02 = "242604"
+let g:base16_gui03 = "2e2e05"
+let g:base16_gui04 = "ffd129"
+let g:base16_gui05 = "ffda51"
+let g:base16_gui06 = "ffe178"
+let g:base16_gui07 = "ffeba0"
+let g:base16_gui08 = "ee2e00"
+let g:base16_gui09 = "ee8800"
+let g:base16_gui0A = "eebb00"
+let g:base16_gui0B = "63d932"
+let g:base16_gui0C = "3d94a5"
+let g:base16_gui0D = "5b4a9f"
+let g:base16_gui0E = "883e9f"
 let g:base16_gui0F = "a928b9"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffeba0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Bespin
 " Scheme author: Jan T. Sott
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-bespin.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/bespin.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/bespin.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "28211c"
-let g:base16_gui00 = "28211c"
+let g:tinted_gui00 = "28211c"
 let s:gui01        = "36312e"
-let g:base16_gui01 = "36312e"
+let g:tinted_gui01 = "36312e"
 let s:gui02        = "5e5d5c"
-let g:base16_gui02 = "5e5d5c"
+let g:tinted_gui02 = "5e5d5c"
 let s:gui03        = "666666"
-let g:base16_gui03 = "666666"
+let g:tinted_gui03 = "666666"
 let s:gui04        = "797977"
-let g:base16_gui04 = "797977"
+let g:tinted_gui04 = "797977"
 let s:gui05        = "8a8986"
-let g:base16_gui05 = "8a8986"
+let g:tinted_gui05 = "8a8986"
 let s:gui06        = "9d9b97"
-let g:base16_gui06 = "9d9b97"
+let g:tinted_gui06 = "9d9b97"
 let s:gui07        = "baae9e"
-let g:base16_gui07 = "baae9e"
+let g:tinted_gui07 = "baae9e"
 let s:gui08        = "cf6a4c"
-let g:base16_gui08 = "cf6a4c"
+let g:tinted_gui08 = "cf6a4c"
 let s:gui09        = "cf7d34"
-let g:base16_gui09 = "cf7d34"
+let g:tinted_gui09 = "cf7d34"
 let s:gui0A        = "f9ee98"
-let g:base16_gui0A = "f9ee98"
+let g:tinted_gui0A = "f9ee98"
 let s:gui0B        = "54be0d"
-let g:base16_gui0B = "54be0d"
+let g:tinted_gui0B = "54be0d"
 let s:gui0C        = "afc4db"
-let g:base16_gui0C = "afc4db"
+let g:tinted_gui0C = "afc4db"
 let s:gui0D        = "5ea6ea"
-let g:base16_gui0D = "5ea6ea"
+let g:tinted_gui0D = "5ea6ea"
 let s:gui0E        = "9b859d"
-let g:base16_gui0E = "9b859d"
+let g:tinted_gui0E = "9b859d"
 let s:gui0F        = "937121"
+let g:tinted_gui0F = "937121"
+
+" Legacy
+let g:base16_gui00 = "28211c"
+let g:base16_gui01 = "36312e"
+let g:base16_gui02 = "5e5d5c"
+let g:base16_gui03 = "666666"
+let g:base16_gui04 = "797977"
+let g:base16_gui05 = "8a8986"
+let g:base16_gui06 = "9d9b97"
+let g:base16_gui07 = "baae9e"
+let g:base16_gui08 = "cf6a4c"
+let g:base16_gui09 = "cf7d34"
+let g:base16_gui0A = "f9ee98"
+let g:base16_gui0B = "54be0d"
+let g:base16_gui0C = "afc4db"
+let g:base16_gui0D = "5ea6ea"
+let g:base16_gui0E = "9b859d"
 let g:base16_gui0F = "937121"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#baae9e",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Bathory)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-bathory.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-bathory.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-bathory.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "e78a53"
-let g:base16_gui0A = "e78a53"
+let g:tinted_gui0A = "e78a53"
 let s:gui0B        = "fbcb97"
-let g:base16_gui0B = "fbcb97"
+let g:tinted_gui0B = "fbcb97"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "e78a53"
+let g:base16_gui0B = "fbcb97"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Burzum)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-burzum.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-burzum.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-burzum.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "99bbaa"
-let g:base16_gui0A = "99bbaa"
+let g:tinted_gui0A = "99bbaa"
 let s:gui0B        = "ddeecc"
-let g:base16_gui0B = "ddeecc"
+let g:tinted_gui0B = "ddeecc"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "99bbaa"
+let g:base16_gui0B = "ddeecc"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Dark Funeral)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-dark-funeral.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-dark-funeral.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-dark-funeral.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "5f81a5"
-let g:base16_gui0A = "5f81a5"
+let g:tinted_gui0A = "5f81a5"
 let s:gui0B        = "d0dfee"
-let g:base16_gui0B = "d0dfee"
+let g:tinted_gui0B = "d0dfee"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "5f81a5"
+let g:base16_gui0B = "d0dfee"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Gorgoroth)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-gorgoroth.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-gorgoroth.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-gorgoroth.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "8c7f70"
-let g:base16_gui0A = "8c7f70"
+let g:tinted_gui0A = "8c7f70"
 let s:gui0B        = "9b8d7f"
-let g:base16_gui0B = "9b8d7f"
+let g:tinted_gui0B = "9b8d7f"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "8c7f70"
+let g:base16_gui0B = "9b8d7f"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Immortal)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-immortal.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-immortal.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-immortal.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "556677"
-let g:base16_gui0A = "556677"
+let g:tinted_gui0A = "556677"
 let s:gui0B        = "7799bb"
-let g:base16_gui0B = "7799bb"
+let g:tinted_gui0B = "7799bb"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "556677"
+let g:base16_gui0B = "7799bb"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Khold)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-khold.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-khold.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-khold.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "974b46"
-let g:base16_gui0A = "974b46"
+let g:tinted_gui0A = "974b46"
 let s:gui0B        = "eceee3"
-let g:base16_gui0B = "eceee3"
+let g:tinted_gui0B = "eceee3"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "974b46"
+let g:base16_gui0B = "eceee3"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Marduk)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-marduk.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-marduk.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-marduk.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "626b67"
-let g:base16_gui0A = "626b67"
+let g:tinted_gui0A = "626b67"
 let s:gui0B        = "a5aaa7"
-let g:base16_gui0B = "a5aaa7"
+let g:tinted_gui0B = "a5aaa7"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "626b67"
+let g:base16_gui0B = "a5aaa7"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Mayhem)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-mayhem.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-mayhem.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-mayhem.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "eecc6c"
-let g:base16_gui0A = "eecc6c"
+let g:tinted_gui0A = "eecc6c"
 let s:gui0B        = "f3ecd4"
-let g:base16_gui0B = "f3ecd4"
+let g:tinted_gui0B = "f3ecd4"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "eecc6c"
+let g:base16_gui0B = "f3ecd4"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Nile)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-nile.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-nile.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-nile.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "777755"
-let g:base16_gui0A = "777755"
+let g:tinted_gui0A = "777755"
 let s:gui0B        = "aa9988"
-let g:base16_gui0B = "aa9988"
+let g:tinted_gui0B = "aa9988"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "777755"
+let g:base16_gui0B = "aa9988"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal (Venom)
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal-venom.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal-venom.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal-venom.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "79241f"
-let g:base16_gui0A = "79241f"
+let g:tinted_gui0A = "79241f"
 let s:gui0B        = "f8f7f2"
-let g:base16_gui0B = "f8f7f2"
+let g:tinted_gui0B = "f8f7f2"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "79241f"
+let g:base16_gui0B = "f8f7f2"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Black Metal
 " Scheme author: metalelf0 (https://github.com/metalelf0)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-black-metal.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/black-metal.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/black-metal.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "121212"
-let g:base16_gui01 = "121212"
+let g:tinted_gui01 = "121212"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "c1c1c1"
-let g:base16_gui05 = "c1c1c1"
+let g:tinted_gui05 = "c1c1c1"
 let s:gui06        = "999999"
-let g:base16_gui06 = "999999"
+let g:tinted_gui06 = "999999"
 let s:gui07        = "c1c1c1"
-let g:base16_gui07 = "c1c1c1"
+let g:tinted_gui07 = "c1c1c1"
 let s:gui08        = "5f8787"
-let g:base16_gui08 = "5f8787"
+let g:tinted_gui08 = "5f8787"
 let s:gui09        = "aaaaaa"
-let g:base16_gui09 = "aaaaaa"
+let g:tinted_gui09 = "aaaaaa"
 let s:gui0A        = "a06666"
-let g:base16_gui0A = "a06666"
+let g:tinted_gui0A = "a06666"
 let s:gui0B        = "dd9999"
-let g:base16_gui0B = "dd9999"
+let g:tinted_gui0B = "dd9999"
 let s:gui0C        = "aaaaaa"
-let g:base16_gui0C = "aaaaaa"
+let g:tinted_gui0C = "aaaaaa"
 let s:gui0D        = "888888"
-let g:base16_gui0D = "888888"
+let g:tinted_gui0D = "888888"
 let s:gui0E        = "999999"
-let g:base16_gui0E = "999999"
+let g:tinted_gui0E = "999999"
 let s:gui0F        = "444444"
+let g:tinted_gui0F = "444444"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "121212"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "c1c1c1"
+let g:base16_gui06 = "999999"
+let g:base16_gui07 = "c1c1c1"
+let g:base16_gui08 = "5f8787"
+let g:base16_gui09 = "aaaaaa"
+let g:base16_gui0A = "a06666"
+let g:base16_gui0B = "dd9999"
+let g:base16_gui0C = "aaaaaa"
+let g:base16_gui0D = "888888"
+let g:base16_gui0E = "999999"
 let g:base16_gui0F = "444444"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c1c1c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-blueforest.vim
+++ b/colors/base16-blueforest.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Blue Forest
 " Scheme author: alonsodomin (https://github.com/alonsodomin)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-blueforest.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/blueforest.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/blueforest.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "141f2e"
-let g:base16_gui00 = "141f2e"
+let g:tinted_gui00 = "141f2e"
 let s:gui01        = "1e5c1e"
-let g:base16_gui01 = "1e5c1e"
+let g:tinted_gui01 = "1e5c1e"
 let s:gui02        = "273e5c"
-let g:base16_gui02 = "273e5c"
+let g:tinted_gui02 = "273e5c"
 let s:gui03        = "a0ffa0"
-let g:base16_gui03 = "a0ffa0"
+let g:tinted_gui03 = "a0ffa0"
 let s:gui04        = "1e5c1e"
-let g:base16_gui04 = "1e5c1e"
+let g:tinted_gui04 = "1e5c1e"
 let s:gui05        = "ffcc33"
-let g:base16_gui05 = "ffcc33"
+let g:tinted_gui05 = "ffcc33"
 let s:gui06        = "91ccff"
-let g:base16_gui06 = "91ccff"
+let g:tinted_gui06 = "91ccff"
 let s:gui07        = "375780"
-let g:base16_gui07 = "375780"
+let g:tinted_gui07 = "375780"
 let s:gui08        = "fffab1"
-let g:base16_gui08 = "fffab1"
+let g:tinted_gui08 = "fffab1"
 let s:gui09        = "ff8080"
-let g:base16_gui09 = "ff8080"
+let g:tinted_gui09 = "ff8080"
 let s:gui0A        = "91ccff"
-let g:base16_gui0A = "91ccff"
+let g:tinted_gui0A = "91ccff"
 let s:gui0B        = "80ff80"
-let g:base16_gui0B = "80ff80"
+let g:tinted_gui0B = "80ff80"
 let s:gui0C        = "80ff80"
-let g:base16_gui0C = "80ff80"
+let g:tinted_gui0C = "80ff80"
 let s:gui0D        = "a2cff5"
-let g:base16_gui0D = "a2cff5"
+let g:tinted_gui0D = "a2cff5"
 let s:gui0E        = "0099ff"
-let g:base16_gui0E = "0099ff"
+let g:tinted_gui0E = "0099ff"
 let s:gui0F        = "e7e7e7"
+let g:tinted_gui0F = "e7e7e7"
+
+" Legacy
+let g:base16_gui00 = "141f2e"
+let g:base16_gui01 = "1e5c1e"
+let g:base16_gui02 = "273e5c"
+let g:base16_gui03 = "a0ffa0"
+let g:base16_gui04 = "1e5c1e"
+let g:base16_gui05 = "ffcc33"
+let g:base16_gui06 = "91ccff"
+let g:base16_gui07 = "375780"
+let g:base16_gui08 = "fffab1"
+let g:base16_gui09 = "ff8080"
+let g:base16_gui0A = "91ccff"
+let g:base16_gui0B = "80ff80"
+let g:base16_gui0C = "80ff80"
+let g:base16_gui0D = "a2cff5"
+let g:base16_gui0E = "0099ff"
 let g:base16_gui0F = "e7e7e7"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#375780",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-blueish.vim
+++ b/colors/base16-blueish.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Blueish
 " Scheme author: Ben Mayoras
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-blueish.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/blueish.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/blueish.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "182430"
-let g:base16_gui00 = "182430"
+let g:tinted_gui00 = "182430"
 let s:gui01        = "243c54"
-let g:base16_gui01 = "243c54"
+let g:tinted_gui01 = "243c54"
 let s:gui02        = "46290a"
-let g:base16_gui02 = "46290a"
+let g:tinted_gui02 = "46290a"
 let s:gui03        = "616d78"
-let g:base16_gui03 = "616d78"
+let g:tinted_gui03 = "616d78"
 let s:gui04        = "74afe7"
-let g:base16_gui04 = "74afe7"
+let g:tinted_gui04 = "74afe7"
 let s:gui05        = "c8e1f8"
-let g:base16_gui05 = "c8e1f8"
+let g:tinted_gui05 = "c8e1f8"
 let s:gui06        = "ddeaf6"
-let g:base16_gui06 = "ddeaf6"
+let g:tinted_gui06 = "ddeaf6"
 let s:gui07        = "8f98a0"
-let g:base16_gui07 = "8f98a0"
+let g:tinted_gui07 = "8f98a0"
 let s:gui08        = "4ce587"
-let g:base16_gui08 = "4ce587"
+let g:tinted_gui08 = "4ce587"
 let s:gui09        = "f6a85c"
-let g:base16_gui09 = "f6a85c"
+let g:tinted_gui09 = "f6a85c"
 let s:gui0A        = "82aaff"
-let g:base16_gui0A = "82aaff"
+let g:tinted_gui0A = "82aaff"
 let s:gui0B        = "c3e88d"
-let g:base16_gui0B = "c3e88d"
+let g:tinted_gui0B = "c3e88d"
 let s:gui0C        = "5fd1ff"
-let g:base16_gui0C = "5fd1ff"
+let g:tinted_gui0C = "5fd1ff"
 let s:gui0D        = "82aaff"
-let g:base16_gui0D = "82aaff"
+let g:tinted_gui0D = "82aaff"
 let s:gui0E        = "ff84dd"
-let g:base16_gui0E = "ff84dd"
+let g:tinted_gui0E = "ff84dd"
 let s:gui0F        = "bbd2e8"
+let g:tinted_gui0F = "bbd2e8"
+
+" Legacy
+let g:base16_gui00 = "182430"
+let g:base16_gui01 = "243c54"
+let g:base16_gui02 = "46290a"
+let g:base16_gui03 = "616d78"
+let g:base16_gui04 = "74afe7"
+let g:base16_gui05 = "c8e1f8"
+let g:base16_gui06 = "ddeaf6"
+let g:base16_gui07 = "8f98a0"
+let g:base16_gui08 = "4ce587"
+let g:base16_gui09 = "f6a85c"
+let g:base16_gui0A = "82aaff"
+let g:base16_gui0B = "c3e88d"
+let g:base16_gui0C = "5fd1ff"
+let g:base16_gui0D = "82aaff"
+let g:base16_gui0E = "ff84dd"
 let g:base16_gui0F = "bbd2e8"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#8f98a0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Brewer
 " Scheme author: Timothée Poisot (http://github.com/tpoisot)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-brewer.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/brewer.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/brewer.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0c0d0e"
-let g:base16_gui00 = "0c0d0e"
+let g:tinted_gui00 = "0c0d0e"
 let s:gui01        = "2e2f30"
-let g:base16_gui01 = "2e2f30"
+let g:tinted_gui01 = "2e2f30"
 let s:gui02        = "515253"
-let g:base16_gui02 = "515253"
+let g:tinted_gui02 = "515253"
 let s:gui03        = "737475"
-let g:base16_gui03 = "737475"
+let g:tinted_gui03 = "737475"
 let s:gui04        = "959697"
-let g:base16_gui04 = "959697"
+let g:tinted_gui04 = "959697"
 let s:gui05        = "b7b8b9"
-let g:base16_gui05 = "b7b8b9"
+let g:tinted_gui05 = "b7b8b9"
 let s:gui06        = "dadbdc"
-let g:base16_gui06 = "dadbdc"
+let g:tinted_gui06 = "dadbdc"
 let s:gui07        = "fcfdfe"
-let g:base16_gui07 = "fcfdfe"
+let g:tinted_gui07 = "fcfdfe"
 let s:gui08        = "e31a1c"
-let g:base16_gui08 = "e31a1c"
+let g:tinted_gui08 = "e31a1c"
 let s:gui09        = "e6550d"
-let g:base16_gui09 = "e6550d"
+let g:tinted_gui09 = "e6550d"
 let s:gui0A        = "dca060"
-let g:base16_gui0A = "dca060"
+let g:tinted_gui0A = "dca060"
 let s:gui0B        = "31a354"
-let g:base16_gui0B = "31a354"
+let g:tinted_gui0B = "31a354"
 let s:gui0C        = "80b1d3"
-let g:base16_gui0C = "80b1d3"
+let g:tinted_gui0C = "80b1d3"
 let s:gui0D        = "3182bd"
-let g:base16_gui0D = "3182bd"
+let g:tinted_gui0D = "3182bd"
 let s:gui0E        = "756bb1"
-let g:base16_gui0E = "756bb1"
+let g:tinted_gui0E = "756bb1"
 let s:gui0F        = "b15928"
+let g:tinted_gui0F = "b15928"
+
+" Legacy
+let g:base16_gui00 = "0c0d0e"
+let g:base16_gui01 = "2e2f30"
+let g:base16_gui02 = "515253"
+let g:base16_gui03 = "737475"
+let g:base16_gui04 = "959697"
+let g:base16_gui05 = "b7b8b9"
+let g:base16_gui06 = "dadbdc"
+let g:base16_gui07 = "fcfdfe"
+let g:base16_gui08 = "e31a1c"
+let g:base16_gui09 = "e6550d"
+let g:base16_gui0A = "dca060"
+let g:base16_gui0B = "31a354"
+let g:base16_gui0C = "80b1d3"
+let g:base16_gui0D = "3182bd"
+let g:base16_gui0E = "756bb1"
 let g:base16_gui0F = "b15928"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fcfdfe",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Bright
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-bright.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/bright.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/bright.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "303030"
-let g:base16_gui01 = "303030"
+let g:tinted_gui01 = "303030"
 let s:gui02        = "505050"
-let g:base16_gui02 = "505050"
+let g:tinted_gui02 = "505050"
 let s:gui03        = "b0b0b0"
-let g:base16_gui03 = "b0b0b0"
+let g:tinted_gui03 = "b0b0b0"
 let s:gui04        = "d0d0d0"
-let g:base16_gui04 = "d0d0d0"
+let g:tinted_gui04 = "d0d0d0"
 let s:gui05        = "e0e0e0"
-let g:base16_gui05 = "e0e0e0"
+let g:tinted_gui05 = "e0e0e0"
 let s:gui06        = "f5f5f5"
-let g:base16_gui06 = "f5f5f5"
+let g:tinted_gui06 = "f5f5f5"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "fb0120"
-let g:base16_gui08 = "fb0120"
+let g:tinted_gui08 = "fb0120"
 let s:gui09        = "fc6d24"
-let g:base16_gui09 = "fc6d24"
+let g:tinted_gui09 = "fc6d24"
 let s:gui0A        = "fda331"
-let g:base16_gui0A = "fda331"
+let g:tinted_gui0A = "fda331"
 let s:gui0B        = "a1c659"
-let g:base16_gui0B = "a1c659"
+let g:tinted_gui0B = "a1c659"
 let s:gui0C        = "76c7b7"
-let g:base16_gui0C = "76c7b7"
+let g:tinted_gui0C = "76c7b7"
 let s:gui0D        = "6fb3d2"
-let g:base16_gui0D = "6fb3d2"
+let g:tinted_gui0D = "6fb3d2"
 let s:gui0E        = "d381c3"
-let g:base16_gui0E = "d381c3"
+let g:tinted_gui0E = "d381c3"
 let s:gui0F        = "be643c"
+let g:tinted_gui0F = "be643c"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "303030"
+let g:base16_gui02 = "505050"
+let g:base16_gui03 = "b0b0b0"
+let g:base16_gui04 = "d0d0d0"
+let g:base16_gui05 = "e0e0e0"
+let g:base16_gui06 = "f5f5f5"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "fb0120"
+let g:base16_gui09 = "fc6d24"
+let g:base16_gui0A = "fda331"
+let g:base16_gui0B = "a1c659"
+let g:base16_gui0C = "76c7b7"
+let g:base16_gui0D = "6fb3d2"
+let g:base16_gui0E = "d381c3"
 let g:base16_gui0F = "be643c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Brogrammer
 " Scheme author: Vik Ramanujam (http://github.com/piggyslasher)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-brogrammer.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/brogrammer.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/brogrammer.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1f1f1f"
-let g:base16_gui00 = "1f1f1f"
+let g:tinted_gui00 = "1f1f1f"
 let s:gui01        = "f81118"
-let g:base16_gui01 = "f81118"
+let g:tinted_gui01 = "f81118"
 let s:gui02        = "2dc55e"
-let g:base16_gui02 = "2dc55e"
+let g:tinted_gui02 = "2dc55e"
 let s:gui03        = "ecba0f"
-let g:base16_gui03 = "ecba0f"
+let g:tinted_gui03 = "ecba0f"
 let s:gui04        = "2a84d2"
-let g:base16_gui04 = "2a84d2"
+let g:tinted_gui04 = "2a84d2"
 let s:gui05        = "4e5ab7"
-let g:base16_gui05 = "4e5ab7"
+let g:tinted_gui05 = "4e5ab7"
 let s:gui06        = "1081d6"
-let g:base16_gui06 = "1081d6"
+let g:tinted_gui06 = "1081d6"
 let s:gui07        = "d6dbe5"
-let g:base16_gui07 = "d6dbe5"
+let g:tinted_gui07 = "d6dbe5"
 let s:gui08        = "d6dbe5"
-let g:base16_gui08 = "d6dbe5"
+let g:tinted_gui08 = "d6dbe5"
 let s:gui09        = "de352e"
-let g:base16_gui09 = "de352e"
+let g:tinted_gui09 = "de352e"
 let s:gui0A        = "1dd361"
-let g:base16_gui0A = "1dd361"
+let g:tinted_gui0A = "1dd361"
 let s:gui0B        = "f3bd09"
-let g:base16_gui0B = "f3bd09"
+let g:tinted_gui0B = "f3bd09"
 let s:gui0C        = "1081d6"
-let g:base16_gui0C = "1081d6"
+let g:tinted_gui0C = "1081d6"
 let s:gui0D        = "5350b9"
-let g:base16_gui0D = "5350b9"
+let g:tinted_gui0D = "5350b9"
 let s:gui0E        = "0f7ddb"
-let g:base16_gui0E = "0f7ddb"
+let g:tinted_gui0E = "0f7ddb"
 let s:gui0F        = "ffffff"
+let g:tinted_gui0F = "ffffff"
+
+" Legacy
+let g:base16_gui00 = "1f1f1f"
+let g:base16_gui01 = "f81118"
+let g:base16_gui02 = "2dc55e"
+let g:base16_gui03 = "ecba0f"
+let g:base16_gui04 = "2a84d2"
+let g:base16_gui05 = "4e5ab7"
+let g:base16_gui06 = "1081d6"
+let g:base16_gui07 = "d6dbe5"
+let g:base16_gui08 = "d6dbe5"
+let g:base16_gui09 = "de352e"
+let g:base16_gui0A = "1dd361"
+let g:base16_gui0B = "f3bd09"
+let g:base16_gui0C = "1081d6"
+let g:base16_gui0D = "5350b9"
+let g:base16_gui0E = "0f7ddb"
 let g:base16_gui0F = "ffffff"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d6dbe5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Brush Trees Dark
 " Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-brushtrees-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/brushtrees-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/brushtrees-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "485867"
-let g:base16_gui00 = "485867"
+let g:tinted_gui00 = "485867"
 let s:gui01        = "5a6d7a"
-let g:base16_gui01 = "5a6d7a"
+let g:tinted_gui01 = "5a6d7a"
 let s:gui02        = "6d828e"
-let g:base16_gui02 = "6d828e"
+let g:tinted_gui02 = "6d828e"
 let s:gui03        = "8299a1"
-let g:base16_gui03 = "8299a1"
+let g:tinted_gui03 = "8299a1"
 let s:gui04        = "98afb5"
-let g:base16_gui04 = "98afb5"
+let g:tinted_gui04 = "98afb5"
 let s:gui05        = "b0c5c8"
-let g:base16_gui05 = "b0c5c8"
+let g:tinted_gui05 = "b0c5c8"
 let s:gui06        = "c9dbdc"
-let g:base16_gui06 = "c9dbdc"
+let g:tinted_gui06 = "c9dbdc"
 let s:gui07        = "e3efef"
-let g:base16_gui07 = "e3efef"
+let g:tinted_gui07 = "e3efef"
 let s:gui08        = "b38686"
-let g:base16_gui08 = "b38686"
+let g:tinted_gui08 = "b38686"
 let s:gui09        = "d8bba2"
-let g:base16_gui09 = "d8bba2"
+let g:tinted_gui09 = "d8bba2"
 let s:gui0A        = "aab386"
-let g:base16_gui0A = "aab386"
+let g:tinted_gui0A = "aab386"
 let s:gui0B        = "87b386"
-let g:base16_gui0B = "87b386"
+let g:tinted_gui0B = "87b386"
 let s:gui0C        = "86b3b3"
-let g:base16_gui0C = "86b3b3"
+let g:tinted_gui0C = "86b3b3"
 let s:gui0D        = "868cb3"
-let g:base16_gui0D = "868cb3"
+let g:tinted_gui0D = "868cb3"
 let s:gui0E        = "b386b2"
-let g:base16_gui0E = "b386b2"
+let g:tinted_gui0E = "b386b2"
 let s:gui0F        = "b39f9f"
+let g:tinted_gui0F = "b39f9f"
+
+" Legacy
+let g:base16_gui00 = "485867"
+let g:base16_gui01 = "5a6d7a"
+let g:base16_gui02 = "6d828e"
+let g:base16_gui03 = "8299a1"
+let g:base16_gui04 = "98afb5"
+let g:base16_gui05 = "b0c5c8"
+let g:base16_gui06 = "c9dbdc"
+let g:base16_gui07 = "e3efef"
+let g:base16_gui08 = "b38686"
+let g:base16_gui09 = "d8bba2"
+let g:base16_gui0A = "aab386"
+let g:base16_gui0B = "87b386"
+let g:base16_gui0C = "86b3b3"
+let g:base16_gui0D = "868cb3"
+let g:base16_gui0E = "b386b2"
 let g:base16_gui0F = "b39f9f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e3efef",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Brush Trees
 " Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-brushtrees.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/brushtrees.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/brushtrees.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "e3efef"
-let g:base16_gui00 = "e3efef"
+let g:tinted_gui00 = "e3efef"
 let s:gui01        = "c9dbdc"
-let g:base16_gui01 = "c9dbdc"
+let g:tinted_gui01 = "c9dbdc"
 let s:gui02        = "b0c5c8"
-let g:base16_gui02 = "b0c5c8"
+let g:tinted_gui02 = "b0c5c8"
 let s:gui03        = "98afb5"
-let g:base16_gui03 = "98afb5"
+let g:tinted_gui03 = "98afb5"
 let s:gui04        = "8299a1"
-let g:base16_gui04 = "8299a1"
+let g:tinted_gui04 = "8299a1"
 let s:gui05        = "6d828e"
-let g:base16_gui05 = "6d828e"
+let g:tinted_gui05 = "6d828e"
 let s:gui06        = "5a6d7a"
-let g:base16_gui06 = "5a6d7a"
+let g:tinted_gui06 = "5a6d7a"
 let s:gui07        = "485867"
-let g:base16_gui07 = "485867"
+let g:tinted_gui07 = "485867"
 let s:gui08        = "b38686"
-let g:base16_gui08 = "b38686"
+let g:tinted_gui08 = "b38686"
 let s:gui09        = "d8bba2"
-let g:base16_gui09 = "d8bba2"
+let g:tinted_gui09 = "d8bba2"
 let s:gui0A        = "aab386"
-let g:base16_gui0A = "aab386"
+let g:tinted_gui0A = "aab386"
 let s:gui0B        = "87b386"
-let g:base16_gui0B = "87b386"
+let g:tinted_gui0B = "87b386"
 let s:gui0C        = "86b3b3"
-let g:base16_gui0C = "86b3b3"
+let g:tinted_gui0C = "86b3b3"
 let s:gui0D        = "868cb3"
-let g:base16_gui0D = "868cb3"
+let g:tinted_gui0D = "868cb3"
 let s:gui0E        = "b386b2"
-let g:base16_gui0E = "b386b2"
+let g:tinted_gui0E = "b386b2"
 let s:gui0F        = "b39f9f"
+let g:tinted_gui0F = "b39f9f"
+
+" Legacy
+let g:base16_gui00 = "e3efef"
+let g:base16_gui01 = "c9dbdc"
+let g:base16_gui02 = "b0c5c8"
+let g:base16_gui03 = "98afb5"
+let g:base16_gui04 = "8299a1"
+let g:base16_gui05 = "6d828e"
+let g:base16_gui06 = "5a6d7a"
+let g:base16_gui07 = "485867"
+let g:base16_gui08 = "b38686"
+let g:base16_gui09 = "d8bba2"
+let g:base16_gui0A = "aab386"
+let g:base16_gui0B = "87b386"
+let g:base16_gui0C = "86b3b3"
+let g:base16_gui0D = "868cb3"
+let g:base16_gui0E = "b386b2"
 let g:base16_gui0F = "b39f9f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#485867",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-caroline.vim
+++ b/colors/base16-caroline.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: caroline
 " Scheme author: ed (https://codeberg.org/ed)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-caroline.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/caroline.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/caroline.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c1213"
-let g:base16_gui00 = "1c1213"
+let g:tinted_gui00 = "1c1213"
 let s:gui01        = "3a2425"
-let g:base16_gui01 = "3a2425"
+let g:tinted_gui01 = "3a2425"
 let s:gui02        = "563837"
-let g:base16_gui02 = "563837"
+let g:tinted_gui02 = "563837"
 let s:gui03        = "6d4745"
-let g:base16_gui03 = "6d4745"
+let g:tinted_gui03 = "6d4745"
 let s:gui04        = "8b5d57"
-let g:base16_gui04 = "8b5d57"
+let g:tinted_gui04 = "8b5d57"
 let s:gui05        = "a87569"
-let g:base16_gui05 = "a87569"
+let g:tinted_gui05 = "a87569"
 let s:gui06        = "c58d7b"
-let g:base16_gui06 = "c58d7b"
+let g:tinted_gui06 = "c58d7b"
 let s:gui07        = "e3a68c"
-let g:base16_gui07 = "e3a68c"
+let g:tinted_gui07 = "e3a68c"
 let s:gui08        = "c24f57"
-let g:base16_gui08 = "c24f57"
+let g:tinted_gui08 = "c24f57"
 let s:gui09        = "a63650"
-let g:base16_gui09 = "a63650"
+let g:tinted_gui09 = "a63650"
 let s:gui0A        = "f28171"
-let g:base16_gui0A = "f28171"
+let g:tinted_gui0A = "f28171"
 let s:gui0B        = "806c61"
-let g:base16_gui0B = "806c61"
+let g:tinted_gui0B = "806c61"
 let s:gui0C        = "6b6566"
-let g:base16_gui0C = "6b6566"
+let g:tinted_gui0C = "6b6566"
 let s:gui0D        = "684c59"
-let g:base16_gui0D = "684c59"
+let g:tinted_gui0D = "684c59"
 let s:gui0E        = "a63650"
-let g:base16_gui0E = "a63650"
+let g:tinted_gui0E = "a63650"
 let s:gui0F        = "893f45"
+let g:tinted_gui0F = "893f45"
+
+" Legacy
+let g:base16_gui00 = "1c1213"
+let g:base16_gui01 = "3a2425"
+let g:base16_gui02 = "563837"
+let g:base16_gui03 = "6d4745"
+let g:base16_gui04 = "8b5d57"
+let g:base16_gui05 = "a87569"
+let g:base16_gui06 = "c58d7b"
+let g:base16_gui07 = "e3a68c"
+let g:base16_gui08 = "c24f57"
+let g:base16_gui09 = "a63650"
+let g:base16_gui0A = "f28171"
+let g:base16_gui0B = "806c61"
+let g:base16_gui0C = "6b6566"
+let g:base16_gui0D = "684c59"
+let g:base16_gui0E = "a63650"
 let g:base16_gui0F = "893f45"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e3a68c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-catppuccin-frappe.vim
+++ b/colors/base16-catppuccin-frappe.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Catppuccin Frappe
 " Scheme author: https://github.com/catppuccin/catppuccin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-catppuccin-frappe.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/catppuccin-frappe.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/catppuccin-frappe.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "303446"
-let g:base16_gui00 = "303446"
+let g:tinted_gui00 = "303446"
 let s:gui01        = "292c3c"
-let g:base16_gui01 = "292c3c"
+let g:tinted_gui01 = "292c3c"
 let s:gui02        = "414559"
-let g:base16_gui02 = "414559"
+let g:tinted_gui02 = "414559"
 let s:gui03        = "51576d"
-let g:base16_gui03 = "51576d"
+let g:tinted_gui03 = "51576d"
 let s:gui04        = "626880"
-let g:base16_gui04 = "626880"
+let g:tinted_gui04 = "626880"
 let s:gui05        = "c6d0f5"
-let g:base16_gui05 = "c6d0f5"
+let g:tinted_gui05 = "c6d0f5"
 let s:gui06        = "f2d5cf"
-let g:base16_gui06 = "f2d5cf"
+let g:tinted_gui06 = "f2d5cf"
 let s:gui07        = "babbf1"
-let g:base16_gui07 = "babbf1"
+let g:tinted_gui07 = "babbf1"
 let s:gui08        = "e78284"
-let g:base16_gui08 = "e78284"
+let g:tinted_gui08 = "e78284"
 let s:gui09        = "ef9f76"
-let g:base16_gui09 = "ef9f76"
+let g:tinted_gui09 = "ef9f76"
 let s:gui0A        = "e5c890"
-let g:base16_gui0A = "e5c890"
+let g:tinted_gui0A = "e5c890"
 let s:gui0B        = "a6d189"
-let g:base16_gui0B = "a6d189"
+let g:tinted_gui0B = "a6d189"
 let s:gui0C        = "81c8be"
-let g:base16_gui0C = "81c8be"
+let g:tinted_gui0C = "81c8be"
 let s:gui0D        = "8caaee"
-let g:base16_gui0D = "8caaee"
+let g:tinted_gui0D = "8caaee"
 let s:gui0E        = "ca9ee6"
-let g:base16_gui0E = "ca9ee6"
+let g:tinted_gui0E = "ca9ee6"
 let s:gui0F        = "eebebe"
+let g:tinted_gui0F = "eebebe"
+
+" Legacy
+let g:base16_gui00 = "303446"
+let g:base16_gui01 = "292c3c"
+let g:base16_gui02 = "414559"
+let g:base16_gui03 = "51576d"
+let g:base16_gui04 = "626880"
+let g:base16_gui05 = "c6d0f5"
+let g:base16_gui06 = "f2d5cf"
+let g:base16_gui07 = "babbf1"
+let g:base16_gui08 = "e78284"
+let g:base16_gui09 = "ef9f76"
+let g:base16_gui0A = "e5c890"
+let g:base16_gui0B = "a6d189"
+let g:base16_gui0C = "81c8be"
+let g:base16_gui0D = "8caaee"
+let g:base16_gui0E = "ca9ee6"
 let g:base16_gui0F = "eebebe"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#babbf1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-catppuccin-latte.vim
+++ b/colors/base16-catppuccin-latte.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Catppuccin Latte
 " Scheme author: https://github.com/catppuccin/catppuccin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-catppuccin-latte.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/catppuccin-latte.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/catppuccin-latte.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "eff1f5"
-let g:base16_gui00 = "eff1f5"
+let g:tinted_gui00 = "eff1f5"
 let s:gui01        = "e6e9ef"
-let g:base16_gui01 = "e6e9ef"
+let g:tinted_gui01 = "e6e9ef"
 let s:gui02        = "ccd0da"
-let g:base16_gui02 = "ccd0da"
+let g:tinted_gui02 = "ccd0da"
 let s:gui03        = "bcc0cc"
-let g:base16_gui03 = "bcc0cc"
+let g:tinted_gui03 = "bcc0cc"
 let s:gui04        = "acb0be"
-let g:base16_gui04 = "acb0be"
+let g:tinted_gui04 = "acb0be"
 let s:gui05        = "4c4f69"
-let g:base16_gui05 = "4c4f69"
+let g:tinted_gui05 = "4c4f69"
 let s:gui06        = "dc8a78"
-let g:base16_gui06 = "dc8a78"
+let g:tinted_gui06 = "dc8a78"
 let s:gui07        = "7287fd"
-let g:base16_gui07 = "7287fd"
+let g:tinted_gui07 = "7287fd"
 let s:gui08        = "d20f39"
-let g:base16_gui08 = "d20f39"
+let g:tinted_gui08 = "d20f39"
 let s:gui09        = "fe640b"
-let g:base16_gui09 = "fe640b"
+let g:tinted_gui09 = "fe640b"
 let s:gui0A        = "df8e1d"
-let g:base16_gui0A = "df8e1d"
+let g:tinted_gui0A = "df8e1d"
 let s:gui0B        = "40a02b"
-let g:base16_gui0B = "40a02b"
+let g:tinted_gui0B = "40a02b"
 let s:gui0C        = "179299"
-let g:base16_gui0C = "179299"
+let g:tinted_gui0C = "179299"
 let s:gui0D        = "1e66f5"
-let g:base16_gui0D = "1e66f5"
+let g:tinted_gui0D = "1e66f5"
 let s:gui0E        = "8839ef"
-let g:base16_gui0E = "8839ef"
+let g:tinted_gui0E = "8839ef"
 let s:gui0F        = "dd7878"
+let g:tinted_gui0F = "dd7878"
+
+" Legacy
+let g:base16_gui00 = "eff1f5"
+let g:base16_gui01 = "e6e9ef"
+let g:base16_gui02 = "ccd0da"
+let g:base16_gui03 = "bcc0cc"
+let g:base16_gui04 = "acb0be"
+let g:base16_gui05 = "4c4f69"
+let g:base16_gui06 = "dc8a78"
+let g:base16_gui07 = "7287fd"
+let g:base16_gui08 = "d20f39"
+let g:base16_gui09 = "fe640b"
+let g:base16_gui0A = "df8e1d"
+let g:base16_gui0B = "40a02b"
+let g:base16_gui0C = "179299"
+let g:base16_gui0D = "1e66f5"
+let g:base16_gui0E = "8839ef"
 let g:base16_gui0F = "dd7878"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#7287fd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-catppuccin-macchiato.vim
+++ b/colors/base16-catppuccin-macchiato.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Catppuccin Macchiato
 " Scheme author: https://github.com/catppuccin/catppuccin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-catppuccin-macchiato.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/catppuccin-macchiato.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/catppuccin-macchiato.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "24273a"
-let g:base16_gui00 = "24273a"
+let g:tinted_gui00 = "24273a"
 let s:gui01        = "1e2030"
-let g:base16_gui01 = "1e2030"
+let g:tinted_gui01 = "1e2030"
 let s:gui02        = "363a4f"
-let g:base16_gui02 = "363a4f"
+let g:tinted_gui02 = "363a4f"
 let s:gui03        = "494d64"
-let g:base16_gui03 = "494d64"
+let g:tinted_gui03 = "494d64"
 let s:gui04        = "5b6078"
-let g:base16_gui04 = "5b6078"
+let g:tinted_gui04 = "5b6078"
 let s:gui05        = "cad3f5"
-let g:base16_gui05 = "cad3f5"
+let g:tinted_gui05 = "cad3f5"
 let s:gui06        = "f4dbd6"
-let g:base16_gui06 = "f4dbd6"
+let g:tinted_gui06 = "f4dbd6"
 let s:gui07        = "b7bdf8"
-let g:base16_gui07 = "b7bdf8"
+let g:tinted_gui07 = "b7bdf8"
 let s:gui08        = "ed8796"
-let g:base16_gui08 = "ed8796"
+let g:tinted_gui08 = "ed8796"
 let s:gui09        = "f5a97f"
-let g:base16_gui09 = "f5a97f"
+let g:tinted_gui09 = "f5a97f"
 let s:gui0A        = "eed49f"
-let g:base16_gui0A = "eed49f"
+let g:tinted_gui0A = "eed49f"
 let s:gui0B        = "a6da95"
-let g:base16_gui0B = "a6da95"
+let g:tinted_gui0B = "a6da95"
 let s:gui0C        = "8bd5ca"
-let g:base16_gui0C = "8bd5ca"
+let g:tinted_gui0C = "8bd5ca"
 let s:gui0D        = "8aadf4"
-let g:base16_gui0D = "8aadf4"
+let g:tinted_gui0D = "8aadf4"
 let s:gui0E        = "c6a0f6"
-let g:base16_gui0E = "c6a0f6"
+let g:tinted_gui0E = "c6a0f6"
 let s:gui0F        = "f0c6c6"
+let g:tinted_gui0F = "f0c6c6"
+
+" Legacy
+let g:base16_gui00 = "24273a"
+let g:base16_gui01 = "1e2030"
+let g:base16_gui02 = "363a4f"
+let g:base16_gui03 = "494d64"
+let g:base16_gui04 = "5b6078"
+let g:base16_gui05 = "cad3f5"
+let g:base16_gui06 = "f4dbd6"
+let g:base16_gui07 = "b7bdf8"
+let g:base16_gui08 = "ed8796"
+let g:base16_gui09 = "f5a97f"
+let g:base16_gui0A = "eed49f"
+let g:base16_gui0B = "a6da95"
+let g:base16_gui0C = "8bd5ca"
+let g:base16_gui0D = "8aadf4"
+let g:base16_gui0E = "c6a0f6"
 let g:base16_gui0F = "f0c6c6"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#b7bdf8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-catppuccin-mocha.vim
+++ b/colors/base16-catppuccin-mocha.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Catppuccin Mocha
 " Scheme author: https://github.com/catppuccin/catppuccin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-catppuccin-mocha.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/catppuccin-mocha.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/catppuccin-mocha.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1e1e2e"
-let g:base16_gui00 = "1e1e2e"
+let g:tinted_gui00 = "1e1e2e"
 let s:gui01        = "181825"
-let g:base16_gui01 = "181825"
+let g:tinted_gui01 = "181825"
 let s:gui02        = "313244"
-let g:base16_gui02 = "313244"
+let g:tinted_gui02 = "313244"
 let s:gui03        = "45475a"
-let g:base16_gui03 = "45475a"
+let g:tinted_gui03 = "45475a"
 let s:gui04        = "585b70"
-let g:base16_gui04 = "585b70"
+let g:tinted_gui04 = "585b70"
 let s:gui05        = "cdd6f4"
-let g:base16_gui05 = "cdd6f4"
+let g:tinted_gui05 = "cdd6f4"
 let s:gui06        = "f5e0dc"
-let g:base16_gui06 = "f5e0dc"
+let g:tinted_gui06 = "f5e0dc"
 let s:gui07        = "b4befe"
-let g:base16_gui07 = "b4befe"
+let g:tinted_gui07 = "b4befe"
 let s:gui08        = "f38ba8"
-let g:base16_gui08 = "f38ba8"
+let g:tinted_gui08 = "f38ba8"
 let s:gui09        = "fab387"
-let g:base16_gui09 = "fab387"
+let g:tinted_gui09 = "fab387"
 let s:gui0A        = "f9e2af"
-let g:base16_gui0A = "f9e2af"
+let g:tinted_gui0A = "f9e2af"
 let s:gui0B        = "a6e3a1"
-let g:base16_gui0B = "a6e3a1"
+let g:tinted_gui0B = "a6e3a1"
 let s:gui0C        = "94e2d5"
-let g:base16_gui0C = "94e2d5"
+let g:tinted_gui0C = "94e2d5"
 let s:gui0D        = "89b4fa"
-let g:base16_gui0D = "89b4fa"
+let g:tinted_gui0D = "89b4fa"
 let s:gui0E        = "cba6f7"
-let g:base16_gui0E = "cba6f7"
+let g:tinted_gui0E = "cba6f7"
 let s:gui0F        = "f2cdcd"
+let g:tinted_gui0F = "f2cdcd"
+
+" Legacy
+let g:base16_gui00 = "1e1e2e"
+let g:base16_gui01 = "181825"
+let g:base16_gui02 = "313244"
+let g:base16_gui03 = "45475a"
+let g:base16_gui04 = "585b70"
+let g:base16_gui05 = "cdd6f4"
+let g:base16_gui06 = "f5e0dc"
+let g:base16_gui07 = "b4befe"
+let g:base16_gui08 = "f38ba8"
+let g:base16_gui09 = "fab387"
+let g:base16_gui0A = "f9e2af"
+let g:base16_gui0B = "a6e3a1"
+let g:base16_gui0C = "94e2d5"
+let g:base16_gui0D = "89b4fa"
+let g:base16_gui0E = "cba6f7"
 let g:base16_gui0F = "f2cdcd"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#b4befe",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Chalk
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-chalk.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/chalk.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/chalk.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "151515"
-let g:base16_gui00 = "151515"
+let g:tinted_gui00 = "151515"
 let s:gui01        = "202020"
-let g:base16_gui01 = "202020"
+let g:tinted_gui01 = "202020"
 let s:gui02        = "303030"
-let g:base16_gui02 = "303030"
+let g:tinted_gui02 = "303030"
 let s:gui03        = "505050"
-let g:base16_gui03 = "505050"
+let g:tinted_gui03 = "505050"
 let s:gui04        = "b0b0b0"
-let g:base16_gui04 = "b0b0b0"
+let g:tinted_gui04 = "b0b0b0"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "f5f5f5"
-let g:base16_gui07 = "f5f5f5"
+let g:tinted_gui07 = "f5f5f5"
 let s:gui08        = "fb9fb1"
-let g:base16_gui08 = "fb9fb1"
+let g:tinted_gui08 = "fb9fb1"
 let s:gui09        = "eda987"
-let g:base16_gui09 = "eda987"
+let g:tinted_gui09 = "eda987"
 let s:gui0A        = "ddb26f"
-let g:base16_gui0A = "ddb26f"
+let g:tinted_gui0A = "ddb26f"
 let s:gui0B        = "acc267"
-let g:base16_gui0B = "acc267"
+let g:tinted_gui0B = "acc267"
 let s:gui0C        = "12cfc0"
-let g:base16_gui0C = "12cfc0"
+let g:tinted_gui0C = "12cfc0"
 let s:gui0D        = "6fc2ef"
-let g:base16_gui0D = "6fc2ef"
+let g:tinted_gui0D = "6fc2ef"
 let s:gui0E        = "e1a3ee"
-let g:base16_gui0E = "e1a3ee"
+let g:tinted_gui0E = "e1a3ee"
 let s:gui0F        = "deaf8f"
+let g:tinted_gui0F = "deaf8f"
+
+" Legacy
+let g:base16_gui00 = "151515"
+let g:base16_gui01 = "202020"
+let g:base16_gui02 = "303030"
+let g:base16_gui03 = "505050"
+let g:base16_gui04 = "b0b0b0"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "f5f5f5"
+let g:base16_gui08 = "fb9fb1"
+let g:base16_gui09 = "eda987"
+let g:base16_gui0A = "ddb26f"
+let g:base16_gui0B = "acc267"
+let g:base16_gui0C = "12cfc0"
+let g:base16_gui0D = "6fc2ef"
+let g:base16_gui0E = "e1a3ee"
 let g:base16_gui0F = "deaf8f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f5f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Circus
 " Scheme author: Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-circus.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/circus.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/circus.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "191919"
-let g:base16_gui00 = "191919"
+let g:tinted_gui00 = "191919"
 let s:gui01        = "202020"
-let g:base16_gui01 = "202020"
+let g:tinted_gui01 = "202020"
 let s:gui02        = "303030"
-let g:base16_gui02 = "303030"
+let g:tinted_gui02 = "303030"
 let s:gui03        = "5f5a60"
-let g:base16_gui03 = "5f5a60"
+let g:tinted_gui03 = "5f5a60"
 let s:gui04        = "505050"
-let g:base16_gui04 = "505050"
+let g:tinted_gui04 = "505050"
 let s:gui05        = "a7a7a7"
-let g:base16_gui05 = "a7a7a7"
+let g:tinted_gui05 = "a7a7a7"
 let s:gui06        = "808080"
-let g:base16_gui06 = "808080"
+let g:tinted_gui06 = "808080"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "dc657d"
-let g:base16_gui08 = "dc657d"
+let g:tinted_gui08 = "dc657d"
 let s:gui09        = "4bb1a7"
-let g:base16_gui09 = "4bb1a7"
+let g:tinted_gui09 = "4bb1a7"
 let s:gui0A        = "c3ba63"
-let g:base16_gui0A = "c3ba63"
+let g:tinted_gui0A = "c3ba63"
 let s:gui0B        = "84b97c"
-let g:base16_gui0B = "84b97c"
+let g:tinted_gui0B = "84b97c"
 let s:gui0C        = "4bb1a7"
-let g:base16_gui0C = "4bb1a7"
+let g:tinted_gui0C = "4bb1a7"
 let s:gui0D        = "639ee4"
-let g:base16_gui0D = "639ee4"
+let g:tinted_gui0D = "639ee4"
 let s:gui0E        = "b888e2"
-let g:base16_gui0E = "b888e2"
+let g:tinted_gui0E = "b888e2"
 let s:gui0F        = "b888e2"
+let g:tinted_gui0F = "b888e2"
+
+" Legacy
+let g:base16_gui00 = "191919"
+let g:base16_gui01 = "202020"
+let g:base16_gui02 = "303030"
+let g:base16_gui03 = "5f5a60"
+let g:base16_gui04 = "505050"
+let g:base16_gui05 = "a7a7a7"
+let g:base16_gui06 = "808080"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "dc657d"
+let g:base16_gui09 = "4bb1a7"
+let g:base16_gui0A = "c3ba63"
+let g:base16_gui0B = "84b97c"
+let g:base16_gui0C = "4bb1a7"
+let g:base16_gui0D = "639ee4"
+let g:base16_gui0E = "b888e2"
 let g:base16_gui0F = "b888e2"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Classic Dark
 " Scheme author: Jason Heeris (http://heeris.id.au)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-classic-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/classic-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/classic-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "151515"
-let g:base16_gui00 = "151515"
+let g:tinted_gui00 = "151515"
 let s:gui01        = "202020"
-let g:base16_gui01 = "202020"
+let g:tinted_gui01 = "202020"
 let s:gui02        = "303030"
-let g:base16_gui02 = "303030"
+let g:tinted_gui02 = "303030"
 let s:gui03        = "505050"
-let g:base16_gui03 = "505050"
+let g:tinted_gui03 = "505050"
 let s:gui04        = "b0b0b0"
-let g:base16_gui04 = "b0b0b0"
+let g:tinted_gui04 = "b0b0b0"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "f5f5f5"
-let g:base16_gui07 = "f5f5f5"
+let g:tinted_gui07 = "f5f5f5"
 let s:gui08        = "ac4142"
-let g:base16_gui08 = "ac4142"
+let g:tinted_gui08 = "ac4142"
 let s:gui09        = "d28445"
-let g:base16_gui09 = "d28445"
+let g:tinted_gui09 = "d28445"
 let s:gui0A        = "f4bf75"
-let g:base16_gui0A = "f4bf75"
+let g:tinted_gui0A = "f4bf75"
 let s:gui0B        = "90a959"
-let g:base16_gui0B = "90a959"
+let g:tinted_gui0B = "90a959"
 let s:gui0C        = "75b5aa"
-let g:base16_gui0C = "75b5aa"
+let g:tinted_gui0C = "75b5aa"
 let s:gui0D        = "6a9fb5"
-let g:base16_gui0D = "6a9fb5"
+let g:tinted_gui0D = "6a9fb5"
 let s:gui0E        = "aa759f"
-let g:base16_gui0E = "aa759f"
+let g:tinted_gui0E = "aa759f"
 let s:gui0F        = "8f5536"
+let g:tinted_gui0F = "8f5536"
+
+" Legacy
+let g:base16_gui00 = "151515"
+let g:base16_gui01 = "202020"
+let g:base16_gui02 = "303030"
+let g:base16_gui03 = "505050"
+let g:base16_gui04 = "b0b0b0"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "f5f5f5"
+let g:base16_gui08 = "ac4142"
+let g:base16_gui09 = "d28445"
+let g:base16_gui0A = "f4bf75"
+let g:base16_gui0B = "90a959"
+let g:base16_gui0C = "75b5aa"
+let g:base16_gui0D = "6a9fb5"
+let g:base16_gui0E = "aa759f"
 let g:base16_gui0F = "8f5536"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f5f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Classic Light
 " Scheme author: Jason Heeris (http://heeris.id.au)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-classic-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/classic-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/classic-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f5f5f5"
-let g:base16_gui00 = "f5f5f5"
+let g:tinted_gui00 = "f5f5f5"
 let s:gui01        = "e0e0e0"
-let g:base16_gui01 = "e0e0e0"
+let g:tinted_gui01 = "e0e0e0"
 let s:gui02        = "d0d0d0"
-let g:base16_gui02 = "d0d0d0"
+let g:tinted_gui02 = "d0d0d0"
 let s:gui03        = "b0b0b0"
-let g:base16_gui03 = "b0b0b0"
+let g:tinted_gui03 = "b0b0b0"
 let s:gui04        = "505050"
-let g:base16_gui04 = "505050"
+let g:tinted_gui04 = "505050"
 let s:gui05        = "303030"
-let g:base16_gui05 = "303030"
+let g:tinted_gui05 = "303030"
 let s:gui06        = "202020"
-let g:base16_gui06 = "202020"
+let g:tinted_gui06 = "202020"
 let s:gui07        = "151515"
-let g:base16_gui07 = "151515"
+let g:tinted_gui07 = "151515"
 let s:gui08        = "ac4142"
-let g:base16_gui08 = "ac4142"
+let g:tinted_gui08 = "ac4142"
 let s:gui09        = "d28445"
-let g:base16_gui09 = "d28445"
+let g:tinted_gui09 = "d28445"
 let s:gui0A        = "f4bf75"
-let g:base16_gui0A = "f4bf75"
+let g:tinted_gui0A = "f4bf75"
 let s:gui0B        = "90a959"
-let g:base16_gui0B = "90a959"
+let g:tinted_gui0B = "90a959"
 let s:gui0C        = "75b5aa"
-let g:base16_gui0C = "75b5aa"
+let g:tinted_gui0C = "75b5aa"
 let s:gui0D        = "6a9fb5"
-let g:base16_gui0D = "6a9fb5"
+let g:tinted_gui0D = "6a9fb5"
 let s:gui0E        = "aa759f"
-let g:base16_gui0E = "aa759f"
+let g:tinted_gui0E = "aa759f"
 let s:gui0F        = "8f5536"
+let g:tinted_gui0F = "8f5536"
+
+" Legacy
+let g:base16_gui00 = "f5f5f5"
+let g:base16_gui01 = "e0e0e0"
+let g:base16_gui02 = "d0d0d0"
+let g:base16_gui03 = "b0b0b0"
+let g:base16_gui04 = "505050"
+let g:base16_gui05 = "303030"
+let g:base16_gui06 = "202020"
+let g:base16_gui07 = "151515"
+let g:base16_gui08 = "ac4142"
+let g:base16_gui09 = "d28445"
+let g:base16_gui0A = "f4bf75"
+let g:base16_gui0B = "90a959"
+let g:base16_gui0C = "75b5aa"
+let g:base16_gui0D = "6a9fb5"
+let g:base16_gui0E = "aa759f"
 let g:base16_gui0F = "8f5536"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#151515",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Codeschool
 " Scheme author: blockloop
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-codeschool.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/codeschool.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/codeschool.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "232c31"
-let g:base16_gui00 = "232c31"
+let g:tinted_gui00 = "232c31"
 let s:gui01        = "1c3657"
-let g:base16_gui01 = "1c3657"
+let g:tinted_gui01 = "1c3657"
 let s:gui02        = "2a343a"
-let g:base16_gui02 = "2a343a"
+let g:tinted_gui02 = "2a343a"
 let s:gui03        = "3f4944"
-let g:base16_gui03 = "3f4944"
+let g:tinted_gui03 = "3f4944"
 let s:gui04        = "84898c"
-let g:base16_gui04 = "84898c"
+let g:tinted_gui04 = "84898c"
 let s:gui05        = "9ea7a6"
-let g:base16_gui05 = "9ea7a6"
+let g:tinted_gui05 = "9ea7a6"
 let s:gui06        = "a7cfa3"
-let g:base16_gui06 = "a7cfa3"
+let g:tinted_gui06 = "a7cfa3"
 let s:gui07        = "b5d8f6"
-let g:base16_gui07 = "b5d8f6"
+let g:tinted_gui07 = "b5d8f6"
 let s:gui08        = "2a5491"
-let g:base16_gui08 = "2a5491"
+let g:tinted_gui08 = "2a5491"
 let s:gui09        = "43820d"
-let g:base16_gui09 = "43820d"
+let g:tinted_gui09 = "43820d"
 let s:gui0A        = "a03b1e"
-let g:base16_gui0A = "a03b1e"
+let g:tinted_gui0A = "a03b1e"
 let s:gui0B        = "237986"
-let g:base16_gui0B = "237986"
+let g:tinted_gui0B = "237986"
 let s:gui0C        = "b02f30"
-let g:base16_gui0C = "b02f30"
+let g:tinted_gui0C = "b02f30"
 let s:gui0D        = "484d79"
-let g:base16_gui0D = "484d79"
+let g:tinted_gui0D = "484d79"
 let s:gui0E        = "c59820"
-let g:base16_gui0E = "c59820"
+let g:tinted_gui0E = "c59820"
 let s:gui0F        = "c98344"
+let g:tinted_gui0F = "c98344"
+
+" Legacy
+let g:base16_gui00 = "232c31"
+let g:base16_gui01 = "1c3657"
+let g:base16_gui02 = "2a343a"
+let g:base16_gui03 = "3f4944"
+let g:base16_gui04 = "84898c"
+let g:base16_gui05 = "9ea7a6"
+let g:base16_gui06 = "a7cfa3"
+let g:base16_gui07 = "b5d8f6"
+let g:base16_gui08 = "2a5491"
+let g:base16_gui09 = "43820d"
+let g:base16_gui0A = "a03b1e"
+let g:base16_gui0B = "237986"
+let g:base16_gui0C = "b02f30"
+let g:base16_gui0D = "484d79"
+let g:base16_gui0E = "c59820"
 let g:base16_gui0F = "c98344"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#b5d8f6",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-colors.vim
+++ b/colors/base16-colors.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Colors
 " Scheme author: mrmrs (http://clrs.cc)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-colors.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/colors.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/colors.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "111111"
-let g:base16_gui00 = "111111"
+let g:tinted_gui00 = "111111"
 let s:gui01        = "333333"
-let g:base16_gui01 = "333333"
+let g:tinted_gui01 = "333333"
 let s:gui02        = "555555"
-let g:base16_gui02 = "555555"
+let g:tinted_gui02 = "555555"
 let s:gui03        = "777777"
-let g:base16_gui03 = "777777"
+let g:tinted_gui03 = "777777"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "bbbbbb"
-let g:base16_gui05 = "bbbbbb"
+let g:tinted_gui05 = "bbbbbb"
 let s:gui06        = "dddddd"
-let g:base16_gui06 = "dddddd"
+let g:tinted_gui06 = "dddddd"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff4136"
-let g:base16_gui08 = "ff4136"
+let g:tinted_gui08 = "ff4136"
 let s:gui09        = "ff851b"
-let g:base16_gui09 = "ff851b"
+let g:tinted_gui09 = "ff851b"
 let s:gui0A        = "ffdc00"
-let g:base16_gui0A = "ffdc00"
+let g:tinted_gui0A = "ffdc00"
 let s:gui0B        = "2ecc40"
-let g:base16_gui0B = "2ecc40"
+let g:tinted_gui0B = "2ecc40"
 let s:gui0C        = "7fdbff"
-let g:base16_gui0C = "7fdbff"
+let g:tinted_gui0C = "7fdbff"
 let s:gui0D        = "0074d9"
-let g:base16_gui0D = "0074d9"
+let g:tinted_gui0D = "0074d9"
 let s:gui0E        = "b10dc9"
-let g:base16_gui0E = "b10dc9"
+let g:tinted_gui0E = "b10dc9"
 let s:gui0F        = "85144b"
+let g:tinted_gui0F = "85144b"
+
+" Legacy
+let g:base16_gui00 = "111111"
+let g:base16_gui01 = "333333"
+let g:base16_gui02 = "555555"
+let g:base16_gui03 = "777777"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "bbbbbb"
+let g:base16_gui06 = "dddddd"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff4136"
+let g:base16_gui09 = "ff851b"
+let g:base16_gui0A = "ffdc00"
+let g:base16_gui0B = "2ecc40"
+let g:base16_gui0C = "7fdbff"
+let g:base16_gui0D = "0074d9"
+let g:base16_gui0E = "b10dc9"
 let g:base16_gui0F = "85144b"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Cupcake
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-cupcake.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/cupcake.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/cupcake.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fbf1f2"
-let g:base16_gui00 = "fbf1f2"
+let g:tinted_gui00 = "fbf1f2"
 let s:gui01        = "f2f1f4"
-let g:base16_gui01 = "f2f1f4"
+let g:tinted_gui01 = "f2f1f4"
 let s:gui02        = "d8d5dd"
-let g:base16_gui02 = "d8d5dd"
+let g:tinted_gui02 = "d8d5dd"
 let s:gui03        = "bfb9c6"
-let g:base16_gui03 = "bfb9c6"
+let g:tinted_gui03 = "bfb9c6"
 let s:gui04        = "a59daf"
-let g:base16_gui04 = "a59daf"
+let g:tinted_gui04 = "a59daf"
 let s:gui05        = "8b8198"
-let g:base16_gui05 = "8b8198"
+let g:tinted_gui05 = "8b8198"
 let s:gui06        = "72677e"
-let g:base16_gui06 = "72677e"
+let g:tinted_gui06 = "72677e"
 let s:gui07        = "585062"
-let g:base16_gui07 = "585062"
+let g:tinted_gui07 = "585062"
 let s:gui08        = "d57e85"
-let g:base16_gui08 = "d57e85"
+let g:tinted_gui08 = "d57e85"
 let s:gui09        = "ebb790"
-let g:base16_gui09 = "ebb790"
+let g:tinted_gui09 = "ebb790"
 let s:gui0A        = "dcb16c"
-let g:base16_gui0A = "dcb16c"
+let g:tinted_gui0A = "dcb16c"
 let s:gui0B        = "a3b367"
-let g:base16_gui0B = "a3b367"
+let g:tinted_gui0B = "a3b367"
 let s:gui0C        = "69a9a7"
-let g:base16_gui0C = "69a9a7"
+let g:tinted_gui0C = "69a9a7"
 let s:gui0D        = "7297b9"
-let g:base16_gui0D = "7297b9"
+let g:tinted_gui0D = "7297b9"
 let s:gui0E        = "bb99b4"
-let g:base16_gui0E = "bb99b4"
+let g:tinted_gui0E = "bb99b4"
 let s:gui0F        = "baa58c"
+let g:tinted_gui0F = "baa58c"
+
+" Legacy
+let g:base16_gui00 = "fbf1f2"
+let g:base16_gui01 = "f2f1f4"
+let g:base16_gui02 = "d8d5dd"
+let g:base16_gui03 = "bfb9c6"
+let g:base16_gui04 = "a59daf"
+let g:base16_gui05 = "8b8198"
+let g:base16_gui06 = "72677e"
+let g:base16_gui07 = "585062"
+let g:base16_gui08 = "d57e85"
+let g:base16_gui09 = "ebb790"
+let g:base16_gui0A = "dcb16c"
+let g:base16_gui0B = "a3b367"
+let g:base16_gui0C = "69a9a7"
+let g:base16_gui0D = "7297b9"
+let g:base16_gui0E = "bb99b4"
 let g:base16_gui0F = "baa58c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#585062",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Cupertino
 " Scheme author: Defman21
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-cupertino.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/cupertino.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/cupertino.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "c0c0c0"
-let g:base16_gui01 = "c0c0c0"
+let g:tinted_gui01 = "c0c0c0"
 let s:gui02        = "c0c0c0"
-let g:base16_gui02 = "c0c0c0"
+let g:tinted_gui02 = "c0c0c0"
 let s:gui03        = "808080"
-let g:base16_gui03 = "808080"
+let g:tinted_gui03 = "808080"
 let s:gui04        = "808080"
-let g:base16_gui04 = "808080"
+let g:tinted_gui04 = "808080"
 let s:gui05        = "404040"
-let g:base16_gui05 = "404040"
+let g:tinted_gui05 = "404040"
 let s:gui06        = "404040"
-let g:base16_gui06 = "404040"
+let g:tinted_gui06 = "404040"
 let s:gui07        = "5e5e5e"
-let g:base16_gui07 = "5e5e5e"
+let g:tinted_gui07 = "5e5e5e"
 let s:gui08        = "c41a15"
-let g:base16_gui08 = "c41a15"
+let g:tinted_gui08 = "c41a15"
 let s:gui09        = "eb8500"
-let g:base16_gui09 = "eb8500"
+let g:tinted_gui09 = "eb8500"
 let s:gui0A        = "826b28"
-let g:base16_gui0A = "826b28"
+let g:tinted_gui0A = "826b28"
 let s:gui0B        = "007400"
-let g:base16_gui0B = "007400"
+let g:tinted_gui0B = "007400"
 let s:gui0C        = "318495"
-let g:base16_gui0C = "318495"
+let g:tinted_gui0C = "318495"
 let s:gui0D        = "0000ff"
-let g:base16_gui0D = "0000ff"
+let g:tinted_gui0D = "0000ff"
 let s:gui0E        = "a90d91"
-let g:base16_gui0E = "a90d91"
+let g:tinted_gui0E = "a90d91"
 let s:gui0F        = "826b28"
+let g:tinted_gui0F = "826b28"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "c0c0c0"
+let g:base16_gui02 = "c0c0c0"
+let g:base16_gui03 = "808080"
+let g:base16_gui04 = "808080"
+let g:base16_gui05 = "404040"
+let g:base16_gui06 = "404040"
+let g:base16_gui07 = "5e5e5e"
+let g:base16_gui08 = "c41a15"
+let g:base16_gui09 = "eb8500"
+let g:base16_gui0A = "826b28"
+let g:base16_gui0B = "007400"
+let g:base16_gui0C = "318495"
+let g:base16_gui0D = "0000ff"
+let g:base16_gui0E = "a90d91"
 let g:base16_gui0F = "826b28"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#5e5e5e",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-da-one-black.vim
+++ b/colors/base16-da-one-black.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Da One Black
 " Scheme author: NNB (https://github.com/NNBnh)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-da-one-black.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/da-one-black.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/da-one-black.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "282828"
-let g:base16_gui01 = "282828"
+let g:tinted_gui01 = "282828"
 let s:gui02        = "585858"
-let g:base16_gui02 = "585858"
+let g:tinted_gui02 = "585858"
 let s:gui03        = "888888"
-let g:base16_gui03 = "888888"
+let g:tinted_gui03 = "888888"
 let s:gui04        = "c8c8c8"
-let g:base16_gui04 = "c8c8c8"
+let g:tinted_gui04 = "c8c8c8"
 let s:gui05        = "ffffff"
-let g:base16_gui05 = "ffffff"
+let g:tinted_gui05 = "ffffff"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "fa7883"
-let g:base16_gui08 = "fa7883"
+let g:tinted_gui08 = "fa7883"
 let s:gui09        = "ffc387"
-let g:base16_gui09 = "ffc387"
+let g:tinted_gui09 = "ffc387"
 let s:gui0A        = "ff9470"
-let g:base16_gui0A = "ff9470"
+let g:tinted_gui0A = "ff9470"
 let s:gui0B        = "98c379"
-let g:base16_gui0B = "98c379"
+let g:tinted_gui0B = "98c379"
 let s:gui0C        = "8af5ff"
-let g:base16_gui0C = "8af5ff"
+let g:tinted_gui0C = "8af5ff"
 let s:gui0D        = "6bb8ff"
-let g:base16_gui0D = "6bb8ff"
+let g:tinted_gui0D = "6bb8ff"
 let s:gui0E        = "e799ff"
-let g:base16_gui0E = "e799ff"
+let g:tinted_gui0E = "e799ff"
 let s:gui0F        = "b3684f"
+let g:tinted_gui0F = "b3684f"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "282828"
+let g:base16_gui02 = "585858"
+let g:base16_gui03 = "888888"
+let g:base16_gui04 = "c8c8c8"
+let g:base16_gui05 = "ffffff"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "fa7883"
+let g:base16_gui09 = "ffc387"
+let g:base16_gui0A = "ff9470"
+let g:base16_gui0B = "98c379"
+let g:base16_gui0C = "8af5ff"
+let g:base16_gui0D = "6bb8ff"
+let g:base16_gui0E = "e799ff"
 let g:base16_gui0F = "b3684f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-da-one-gray.vim
+++ b/colors/base16-da-one-gray.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Da One Gray
 " Scheme author: NNB (https://github.com/NNBnh)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-da-one-gray.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/da-one-gray.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/da-one-gray.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "181818"
-let g:base16_gui00 = "181818"
+let g:tinted_gui00 = "181818"
 let s:gui01        = "282828"
-let g:base16_gui01 = "282828"
+let g:tinted_gui01 = "282828"
 let s:gui02        = "585858"
-let g:base16_gui02 = "585858"
+let g:tinted_gui02 = "585858"
 let s:gui03        = "888888"
-let g:base16_gui03 = "888888"
+let g:tinted_gui03 = "888888"
 let s:gui04        = "c8c8c8"
-let g:base16_gui04 = "c8c8c8"
+let g:tinted_gui04 = "c8c8c8"
 let s:gui05        = "ffffff"
-let g:base16_gui05 = "ffffff"
+let g:tinted_gui05 = "ffffff"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "fa7883"
-let g:base16_gui08 = "fa7883"
+let g:tinted_gui08 = "fa7883"
 let s:gui09        = "ffc387"
-let g:base16_gui09 = "ffc387"
+let g:tinted_gui09 = "ffc387"
 let s:gui0A        = "ff9470"
-let g:base16_gui0A = "ff9470"
+let g:tinted_gui0A = "ff9470"
 let s:gui0B        = "98c379"
-let g:base16_gui0B = "98c379"
+let g:tinted_gui0B = "98c379"
 let s:gui0C        = "8af5ff"
-let g:base16_gui0C = "8af5ff"
+let g:tinted_gui0C = "8af5ff"
 let s:gui0D        = "6bb8ff"
-let g:base16_gui0D = "6bb8ff"
+let g:tinted_gui0D = "6bb8ff"
 let s:gui0E        = "e799ff"
-let g:base16_gui0E = "e799ff"
+let g:tinted_gui0E = "e799ff"
 let s:gui0F        = "b3684f"
+let g:tinted_gui0F = "b3684f"
+
+" Legacy
+let g:base16_gui00 = "181818"
+let g:base16_gui01 = "282828"
+let g:base16_gui02 = "585858"
+let g:base16_gui03 = "888888"
+let g:base16_gui04 = "c8c8c8"
+let g:base16_gui05 = "ffffff"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "fa7883"
+let g:base16_gui09 = "ffc387"
+let g:base16_gui0A = "ff9470"
+let g:base16_gui0B = "98c379"
+let g:base16_gui0C = "8af5ff"
+let g:base16_gui0D = "6bb8ff"
+let g:base16_gui0E = "e799ff"
 let g:base16_gui0F = "b3684f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-da-one-ocean.vim
+++ b/colors/base16-da-one-ocean.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Da One Ocean
 " Scheme author: NNB (https://github.com/NNBnh)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-da-one-ocean.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/da-one-ocean.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/da-one-ocean.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171726"
-let g:base16_gui00 = "171726"
+let g:tinted_gui00 = "171726"
 let s:gui01        = "22273d"
-let g:base16_gui01 = "22273d"
+let g:tinted_gui01 = "22273d"
 let s:gui02        = "525866"
-let g:base16_gui02 = "525866"
+let g:tinted_gui02 = "525866"
 let s:gui03        = "878d96"
-let g:base16_gui03 = "878d96"
+let g:tinted_gui03 = "878d96"
 let s:gui04        = "c8c8c8"
-let g:base16_gui04 = "c8c8c8"
+let g:tinted_gui04 = "c8c8c8"
 let s:gui05        = "ffffff"
-let g:base16_gui05 = "ffffff"
+let g:tinted_gui05 = "ffffff"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "fa7883"
-let g:base16_gui08 = "fa7883"
+let g:tinted_gui08 = "fa7883"
 let s:gui09        = "ffc387"
-let g:base16_gui09 = "ffc387"
+let g:tinted_gui09 = "ffc387"
 let s:gui0A        = "ff9470"
-let g:base16_gui0A = "ff9470"
+let g:tinted_gui0A = "ff9470"
 let s:gui0B        = "98c379"
-let g:base16_gui0B = "98c379"
+let g:tinted_gui0B = "98c379"
 let s:gui0C        = "8af5ff"
-let g:base16_gui0C = "8af5ff"
+let g:tinted_gui0C = "8af5ff"
 let s:gui0D        = "6bb8ff"
-let g:base16_gui0D = "6bb8ff"
+let g:tinted_gui0D = "6bb8ff"
 let s:gui0E        = "e799ff"
-let g:base16_gui0E = "e799ff"
+let g:tinted_gui0E = "e799ff"
 let s:gui0F        = "b3684f"
+let g:tinted_gui0F = "b3684f"
+
+" Legacy
+let g:base16_gui00 = "171726"
+let g:base16_gui01 = "22273d"
+let g:base16_gui02 = "525866"
+let g:base16_gui03 = "878d96"
+let g:base16_gui04 = "c8c8c8"
+let g:base16_gui05 = "ffffff"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "fa7883"
+let g:base16_gui09 = "ffc387"
+let g:base16_gui0A = "ff9470"
+let g:base16_gui0B = "98c379"
+let g:base16_gui0C = "8af5ff"
+let g:base16_gui0D = "6bb8ff"
+let g:base16_gui0E = "e799ff"
 let g:base16_gui0F = "b3684f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-da-one-paper.vim
+++ b/colors/base16-da-one-paper.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Da One Paper
 " Scheme author: NNB (https://github.com/NNBnh)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-da-one-paper.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/da-one-paper.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/da-one-paper.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "faf0dc"
-let g:base16_gui00 = "faf0dc"
+let g:tinted_gui00 = "faf0dc"
 let s:gui01        = "c8c8c8"
-let g:base16_gui01 = "c8c8c8"
+let g:tinted_gui01 = "c8c8c8"
 let s:gui02        = "888888"
-let g:base16_gui02 = "888888"
+let g:tinted_gui02 = "888888"
 let s:gui03        = "585858"
-let g:base16_gui03 = "585858"
+let g:tinted_gui03 = "585858"
 let s:gui04        = "282828"
-let g:base16_gui04 = "282828"
+let g:tinted_gui04 = "282828"
 let s:gui05        = "181818"
-let g:base16_gui05 = "181818"
+let g:tinted_gui05 = "181818"
 let s:gui06        = "000000"
-let g:base16_gui06 = "000000"
+let g:tinted_gui06 = "000000"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "de5d6e"
-let g:base16_gui08 = "de5d6e"
+let g:tinted_gui08 = "de5d6e"
 let s:gui09        = "ff9470"
-let g:base16_gui09 = "ff9470"
+let g:tinted_gui09 = "ff9470"
 let s:gui0A        = "b3684f"
-let g:base16_gui0A = "b3684f"
+let g:tinted_gui0A = "b3684f"
 let s:gui0B        = "76a85d"
-let g:base16_gui0B = "76a85d"
+let g:tinted_gui0B = "76a85d"
 let s:gui0C        = "64b5a7"
-let g:base16_gui0C = "64b5a7"
+let g:tinted_gui0C = "64b5a7"
 let s:gui0D        = "5890f8"
-let g:base16_gui0D = "5890f8"
+let g:tinted_gui0D = "5890f8"
 let s:gui0E        = "c173d1"
-let g:base16_gui0E = "c173d1"
+let g:tinted_gui0E = "c173d1"
 let s:gui0F        = "b3684f"
+let g:tinted_gui0F = "b3684f"
+
+" Legacy
+let g:base16_gui00 = "faf0dc"
+let g:base16_gui01 = "c8c8c8"
+let g:base16_gui02 = "888888"
+let g:base16_gui03 = "585858"
+let g:base16_gui04 = "282828"
+let g:base16_gui05 = "181818"
+let g:base16_gui06 = "000000"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "de5d6e"
+let g:base16_gui09 = "ff9470"
+let g:base16_gui0A = "b3684f"
+let g:base16_gui0B = "76a85d"
+let g:base16_gui0C = "64b5a7"
+let g:base16_gui0D = "5890f8"
+let g:base16_gui0E = "c173d1"
 let g:base16_gui0F = "b3684f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-da-one-sea.vim
+++ b/colors/base16-da-one-sea.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Da One Sea
 " Scheme author: NNB (https://github.com/NNBnh)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-da-one-sea.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/da-one-sea.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/da-one-sea.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "22273d"
-let g:base16_gui00 = "22273d"
+let g:tinted_gui00 = "22273d"
 let s:gui01        = "374059"
-let g:base16_gui01 = "374059"
+let g:tinted_gui01 = "374059"
 let s:gui02        = "525866"
-let g:base16_gui02 = "525866"
+let g:tinted_gui02 = "525866"
 let s:gui03        = "878d96"
-let g:base16_gui03 = "878d96"
+let g:tinted_gui03 = "878d96"
 let s:gui04        = "c8c8c8"
-let g:base16_gui04 = "c8c8c8"
+let g:tinted_gui04 = "c8c8c8"
 let s:gui05        = "ffffff"
-let g:base16_gui05 = "ffffff"
+let g:tinted_gui05 = "ffffff"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "fa7883"
-let g:base16_gui08 = "fa7883"
+let g:tinted_gui08 = "fa7883"
 let s:gui09        = "ffc387"
-let g:base16_gui09 = "ffc387"
+let g:tinted_gui09 = "ffc387"
 let s:gui0A        = "ff9470"
-let g:base16_gui0A = "ff9470"
+let g:tinted_gui0A = "ff9470"
 let s:gui0B        = "98c379"
-let g:base16_gui0B = "98c379"
+let g:tinted_gui0B = "98c379"
 let s:gui0C        = "8af5ff"
-let g:base16_gui0C = "8af5ff"
+let g:tinted_gui0C = "8af5ff"
 let s:gui0D        = "6bb8ff"
-let g:base16_gui0D = "6bb8ff"
+let g:tinted_gui0D = "6bb8ff"
 let s:gui0E        = "e799ff"
-let g:base16_gui0E = "e799ff"
+let g:tinted_gui0E = "e799ff"
 let s:gui0F        = "b3684f"
+let g:tinted_gui0F = "b3684f"
+
+" Legacy
+let g:base16_gui00 = "22273d"
+let g:base16_gui01 = "374059"
+let g:base16_gui02 = "525866"
+let g:base16_gui03 = "878d96"
+let g:base16_gui04 = "c8c8c8"
+let g:base16_gui05 = "ffffff"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "fa7883"
+let g:base16_gui09 = "ffc387"
+let g:base16_gui0A = "ff9470"
+let g:base16_gui0B = "98c379"
+let g:base16_gui0C = "8af5ff"
+let g:base16_gui0D = "6bb8ff"
+let g:base16_gui0E = "e799ff"
 let g:base16_gui0F = "b3684f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-da-one-white.vim
+++ b/colors/base16-da-one-white.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Da One White
 " Scheme author: NNB (https://github.com/NNBnh)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-da-one-white.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/da-one-white.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/da-one-white.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "c8c8c8"
-let g:base16_gui01 = "c8c8c8"
+let g:tinted_gui01 = "c8c8c8"
 let s:gui02        = "888888"
-let g:base16_gui02 = "888888"
+let g:tinted_gui02 = "888888"
 let s:gui03        = "585858"
-let g:base16_gui03 = "585858"
+let g:tinted_gui03 = "585858"
 let s:gui04        = "282828"
-let g:base16_gui04 = "282828"
+let g:tinted_gui04 = "282828"
 let s:gui05        = "181818"
-let g:base16_gui05 = "181818"
+let g:tinted_gui05 = "181818"
 let s:gui06        = "000000"
-let g:base16_gui06 = "000000"
+let g:tinted_gui06 = "000000"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "de5d6e"
-let g:base16_gui08 = "de5d6e"
+let g:tinted_gui08 = "de5d6e"
 let s:gui09        = "ff9470"
-let g:base16_gui09 = "ff9470"
+let g:tinted_gui09 = "ff9470"
 let s:gui0A        = "b3684f"
-let g:base16_gui0A = "b3684f"
+let g:tinted_gui0A = "b3684f"
 let s:gui0B        = "76a85d"
-let g:base16_gui0B = "76a85d"
+let g:tinted_gui0B = "76a85d"
 let s:gui0C        = "64b5a7"
-let g:base16_gui0C = "64b5a7"
+let g:tinted_gui0C = "64b5a7"
 let s:gui0D        = "5890f8"
-let g:base16_gui0D = "5890f8"
+let g:tinted_gui0D = "5890f8"
 let s:gui0E        = "c173d1"
-let g:base16_gui0E = "c173d1"
+let g:tinted_gui0E = "c173d1"
 let s:gui0F        = "b3684f"
+let g:tinted_gui0F = "b3684f"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "c8c8c8"
+let g:base16_gui02 = "888888"
+let g:base16_gui03 = "585858"
+let g:base16_gui04 = "282828"
+let g:base16_gui05 = "181818"
+let g:base16_gui06 = "000000"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "de5d6e"
+let g:base16_gui09 = "ff9470"
+let g:base16_gui0A = "b3684f"
+let g:base16_gui0B = "76a85d"
+let g:base16_gui0C = "64b5a7"
+let g:base16_gui0D = "5890f8"
+let g:base16_gui0E = "c173d1"
 let g:base16_gui0F = "b3684f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-danqing-light.vim
+++ b/colors/base16-danqing-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: DanQing Light
 " Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-danqing-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/danqing-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/danqing-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fcfefd"
-let g:base16_gui00 = "fcfefd"
+let g:tinted_gui00 = "fcfefd"
 let s:gui01        = "ecf6f2"
-let g:base16_gui01 = "ecf6f2"
+let g:tinted_gui01 = "ecf6f2"
 let s:gui02        = "e0f0ef"
-let g:base16_gui02 = "e0f0ef"
+let g:tinted_gui02 = "e0f0ef"
 let s:gui03        = "cad8d2"
-let g:base16_gui03 = "cad8d2"
+let g:tinted_gui03 = "cad8d2"
 let s:gui04        = "9da8a3"
-let g:base16_gui04 = "9da8a3"
+let g:tinted_gui04 = "9da8a3"
 let s:gui05        = "5a605d"
-let g:base16_gui05 = "5a605d"
+let g:tinted_gui05 = "5a605d"
 let s:gui06        = "434846"
-let g:base16_gui06 = "434846"
+let g:tinted_gui06 = "434846"
 let s:gui07        = "2d302f"
-let g:base16_gui07 = "2d302f"
+let g:tinted_gui07 = "2d302f"
 let s:gui08        = "f9906f"
-let g:base16_gui08 = "f9906f"
+let g:tinted_gui08 = "f9906f"
 let s:gui09        = "b38a61"
-let g:base16_gui09 = "b38a61"
+let g:tinted_gui09 = "b38a61"
 let s:gui0A        = "f0c239"
-let g:base16_gui0A = "f0c239"
+let g:tinted_gui0A = "f0c239"
 let s:gui0B        = "8ab361"
-let g:base16_gui0B = "8ab361"
+let g:tinted_gui0B = "8ab361"
 let s:gui0C        = "30dff3"
-let g:base16_gui0C = "30dff3"
+let g:tinted_gui0C = "30dff3"
 let s:gui0D        = "b0a4e3"
-let g:base16_gui0D = "b0a4e3"
+let g:tinted_gui0D = "b0a4e3"
 let s:gui0E        = "cca4e3"
-let g:base16_gui0E = "cca4e3"
+let g:tinted_gui0E = "cca4e3"
 let s:gui0F        = "ca6924"
+let g:tinted_gui0F = "ca6924"
+
+" Legacy
+let g:base16_gui00 = "fcfefd"
+let g:base16_gui01 = "ecf6f2"
+let g:base16_gui02 = "e0f0ef"
+let g:base16_gui03 = "cad8d2"
+let g:base16_gui04 = "9da8a3"
+let g:base16_gui05 = "5a605d"
+let g:base16_gui06 = "434846"
+let g:base16_gui07 = "2d302f"
+let g:base16_gui08 = "f9906f"
+let g:base16_gui09 = "b38a61"
+let g:base16_gui0A = "f0c239"
+let g:base16_gui0B = "8ab361"
+let g:base16_gui0C = "30dff3"
+let g:base16_gui0D = "b0a4e3"
+let g:base16_gui0E = "cca4e3"
 let g:base16_gui0F = "ca6924"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#2d302f",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-danqing.vim
+++ b/colors/base16-danqing.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: DanQing
 " Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-danqing.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/danqing.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/danqing.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2d302f"
-let g:base16_gui00 = "2d302f"
+let g:tinted_gui00 = "2d302f"
 let s:gui01        = "434846"
-let g:base16_gui01 = "434846"
+let g:tinted_gui01 = "434846"
 let s:gui02        = "5a605d"
-let g:base16_gui02 = "5a605d"
+let g:tinted_gui02 = "5a605d"
 let s:gui03        = "9da8a3"
-let g:base16_gui03 = "9da8a3"
+let g:tinted_gui03 = "9da8a3"
 let s:gui04        = "cad8d2"
-let g:base16_gui04 = "cad8d2"
+let g:tinted_gui04 = "cad8d2"
 let s:gui05        = "e0f0ef"
-let g:base16_gui05 = "e0f0ef"
+let g:tinted_gui05 = "e0f0ef"
 let s:gui06        = "ecf6f2"
-let g:base16_gui06 = "ecf6f2"
+let g:tinted_gui06 = "ecf6f2"
 let s:gui07        = "fcfefd"
-let g:base16_gui07 = "fcfefd"
+let g:tinted_gui07 = "fcfefd"
 let s:gui08        = "f9906f"
-let g:base16_gui08 = "f9906f"
+let g:tinted_gui08 = "f9906f"
 let s:gui09        = "b38a61"
-let g:base16_gui09 = "b38a61"
+let g:tinted_gui09 = "b38a61"
 let s:gui0A        = "f0c239"
-let g:base16_gui0A = "f0c239"
+let g:tinted_gui0A = "f0c239"
 let s:gui0B        = "8ab361"
-let g:base16_gui0B = "8ab361"
+let g:tinted_gui0B = "8ab361"
 let s:gui0C        = "30dff3"
-let g:base16_gui0C = "30dff3"
+let g:tinted_gui0C = "30dff3"
 let s:gui0D        = "b0a4e3"
-let g:base16_gui0D = "b0a4e3"
+let g:tinted_gui0D = "b0a4e3"
 let s:gui0E        = "cca4e3"
-let g:base16_gui0E = "cca4e3"
+let g:tinted_gui0E = "cca4e3"
 let s:gui0F        = "ca6924"
+let g:tinted_gui0F = "ca6924"
+
+" Legacy
+let g:base16_gui00 = "2d302f"
+let g:base16_gui01 = "434846"
+let g:base16_gui02 = "5a605d"
+let g:base16_gui03 = "9da8a3"
+let g:base16_gui04 = "cad8d2"
+let g:base16_gui05 = "e0f0ef"
+let g:base16_gui06 = "ecf6f2"
+let g:base16_gui07 = "fcfefd"
+let g:base16_gui08 = "f9906f"
+let g:base16_gui09 = "b38a61"
+let g:base16_gui0A = "f0c239"
+let g:base16_gui0B = "8ab361"
+let g:base16_gui0C = "30dff3"
+let g:base16_gui0D = "b0a4e3"
+let g:base16_gui0E = "cca4e3"
 let g:base16_gui0F = "ca6924"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fcfefd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-darcula.vim
+++ b/colors/base16-darcula.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Darcula
 " Scheme author: jetbrains
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-darcula.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/darcula.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/darcula.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2b2b2b"
-let g:base16_gui00 = "2b2b2b"
+let g:tinted_gui00 = "2b2b2b"
 let s:gui01        = "323232"
-let g:base16_gui01 = "323232"
+let g:tinted_gui01 = "323232"
 let s:gui02        = "323232"
-let g:base16_gui02 = "323232"
+let g:tinted_gui02 = "323232"
 let s:gui03        = "606366"
-let g:base16_gui03 = "606366"
+let g:tinted_gui03 = "606366"
 let s:gui04        = "a4a3a3"
-let g:base16_gui04 = "a4a3a3"
+let g:tinted_gui04 = "a4a3a3"
 let s:gui05        = "a9b7c6"
-let g:base16_gui05 = "a9b7c6"
+let g:tinted_gui05 = "a9b7c6"
 let s:gui06        = "ffc66d"
-let g:base16_gui06 = "ffc66d"
+let g:tinted_gui06 = "ffc66d"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "4eade5"
-let g:base16_gui08 = "4eade5"
+let g:tinted_gui08 = "4eade5"
 let s:gui09        = "689757"
-let g:base16_gui09 = "689757"
+let g:tinted_gui09 = "689757"
 let s:gui0A        = "bbb529"
-let g:base16_gui0A = "bbb529"
+let g:tinted_gui0A = "bbb529"
 let s:gui0B        = "6a8759"
-let g:base16_gui0B = "6a8759"
+let g:tinted_gui0B = "6a8759"
 let s:gui0C        = "629755"
-let g:base16_gui0C = "629755"
+let g:tinted_gui0C = "629755"
 let s:gui0D        = "9876aa"
-let g:base16_gui0D = "9876aa"
+let g:tinted_gui0D = "9876aa"
 let s:gui0E        = "cc7832"
-let g:base16_gui0E = "cc7832"
+let g:tinted_gui0E = "cc7832"
 let s:gui0F        = "808080"
+let g:tinted_gui0F = "808080"
+
+" Legacy
+let g:base16_gui00 = "2b2b2b"
+let g:base16_gui01 = "323232"
+let g:base16_gui02 = "323232"
+let g:base16_gui03 = "606366"
+let g:base16_gui04 = "a4a3a3"
+let g:base16_gui05 = "a9b7c6"
+let g:base16_gui06 = "ffc66d"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "4eade5"
+let g:base16_gui09 = "689757"
+let g:base16_gui0A = "bbb529"
+let g:base16_gui0B = "6a8759"
+let g:base16_gui0C = "629755"
+let g:base16_gui0D = "9876aa"
+let g:base16_gui0E = "cc7832"
 let g:base16_gui0F = "808080"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: darkmoss
 " Scheme author: Gabriel Avanzi (https://github.com/avanzzzi)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-darkmoss.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/darkmoss.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/darkmoss.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171e1f"
-let g:base16_gui00 = "171e1f"
+let g:tinted_gui00 = "171e1f"
 let s:gui01        = "252c2d"
-let g:base16_gui01 = "252c2d"
+let g:tinted_gui01 = "252c2d"
 let s:gui02        = "373c3d"
-let g:base16_gui02 = "373c3d"
+let g:tinted_gui02 = "373c3d"
 let s:gui03        = "555e5f"
-let g:base16_gui03 = "555e5f"
+let g:tinted_gui03 = "555e5f"
 let s:gui04        = "818f80"
-let g:base16_gui04 = "818f80"
+let g:tinted_gui04 = "818f80"
 let s:gui05        = "c7c7a5"
-let g:base16_gui05 = "c7c7a5"
+let g:tinted_gui05 = "c7c7a5"
 let s:gui06        = "e3e3c8"
-let g:base16_gui06 = "e3e3c8"
+let g:tinted_gui06 = "e3e3c8"
 let s:gui07        = "e1eaef"
-let g:base16_gui07 = "e1eaef"
+let g:tinted_gui07 = "e1eaef"
 let s:gui08        = "ff4658"
-let g:base16_gui08 = "ff4658"
+let g:tinted_gui08 = "ff4658"
 let s:gui09        = "e6db74"
-let g:base16_gui09 = "e6db74"
+let g:tinted_gui09 = "e6db74"
 let s:gui0A        = "fdb11f"
-let g:base16_gui0A = "fdb11f"
+let g:tinted_gui0A = "fdb11f"
 let s:gui0B        = "499180"
-let g:base16_gui0B = "499180"
+let g:tinted_gui0B = "499180"
 let s:gui0C        = "66d9ef"
-let g:base16_gui0C = "66d9ef"
+let g:tinted_gui0C = "66d9ef"
 let s:gui0D        = "498091"
-let g:base16_gui0D = "498091"
+let g:tinted_gui0D = "498091"
 let s:gui0E        = "9bc0c8"
-let g:base16_gui0E = "9bc0c8"
+let g:tinted_gui0E = "9bc0c8"
 let s:gui0F        = "d27b53"
+let g:tinted_gui0F = "d27b53"
+
+" Legacy
+let g:base16_gui00 = "171e1f"
+let g:base16_gui01 = "252c2d"
+let g:base16_gui02 = "373c3d"
+let g:base16_gui03 = "555e5f"
+let g:base16_gui04 = "818f80"
+let g:base16_gui05 = "c7c7a5"
+let g:base16_gui06 = "e3e3c8"
+let g:base16_gui07 = "e1eaef"
+let g:base16_gui08 = "ff4658"
+let g:base16_gui09 = "e6db74"
+let g:base16_gui0A = "fdb11f"
+let g:base16_gui0B = "499180"
+let g:base16_gui0C = "66d9ef"
+let g:base16_gui0D = "498091"
+let g:base16_gui0E = "9bc0c8"
 let g:base16_gui0F = "d27b53"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e1eaef",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Darktooth
 " Scheme author: Jason Milkins (https://github.com/jasonm23)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-darktooth.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/darktooth.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/darktooth.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1d2021"
-let g:base16_gui00 = "1d2021"
+let g:tinted_gui00 = "1d2021"
 let s:gui01        = "32302f"
-let g:base16_gui01 = "32302f"
+let g:tinted_gui01 = "32302f"
 let s:gui02        = "504945"
-let g:base16_gui02 = "504945"
+let g:tinted_gui02 = "504945"
 let s:gui03        = "665c54"
-let g:base16_gui03 = "665c54"
+let g:tinted_gui03 = "665c54"
 let s:gui04        = "928374"
-let g:base16_gui04 = "928374"
+let g:tinted_gui04 = "928374"
 let s:gui05        = "a89984"
-let g:base16_gui05 = "a89984"
+let g:tinted_gui05 = "a89984"
 let s:gui06        = "d5c4a1"
-let g:base16_gui06 = "d5c4a1"
+let g:tinted_gui06 = "d5c4a1"
 let s:gui07        = "fdf4c1"
-let g:base16_gui07 = "fdf4c1"
+let g:tinted_gui07 = "fdf4c1"
 let s:gui08        = "fb543f"
-let g:base16_gui08 = "fb543f"
+let g:tinted_gui08 = "fb543f"
 let s:gui09        = "fe8625"
-let g:base16_gui09 = "fe8625"
+let g:tinted_gui09 = "fe8625"
 let s:gui0A        = "fac03b"
-let g:base16_gui0A = "fac03b"
+let g:tinted_gui0A = "fac03b"
 let s:gui0B        = "95c085"
-let g:base16_gui0B = "95c085"
+let g:tinted_gui0B = "95c085"
 let s:gui0C        = "8ba59b"
-let g:base16_gui0C = "8ba59b"
+let g:tinted_gui0C = "8ba59b"
 let s:gui0D        = "0d6678"
-let g:base16_gui0D = "0d6678"
+let g:tinted_gui0D = "0d6678"
 let s:gui0E        = "8f4673"
-let g:base16_gui0E = "8f4673"
+let g:tinted_gui0E = "8f4673"
 let s:gui0F        = "a87322"
+let g:tinted_gui0F = "a87322"
+
+" Legacy
+let g:base16_gui00 = "1d2021"
+let g:base16_gui01 = "32302f"
+let g:base16_gui02 = "504945"
+let g:base16_gui03 = "665c54"
+let g:base16_gui04 = "928374"
+let g:base16_gui05 = "a89984"
+let g:base16_gui06 = "d5c4a1"
+let g:base16_gui07 = "fdf4c1"
+let g:base16_gui08 = "fb543f"
+let g:base16_gui09 = "fe8625"
+let g:base16_gui0A = "fac03b"
+let g:base16_gui0B = "95c085"
+let g:base16_gui0C = "8ba59b"
+let g:base16_gui0D = "0d6678"
+let g:base16_gui0E = "8f4673"
 let g:base16_gui0F = "a87322"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fdf4c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Dark Violet
 " Scheme author: ruler501 (https://github.com/ruler501/base16-darkviolet)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-darkviolet.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/darkviolet.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/darkviolet.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "231a40"
-let g:base16_gui01 = "231a40"
+let g:tinted_gui01 = "231a40"
 let s:gui02        = "432d59"
-let g:base16_gui02 = "432d59"
+let g:tinted_gui02 = "432d59"
 let s:gui03        = "593380"
-let g:base16_gui03 = "593380"
+let g:tinted_gui03 = "593380"
 let s:gui04        = "00ff00"
-let g:base16_gui04 = "00ff00"
+let g:tinted_gui04 = "00ff00"
 let s:gui05        = "b08ae6"
-let g:base16_gui05 = "b08ae6"
+let g:tinted_gui05 = "b08ae6"
 let s:gui06        = "9045e6"
-let g:base16_gui06 = "9045e6"
+let g:tinted_gui06 = "9045e6"
 let s:gui07        = "a366ff"
-let g:base16_gui07 = "a366ff"
+let g:tinted_gui07 = "a366ff"
 let s:gui08        = "a82ee6"
-let g:base16_gui08 = "a82ee6"
+let g:tinted_gui08 = "a82ee6"
 let s:gui09        = "bb66cc"
-let g:base16_gui09 = "bb66cc"
+let g:tinted_gui09 = "bb66cc"
 let s:gui0A        = "f29df2"
-let g:base16_gui0A = "f29df2"
+let g:tinted_gui0A = "f29df2"
 let s:gui0B        = "4595e6"
-let g:base16_gui0B = "4595e6"
+let g:tinted_gui0B = "4595e6"
 let s:gui0C        = "40dfff"
-let g:base16_gui0C = "40dfff"
+let g:tinted_gui0C = "40dfff"
 let s:gui0D        = "4136d9"
-let g:base16_gui0D = "4136d9"
+let g:tinted_gui0D = "4136d9"
 let s:gui0E        = "7e5ce6"
-let g:base16_gui0E = "7e5ce6"
+let g:tinted_gui0E = "7e5ce6"
 let s:gui0F        = "a886bf"
+let g:tinted_gui0F = "a886bf"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "231a40"
+let g:base16_gui02 = "432d59"
+let g:base16_gui03 = "593380"
+let g:base16_gui04 = "00ff00"
+let g:base16_gui05 = "b08ae6"
+let g:base16_gui06 = "9045e6"
+let g:base16_gui07 = "a366ff"
+let g:base16_gui08 = "a82ee6"
+let g:base16_gui09 = "bb66cc"
+let g:base16_gui0A = "f29df2"
+let g:base16_gui0B = "4595e6"
+let g:base16_gui0C = "40dfff"
+let g:base16_gui0D = "4136d9"
+let g:base16_gui0E = "7e5ce6"
 let g:base16_gui0F = "a886bf"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#a366ff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Decaf
 " Scheme author: Alex Mirrington (https://github.com/alexmirrington)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-decaf.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/decaf.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/decaf.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2d2d2d"
-let g:base16_gui00 = "2d2d2d"
+let g:tinted_gui00 = "2d2d2d"
 let s:gui01        = "393939"
-let g:base16_gui01 = "393939"
+let g:tinted_gui01 = "393939"
 let s:gui02        = "515151"
-let g:base16_gui02 = "515151"
+let g:tinted_gui02 = "515151"
 let s:gui03        = "777777"
-let g:base16_gui03 = "777777"
+let g:tinted_gui03 = "777777"
 let s:gui04        = "b4b7b4"
-let g:base16_gui04 = "b4b7b4"
+let g:tinted_gui04 = "b4b7b4"
 let s:gui05        = "cccccc"
-let g:base16_gui05 = "cccccc"
+let g:tinted_gui05 = "cccccc"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff7f7b"
-let g:base16_gui08 = "ff7f7b"
+let g:tinted_gui08 = "ff7f7b"
 let s:gui09        = "ffbf70"
-let g:base16_gui09 = "ffbf70"
+let g:tinted_gui09 = "ffbf70"
 let s:gui0A        = "ffd67c"
-let g:base16_gui0A = "ffd67c"
+let g:tinted_gui0A = "ffd67c"
 let s:gui0B        = "beda78"
-let g:base16_gui0B = "beda78"
+let g:tinted_gui0B = "beda78"
 let s:gui0C        = "bed6ff"
-let g:base16_gui0C = "bed6ff"
+let g:tinted_gui0C = "bed6ff"
 let s:gui0D        = "90bee1"
-let g:base16_gui0D = "90bee1"
+let g:tinted_gui0D = "90bee1"
 let s:gui0E        = "efb3f7"
-let g:base16_gui0E = "efb3f7"
+let g:tinted_gui0E = "efb3f7"
 let s:gui0F        = "ff93b3"
+let g:tinted_gui0F = "ff93b3"
+
+" Legacy
+let g:base16_gui00 = "2d2d2d"
+let g:base16_gui01 = "393939"
+let g:base16_gui02 = "515151"
+let g:base16_gui03 = "777777"
+let g:base16_gui04 = "b4b7b4"
+let g:base16_gui05 = "cccccc"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff7f7b"
+let g:base16_gui09 = "ffbf70"
+let g:base16_gui0A = "ffd67c"
+let g:base16_gui0B = "beda78"
+let g:base16_gui0C = "bed6ff"
+let g:base16_gui0D = "90bee1"
+let g:base16_gui0E = "efb3f7"
 let g:base16_gui0F = "ff93b3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-deep-oceanic-next.vim
+++ b/colors/base16-deep-oceanic-next.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Deep Oceanic Next
 " Scheme author: spearkkk (https://github.com/spearkkk/deep-oceanic-next)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-deep-oceanic-next.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/deep-oceanic-next.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/deep-oceanic-next.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "003b46"
-let g:base16_gui00 = "003b46"
+let g:tinted_gui00 = "003b46"
 let s:gui01        = "004f5e"
-let g:base16_gui01 = "004f5e"
+let g:tinted_gui01 = "004f5e"
 let s:gui02        = "006374"
-let g:base16_gui02 = "006374"
+let g:tinted_gui02 = "006374"
 let s:gui03        = "007a8a"
-let g:base16_gui03 = "007a8a"
+let g:tinted_gui03 = "007a8a"
 let s:gui04        = "0093a3"
-let g:base16_gui04 = "0093a3"
+let g:tinted_gui04 = "0093a3"
 let s:gui05        = "dce3e8"
-let g:base16_gui05 = "dce3e8"
+let g:tinted_gui05 = "dce3e8"
 let s:gui06        = "e6ebf0"
-let g:base16_gui06 = "e6ebf0"
+let g:tinted_gui06 = "e6ebf0"
 let s:gui07        = "f0f5f5"
-let g:base16_gui07 = "f0f5f5"
+let g:tinted_gui07 = "f0f5f5"
 let s:gui08        = "e6454b"
-let g:base16_gui08 = "e6454b"
+let g:tinted_gui08 = "e6454b"
 let s:gui09        = "ff6a4b"
-let g:base16_gui09 = "ff6a4b"
+let g:tinted_gui09 = "ff6a4b"
 let s:gui0A        = "ffcc66"
-let g:base16_gui0A = "ffcc66"
+let g:tinted_gui0A = "ffcc66"
 let s:gui0B        = "85b57a"
-let g:base16_gui0B = "85b57a"
+let g:tinted_gui0B = "85b57a"
 let s:gui0C        = "4da6a6"
-let g:base16_gui0C = "4da6a6"
+let g:tinted_gui0C = "4da6a6"
 let s:gui0D        = "3a82e6"
-let g:base16_gui0D = "3a82e6"
+let g:tinted_gui0D = "3a82e6"
 let s:gui0E        = "8c4de6"
-let g:base16_gui0E = "8c4de6"
+let g:tinted_gui0E = "8c4de6"
 let s:gui0F        = "e673a3"
+let g:tinted_gui0F = "e673a3"
+
+" Legacy
+let g:base16_gui00 = "003b46"
+let g:base16_gui01 = "004f5e"
+let g:base16_gui02 = "006374"
+let g:base16_gui03 = "007a8a"
+let g:base16_gui04 = "0093a3"
+let g:base16_gui05 = "dce3e8"
+let g:base16_gui06 = "e6ebf0"
+let g:base16_gui07 = "f0f5f5"
+let g:base16_gui08 = "e6454b"
+let g:base16_gui09 = "ff6a4b"
+let g:base16_gui0A = "ffcc66"
+let g:base16_gui0B = "85b57a"
+let g:base16_gui0C = "4da6a6"
+let g:base16_gui0D = "3a82e6"
+let g:base16_gui0E = "8c4de6"
 let g:base16_gui0F = "e673a3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f0f5f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Default Dark
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-default-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/default-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/default-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "181818"
-let g:base16_gui00 = "181818"
+let g:tinted_gui00 = "181818"
 let s:gui01        = "282828"
-let g:base16_gui01 = "282828"
+let g:tinted_gui01 = "282828"
 let s:gui02        = "383838"
-let g:base16_gui02 = "383838"
+let g:tinted_gui02 = "383838"
 let s:gui03        = "585858"
-let g:base16_gui03 = "585858"
+let g:tinted_gui03 = "585858"
 let s:gui04        = "b8b8b8"
-let g:base16_gui04 = "b8b8b8"
+let g:tinted_gui04 = "b8b8b8"
 let s:gui05        = "d8d8d8"
-let g:base16_gui05 = "d8d8d8"
+let g:tinted_gui05 = "d8d8d8"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "f8f8f8"
-let g:base16_gui07 = "f8f8f8"
+let g:tinted_gui07 = "f8f8f8"
 let s:gui08        = "ab4642"
-let g:base16_gui08 = "ab4642"
+let g:tinted_gui08 = "ab4642"
 let s:gui09        = "dc9656"
-let g:base16_gui09 = "dc9656"
+let g:tinted_gui09 = "dc9656"
 let s:gui0A        = "f7ca88"
-let g:base16_gui0A = "f7ca88"
+let g:tinted_gui0A = "f7ca88"
 let s:gui0B        = "a1b56c"
-let g:base16_gui0B = "a1b56c"
+let g:tinted_gui0B = "a1b56c"
 let s:gui0C        = "86c1b9"
-let g:base16_gui0C = "86c1b9"
+let g:tinted_gui0C = "86c1b9"
 let s:gui0D        = "7cafc2"
-let g:base16_gui0D = "7cafc2"
+let g:tinted_gui0D = "7cafc2"
 let s:gui0E        = "ba8baf"
-let g:base16_gui0E = "ba8baf"
+let g:tinted_gui0E = "ba8baf"
 let s:gui0F        = "a16946"
+let g:tinted_gui0F = "a16946"
+
+" Legacy
+let g:base16_gui00 = "181818"
+let g:base16_gui01 = "282828"
+let g:base16_gui02 = "383838"
+let g:base16_gui03 = "585858"
+let g:base16_gui04 = "b8b8b8"
+let g:base16_gui05 = "d8d8d8"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "f8f8f8"
+let g:base16_gui08 = "ab4642"
+let g:base16_gui09 = "dc9656"
+let g:base16_gui0A = "f7ca88"
+let g:base16_gui0B = "a1b56c"
+let g:base16_gui0C = "86c1b9"
+let g:base16_gui0D = "7cafc2"
+let g:base16_gui0E = "ba8baf"
 let g:base16_gui0F = "a16946"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8f8f8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Default Light
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-default-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/default-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/default-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f8f8f8"
-let g:base16_gui00 = "f8f8f8"
+let g:tinted_gui00 = "f8f8f8"
 let s:gui01        = "e8e8e8"
-let g:base16_gui01 = "e8e8e8"
+let g:tinted_gui01 = "e8e8e8"
 let s:gui02        = "d8d8d8"
-let g:base16_gui02 = "d8d8d8"
+let g:tinted_gui02 = "d8d8d8"
 let s:gui03        = "b8b8b8"
-let g:base16_gui03 = "b8b8b8"
+let g:tinted_gui03 = "b8b8b8"
 let s:gui04        = "585858"
-let g:base16_gui04 = "585858"
+let g:tinted_gui04 = "585858"
 let s:gui05        = "383838"
-let g:base16_gui05 = "383838"
+let g:tinted_gui05 = "383838"
 let s:gui06        = "282828"
-let g:base16_gui06 = "282828"
+let g:tinted_gui06 = "282828"
 let s:gui07        = "181818"
-let g:base16_gui07 = "181818"
+let g:tinted_gui07 = "181818"
 let s:gui08        = "ab4642"
-let g:base16_gui08 = "ab4642"
+let g:tinted_gui08 = "ab4642"
 let s:gui09        = "dc9656"
-let g:base16_gui09 = "dc9656"
+let g:tinted_gui09 = "dc9656"
 let s:gui0A        = "f7ca88"
-let g:base16_gui0A = "f7ca88"
+let g:tinted_gui0A = "f7ca88"
 let s:gui0B        = "a1b56c"
-let g:base16_gui0B = "a1b56c"
+let g:tinted_gui0B = "a1b56c"
 let s:gui0C        = "86c1b9"
-let g:base16_gui0C = "86c1b9"
+let g:tinted_gui0C = "86c1b9"
 let s:gui0D        = "7cafc2"
-let g:base16_gui0D = "7cafc2"
+let g:tinted_gui0D = "7cafc2"
 let s:gui0E        = "ba8baf"
-let g:base16_gui0E = "ba8baf"
+let g:tinted_gui0E = "ba8baf"
 let s:gui0F        = "a16946"
+let g:tinted_gui0F = "a16946"
+
+" Legacy
+let g:base16_gui00 = "f8f8f8"
+let g:base16_gui01 = "e8e8e8"
+let g:base16_gui02 = "d8d8d8"
+let g:base16_gui03 = "b8b8b8"
+let g:base16_gui04 = "585858"
+let g:base16_gui05 = "383838"
+let g:base16_gui06 = "282828"
+let g:base16_gui07 = "181818"
+let g:base16_gui08 = "ab4642"
+let g:base16_gui09 = "dc9656"
+let g:base16_gui0A = "f7ca88"
+let g:base16_gui0B = "a1b56c"
+let g:base16_gui0C = "86c1b9"
+let g:base16_gui0D = "7cafc2"
+let g:base16_gui0E = "ba8baf"
 let g:base16_gui0F = "a16946"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#181818",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: dirtysea
 " Scheme author: Kahlil (Kal) Hodgson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-dirtysea.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/dirtysea.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/dirtysea.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "e0e0e0"
-let g:base16_gui00 = "e0e0e0"
+let g:tinted_gui00 = "e0e0e0"
 let s:gui01        = "d0dad0"
-let g:base16_gui01 = "d0dad0"
+let g:tinted_gui01 = "d0dad0"
 let s:gui02        = "d0d0d0"
-let g:base16_gui02 = "d0d0d0"
+let g:tinted_gui02 = "d0d0d0"
 let s:gui03        = "707070"
-let g:base16_gui03 = "707070"
+let g:tinted_gui03 = "707070"
 let s:gui04        = "202020"
-let g:base16_gui04 = "202020"
+let g:tinted_gui04 = "202020"
 let s:gui05        = "000000"
-let g:base16_gui05 = "000000"
+let g:tinted_gui05 = "000000"
 let s:gui06        = "f8f8f8"
-let g:base16_gui06 = "f8f8f8"
+let g:tinted_gui06 = "f8f8f8"
 let s:gui07        = "c4d9c4"
-let g:base16_gui07 = "c4d9c4"
+let g:tinted_gui07 = "c4d9c4"
 let s:gui08        = "840000"
-let g:base16_gui08 = "840000"
+let g:tinted_gui08 = "840000"
 let s:gui09        = "006565"
-let g:base16_gui09 = "006565"
+let g:tinted_gui09 = "006565"
 let s:gui0A        = "755b00"
-let g:base16_gui0A = "755b00"
+let g:tinted_gui0A = "755b00"
 let s:gui0B        = "730073"
-let g:base16_gui0B = "730073"
+let g:tinted_gui0B = "730073"
 let s:gui0C        = "755b00"
-let g:base16_gui0C = "755b00"
+let g:tinted_gui0C = "755b00"
 let s:gui0D        = "007300"
-let g:base16_gui0D = "007300"
+let g:tinted_gui0D = "007300"
 let s:gui0E        = "000090"
-let g:base16_gui0E = "000090"
+let g:tinted_gui0E = "000090"
 let s:gui0F        = "755b00"
+let g:tinted_gui0F = "755b00"
+
+" Legacy
+let g:base16_gui00 = "e0e0e0"
+let g:base16_gui01 = "d0dad0"
+let g:base16_gui02 = "d0d0d0"
+let g:base16_gui03 = "707070"
+let g:base16_gui04 = "202020"
+let g:base16_gui05 = "000000"
+let g:base16_gui06 = "f8f8f8"
+let g:base16_gui07 = "c4d9c4"
+let g:base16_gui08 = "840000"
+let g:base16_gui09 = "006565"
+let g:base16_gui0A = "755b00"
+let g:base16_gui0B = "730073"
+let g:base16_gui0C = "755b00"
+let g:base16_gui0D = "007300"
+let g:base16_gui0E = "000090"
 let g:base16_gui0F = "755b00"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c4d9c4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Dracula
 " Scheme author: Jamy Golden (http://github.com/JamyGolden), based on Dracula Theme (http://github.com/dracula)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-dracula.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/dracula.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/dracula.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282a36"
-let g:base16_gui00 = "282a36"
+let g:tinted_gui00 = "282a36"
 let s:gui01        = "363447"
-let g:base16_gui01 = "363447"
+let g:tinted_gui01 = "363447"
 let s:gui02        = "44475a"
-let g:base16_gui02 = "44475a"
+let g:tinted_gui02 = "44475a"
 let s:gui03        = "6272a4"
-let g:base16_gui03 = "6272a4"
+let g:tinted_gui03 = "6272a4"
 let s:gui04        = "9ea8c7"
-let g:base16_gui04 = "9ea8c7"
+let g:tinted_gui04 = "9ea8c7"
 let s:gui05        = "f8f8f2"
-let g:base16_gui05 = "f8f8f2"
+let g:tinted_gui05 = "f8f8f2"
 let s:gui06        = "f0f1f4"
-let g:base16_gui06 = "f0f1f4"
+let g:tinted_gui06 = "f0f1f4"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff5555"
-let g:base16_gui08 = "ff5555"
+let g:tinted_gui08 = "ff5555"
 let s:gui09        = "ffb86c"
-let g:base16_gui09 = "ffb86c"
+let g:tinted_gui09 = "ffb86c"
 let s:gui0A        = "f1fa8c"
-let g:base16_gui0A = "f1fa8c"
+let g:tinted_gui0A = "f1fa8c"
 let s:gui0B        = "50fa7b"
-let g:base16_gui0B = "50fa7b"
+let g:tinted_gui0B = "50fa7b"
 let s:gui0C        = "8be9fd"
-let g:base16_gui0C = "8be9fd"
+let g:tinted_gui0C = "8be9fd"
 let s:gui0D        = "80bfff"
-let g:base16_gui0D = "80bfff"
+let g:tinted_gui0D = "80bfff"
 let s:gui0E        = "ff79c6"
-let g:base16_gui0E = "ff79c6"
+let g:tinted_gui0E = "ff79c6"
 let s:gui0F        = "bd93f9"
+let g:tinted_gui0F = "bd93f9"
+
+" Legacy
+let g:base16_gui00 = "282a36"
+let g:base16_gui01 = "363447"
+let g:base16_gui02 = "44475a"
+let g:base16_gui03 = "6272a4"
+let g:base16_gui04 = "9ea8c7"
+let g:base16_gui05 = "f8f8f2"
+let g:base16_gui06 = "f0f1f4"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff5555"
+let g:base16_gui09 = "ffb86c"
+let g:base16_gui0A = "f1fa8c"
+let g:base16_gui0B = "50fa7b"
+let g:base16_gui0C = "8be9fd"
+let g:base16_gui0D = "80bfff"
+let g:base16_gui0E = "ff79c6"
 let g:base16_gui0F = "bd93f9"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Edge Dark
 " Scheme author: cjayross (https://github.com/cjayross)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-edge-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/edge-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/edge-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "262729"
-let g:base16_gui00 = "262729"
+let g:tinted_gui00 = "262729"
 let s:gui01        = "88909f"
-let g:base16_gui01 = "88909f"
+let g:tinted_gui01 = "88909f"
 let s:gui02        = "b7bec9"
-let g:base16_gui02 = "b7bec9"
+let g:tinted_gui02 = "b7bec9"
 let s:gui03        = "3e4249"
-let g:base16_gui03 = "3e4249"
+let g:tinted_gui03 = "3e4249"
 let s:gui04        = "73b3e7"
-let g:base16_gui04 = "73b3e7"
+let g:tinted_gui04 = "73b3e7"
 let s:gui05        = "b7bec9"
-let g:base16_gui05 = "b7bec9"
+let g:tinted_gui05 = "b7bec9"
 let s:gui06        = "d390e7"
-let g:base16_gui06 = "d390e7"
+let g:tinted_gui06 = "d390e7"
 let s:gui07        = "3e4249"
-let g:base16_gui07 = "3e4249"
+let g:tinted_gui07 = "3e4249"
 let s:gui08        = "e77171"
-let g:base16_gui08 = "e77171"
+let g:tinted_gui08 = "e77171"
 let s:gui09        = "e77171"
-let g:base16_gui09 = "e77171"
+let g:tinted_gui09 = "e77171"
 let s:gui0A        = "dbb774"
-let g:base16_gui0A = "dbb774"
+let g:tinted_gui0A = "dbb774"
 let s:gui0B        = "a1bf78"
-let g:base16_gui0B = "a1bf78"
+let g:tinted_gui0B = "a1bf78"
 let s:gui0C        = "5ebaa5"
-let g:base16_gui0C = "5ebaa5"
+let g:tinted_gui0C = "5ebaa5"
 let s:gui0D        = "73b3e7"
-let g:base16_gui0D = "73b3e7"
+let g:tinted_gui0D = "73b3e7"
 let s:gui0E        = "d390e7"
-let g:base16_gui0E = "d390e7"
+let g:tinted_gui0E = "d390e7"
 let s:gui0F        = "5ebaa5"
+let g:tinted_gui0F = "5ebaa5"
+
+" Legacy
+let g:base16_gui00 = "262729"
+let g:base16_gui01 = "88909f"
+let g:base16_gui02 = "b7bec9"
+let g:base16_gui03 = "3e4249"
+let g:base16_gui04 = "73b3e7"
+let g:base16_gui05 = "b7bec9"
+let g:base16_gui06 = "d390e7"
+let g:base16_gui07 = "3e4249"
+let g:base16_gui08 = "e77171"
+let g:base16_gui09 = "e77171"
+let g:base16_gui0A = "dbb774"
+let g:base16_gui0B = "a1bf78"
+let g:base16_gui0C = "5ebaa5"
+let g:base16_gui0D = "73b3e7"
+let g:base16_gui0E = "d390e7"
 let g:base16_gui0F = "5ebaa5"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#3e4249",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Edge Light
 " Scheme author: cjayross (https://github.com/cjayross)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-edge-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/edge-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/edge-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fafafa"
-let g:base16_gui00 = "fafafa"
+let g:tinted_gui00 = "fafafa"
 let s:gui01        = "7c9f4b"
-let g:base16_gui01 = "7c9f4b"
+let g:tinted_gui01 = "7c9f4b"
 let s:gui02        = "d69822"
-let g:base16_gui02 = "d69822"
+let g:tinted_gui02 = "d69822"
 let s:gui03        = "5e646f"
-let g:base16_gui03 = "5e646f"
+let g:tinted_gui03 = "5e646f"
 let s:gui04        = "6587bf"
-let g:base16_gui04 = "6587bf"
+let g:tinted_gui04 = "6587bf"
 let s:gui05        = "5e646f"
-let g:base16_gui05 = "5e646f"
+let g:tinted_gui05 = "5e646f"
 let s:gui06        = "b870ce"
-let g:base16_gui06 = "b870ce"
+let g:tinted_gui06 = "b870ce"
 let s:gui07        = "5e646f"
-let g:base16_gui07 = "5e646f"
+let g:tinted_gui07 = "5e646f"
 let s:gui08        = "db7070"
-let g:base16_gui08 = "db7070"
+let g:tinted_gui08 = "db7070"
 let s:gui09        = "db7070"
-let g:base16_gui09 = "db7070"
+let g:tinted_gui09 = "db7070"
 let s:gui0A        = "d69822"
-let g:base16_gui0A = "d69822"
+let g:tinted_gui0A = "d69822"
 let s:gui0B        = "7c9f4b"
-let g:base16_gui0B = "7c9f4b"
+let g:tinted_gui0B = "7c9f4b"
 let s:gui0C        = "509c93"
-let g:base16_gui0C = "509c93"
+let g:tinted_gui0C = "509c93"
 let s:gui0D        = "6587bf"
-let g:base16_gui0D = "6587bf"
+let g:tinted_gui0D = "6587bf"
 let s:gui0E        = "b870ce"
-let g:base16_gui0E = "b870ce"
+let g:tinted_gui0E = "b870ce"
 let s:gui0F        = "509c93"
+let g:tinted_gui0F = "509c93"
+
+" Legacy
+let g:base16_gui00 = "fafafa"
+let g:base16_gui01 = "7c9f4b"
+let g:base16_gui02 = "d69822"
+let g:base16_gui03 = "5e646f"
+let g:base16_gui04 = "6587bf"
+let g:base16_gui05 = "5e646f"
+let g:base16_gui06 = "b870ce"
+let g:base16_gui07 = "5e646f"
+let g:base16_gui08 = "db7070"
+let g:base16_gui09 = "db7070"
+let g:base16_gui0A = "d69822"
+let g:base16_gui0B = "7c9f4b"
+let g:base16_gui0C = "509c93"
+let g:base16_gui0D = "6587bf"
+let g:base16_gui0E = "b870ce"
 let g:base16_gui0F = "509c93"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#5e646f",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Eighties
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-eighties.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/eighties.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/eighties.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2d2d2d"
-let g:base16_gui00 = "2d2d2d"
+let g:tinted_gui00 = "2d2d2d"
 let s:gui01        = "393939"
-let g:base16_gui01 = "393939"
+let g:tinted_gui01 = "393939"
 let s:gui02        = "515151"
-let g:base16_gui02 = "515151"
+let g:tinted_gui02 = "515151"
 let s:gui03        = "747369"
-let g:base16_gui03 = "747369"
+let g:tinted_gui03 = "747369"
 let s:gui04        = "a09f93"
-let g:base16_gui04 = "a09f93"
+let g:tinted_gui04 = "a09f93"
 let s:gui05        = "d3d0c8"
-let g:base16_gui05 = "d3d0c8"
+let g:tinted_gui05 = "d3d0c8"
 let s:gui06        = "e8e6df"
-let g:base16_gui06 = "e8e6df"
+let g:tinted_gui06 = "e8e6df"
 let s:gui07        = "f2f0ec"
-let g:base16_gui07 = "f2f0ec"
+let g:tinted_gui07 = "f2f0ec"
 let s:gui08        = "f2777a"
-let g:base16_gui08 = "f2777a"
+let g:tinted_gui08 = "f2777a"
 let s:gui09        = "f99157"
-let g:base16_gui09 = "f99157"
+let g:tinted_gui09 = "f99157"
 let s:gui0A        = "ffcc66"
-let g:base16_gui0A = "ffcc66"
+let g:tinted_gui0A = "ffcc66"
 let s:gui0B        = "99cc99"
-let g:base16_gui0B = "99cc99"
+let g:tinted_gui0B = "99cc99"
 let s:gui0C        = "66cccc"
-let g:base16_gui0C = "66cccc"
+let g:tinted_gui0C = "66cccc"
 let s:gui0D        = "6699cc"
-let g:base16_gui0D = "6699cc"
+let g:tinted_gui0D = "6699cc"
 let s:gui0E        = "cc99cc"
-let g:base16_gui0E = "cc99cc"
+let g:tinted_gui0E = "cc99cc"
 let s:gui0F        = "d27b53"
+let g:tinted_gui0F = "d27b53"
+
+" Legacy
+let g:base16_gui00 = "2d2d2d"
+let g:base16_gui01 = "393939"
+let g:base16_gui02 = "515151"
+let g:base16_gui03 = "747369"
+let g:base16_gui04 = "a09f93"
+let g:base16_gui05 = "d3d0c8"
+let g:base16_gui06 = "e8e6df"
+let g:base16_gui07 = "f2f0ec"
+let g:base16_gui08 = "f2777a"
+let g:base16_gui09 = "f99157"
+let g:base16_gui0A = "ffcc66"
+let g:base16_gui0B = "99cc99"
+let g:base16_gui0C = "66cccc"
+let g:base16_gui0D = "6699cc"
+let g:base16_gui0E = "cc99cc"
 let g:base16_gui0F = "d27b53"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f2f0ec",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-embers-light.vim
+++ b/colors/base16-embers-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Embers Light
 " Scheme author: Jannik Siebert (https://github.com/janniks)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-embers-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/embers-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/embers-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "d1d6db"
-let g:base16_gui00 = "d1d6db"
+let g:tinted_gui00 = "d1d6db"
 let s:gui01        = "aeb6be"
-let g:base16_gui01 = "aeb6be"
+let g:tinted_gui01 = "aeb6be"
 let s:gui02        = "909aa3"
-let g:base16_gui02 = "909aa3"
+let g:tinted_gui02 = "909aa3"
 let s:gui03        = "75808a"
-let g:base16_gui03 = "75808a"
+let g:tinted_gui03 = "75808a"
 let s:gui04        = "47505a"
-let g:base16_gui04 = "47505a"
+let g:tinted_gui04 = "47505a"
 let s:gui05        = "323b43"
-let g:base16_gui05 = "323b43"
+let g:tinted_gui05 = "323b43"
 let s:gui06        = "20262c"
-let g:base16_gui06 = "20262c"
+let g:tinted_gui06 = "20262c"
 let s:gui07        = "0f1316"
-let g:base16_gui07 = "0f1316"
+let g:tinted_gui07 = "0f1316"
 let s:gui08        = "576d82"
-let g:base16_gui08 = "576d82"
+let g:tinted_gui08 = "576d82"
 let s:gui09        = "578282"
-let g:base16_gui09 = "578282"
+let g:tinted_gui09 = "578282"
 let s:gui0A        = "57826d"
-let g:base16_gui0A = "57826d"
+let g:tinted_gui0A = "57826d"
 let s:gui0B        = "6d8257"
-let g:base16_gui0B = "6d8257"
+let g:tinted_gui0B = "6d8257"
 let s:gui0C        = "826d57"
-let g:base16_gui0C = "826d57"
+let g:tinted_gui0C = "826d57"
 let s:gui0D        = "82576d"
-let g:base16_gui0D = "82576d"
+let g:tinted_gui0D = "82576d"
 let s:gui0E        = "6d5782"
-let g:base16_gui0E = "6d5782"
+let g:tinted_gui0E = "6d5782"
 let s:gui0F        = "575782"
+let g:tinted_gui0F = "575782"
+
+" Legacy
+let g:base16_gui00 = "d1d6db"
+let g:base16_gui01 = "aeb6be"
+let g:base16_gui02 = "909aa3"
+let g:base16_gui03 = "75808a"
+let g:base16_gui04 = "47505a"
+let g:base16_gui05 = "323b43"
+let g:base16_gui06 = "20262c"
+let g:base16_gui07 = "0f1316"
+let g:base16_gui08 = "576d82"
+let g:base16_gui09 = "578282"
+let g:base16_gui0A = "57826d"
+let g:base16_gui0B = "6d8257"
+let g:base16_gui0C = "826d57"
+let g:base16_gui0D = "82576d"
+let g:base16_gui0E = "6d5782"
 let g:base16_gui0F = "575782"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#0f1316",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Embers
 " Scheme author: Jannik Siebert (https://github.com/janniks)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-embers.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/embers.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/embers.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "16130f"
-let g:base16_gui00 = "16130f"
+let g:tinted_gui00 = "16130f"
 let s:gui01        = "2c2620"
-let g:base16_gui01 = "2c2620"
+let g:tinted_gui01 = "2c2620"
 let s:gui02        = "433b32"
-let g:base16_gui02 = "433b32"
+let g:tinted_gui02 = "433b32"
 let s:gui03        = "5a5047"
-let g:base16_gui03 = "5a5047"
+let g:tinted_gui03 = "5a5047"
 let s:gui04        = "8a8075"
-let g:base16_gui04 = "8a8075"
+let g:tinted_gui04 = "8a8075"
 let s:gui05        = "a39a90"
-let g:base16_gui05 = "a39a90"
+let g:tinted_gui05 = "a39a90"
 let s:gui06        = "beb6ae"
-let g:base16_gui06 = "beb6ae"
+let g:tinted_gui06 = "beb6ae"
 let s:gui07        = "dbd6d1"
-let g:base16_gui07 = "dbd6d1"
+let g:tinted_gui07 = "dbd6d1"
 let s:gui08        = "826d57"
-let g:base16_gui08 = "826d57"
+let g:tinted_gui08 = "826d57"
 let s:gui09        = "828257"
-let g:base16_gui09 = "828257"
+let g:tinted_gui09 = "828257"
 let s:gui0A        = "6d8257"
-let g:base16_gui0A = "6d8257"
+let g:tinted_gui0A = "6d8257"
 let s:gui0B        = "57826d"
-let g:base16_gui0B = "57826d"
+let g:tinted_gui0B = "57826d"
 let s:gui0C        = "576d82"
-let g:base16_gui0C = "576d82"
+let g:tinted_gui0C = "576d82"
 let s:gui0D        = "6d5782"
-let g:base16_gui0D = "6d5782"
+let g:tinted_gui0D = "6d5782"
 let s:gui0E        = "82576d"
-let g:base16_gui0E = "82576d"
+let g:tinted_gui0E = "82576d"
 let s:gui0F        = "825757"
+let g:tinted_gui0F = "825757"
+
+" Legacy
+let g:base16_gui00 = "16130f"
+let g:base16_gui01 = "2c2620"
+let g:base16_gui02 = "433b32"
+let g:base16_gui03 = "5a5047"
+let g:base16_gui04 = "8a8075"
+let g:base16_gui05 = "a39a90"
+let g:base16_gui06 = "beb6ae"
+let g:base16_gui07 = "dbd6d1"
+let g:base16_gui08 = "826d57"
+let g:base16_gui09 = "828257"
+let g:base16_gui0A = "6d8257"
+let g:base16_gui0B = "57826d"
+let g:base16_gui0C = "576d82"
+let g:base16_gui0D = "6d5782"
+let g:base16_gui0E = "82576d"
 let g:base16_gui0F = "825757"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#dbd6d1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-emil.vim
+++ b/colors/base16-emil.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: emil
 " Scheme author: limelier
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-emil.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/emil.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/emil.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "efefef"
-let g:base16_gui00 = "efefef"
+let g:tinted_gui00 = "efefef"
 let s:gui01        = "bebed2"
-let g:base16_gui01 = "bebed2"
+let g:tinted_gui01 = "bebed2"
 let s:gui02        = "9e9eaf"
-let g:base16_gui02 = "9e9eaf"
+let g:tinted_gui02 = "9e9eaf"
 let s:gui03        = "7c7c98"
-let g:base16_gui03 = "7c7c98"
+let g:tinted_gui03 = "7c7c98"
 let s:gui04        = "505063"
-let g:base16_gui04 = "505063"
+let g:tinted_gui04 = "505063"
 let s:gui05        = "313145"
-let g:base16_gui05 = "313145"
+let g:tinted_gui05 = "313145"
 let s:gui06        = "22223a"
-let g:base16_gui06 = "22223a"
+let g:tinted_gui06 = "22223a"
 let s:gui07        = "1a1a2f"
-let g:base16_gui07 = "1a1a2f"
+let g:tinted_gui07 = "1a1a2f"
 let s:gui08        = "f43979"
-let g:base16_gui08 = "f43979"
+let g:tinted_gui08 = "f43979"
 let s:gui09        = "d22a8b"
-let g:base16_gui09 = "d22a8b"
+let g:tinted_gui09 = "d22a8b"
 let s:gui0A        = "ff669b"
-let g:base16_gui0A = "ff669b"
+let g:tinted_gui0A = "ff669b"
 let s:gui0B        = "0073a8"
-let g:base16_gui0B = "0073a8"
+let g:tinted_gui0B = "0073a8"
 let s:gui0C        = "2155d6"
-let g:base16_gui0C = "2155d6"
+let g:tinted_gui0C = "2155d6"
 let s:gui0D        = "471397"
-let g:base16_gui0D = "471397"
+let g:tinted_gui0D = "471397"
 let s:gui0E        = "6916b6"
-let g:base16_gui0E = "6916b6"
+let g:tinted_gui0E = "6916b6"
 let s:gui0F        = "8d17a5"
+let g:tinted_gui0F = "8d17a5"
+
+" Legacy
+let g:base16_gui00 = "efefef"
+let g:base16_gui01 = "bebed2"
+let g:base16_gui02 = "9e9eaf"
+let g:base16_gui03 = "7c7c98"
+let g:base16_gui04 = "505063"
+let g:base16_gui05 = "313145"
+let g:base16_gui06 = "22223a"
+let g:base16_gui07 = "1a1a2f"
+let g:base16_gui08 = "f43979"
+let g:base16_gui09 = "d22a8b"
+let g:base16_gui0A = "ff669b"
+let g:base16_gui0B = "0073a8"
+let g:base16_gui0C = "2155d6"
+let g:base16_gui0D = "471397"
+let g:base16_gui0E = "6916b6"
 let g:base16_gui0F = "8d17a5"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1a1a2f",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Equilibrium Dark
 " Scheme author: Carlo Abelli
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-equilibrium-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/equilibrium-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/equilibrium-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0c1118"
-let g:base16_gui00 = "0c1118"
+let g:tinted_gui00 = "0c1118"
 let s:gui01        = "181c22"
-let g:base16_gui01 = "181c22"
+let g:tinted_gui01 = "181c22"
 let s:gui02        = "22262d"
-let g:base16_gui02 = "22262d"
+let g:tinted_gui02 = "22262d"
 let s:gui03        = "7b776e"
-let g:base16_gui03 = "7b776e"
+let g:tinted_gui03 = "7b776e"
 let s:gui04        = "949088"
-let g:base16_gui04 = "949088"
+let g:tinted_gui04 = "949088"
 let s:gui05        = "afaba2"
-let g:base16_gui05 = "afaba2"
+let g:tinted_gui05 = "afaba2"
 let s:gui06        = "cac6bd"
-let g:base16_gui06 = "cac6bd"
+let g:tinted_gui06 = "cac6bd"
 let s:gui07        = "e7e2d9"
-let g:base16_gui07 = "e7e2d9"
+let g:tinted_gui07 = "e7e2d9"
 let s:gui08        = "f04339"
-let g:base16_gui08 = "f04339"
+let g:tinted_gui08 = "f04339"
 let s:gui09        = "df5923"
-let g:base16_gui09 = "df5923"
+let g:tinted_gui09 = "df5923"
 let s:gui0A        = "bb8801"
-let g:base16_gui0A = "bb8801"
+let g:tinted_gui0A = "bb8801"
 let s:gui0B        = "7f8b00"
-let g:base16_gui0B = "7f8b00"
+let g:tinted_gui0B = "7f8b00"
 let s:gui0C        = "00948b"
-let g:base16_gui0C = "00948b"
+let g:tinted_gui0C = "00948b"
 let s:gui0D        = "008dd1"
-let g:base16_gui0D = "008dd1"
+let g:tinted_gui0D = "008dd1"
 let s:gui0E        = "6a7fd2"
-let g:base16_gui0E = "6a7fd2"
+let g:tinted_gui0E = "6a7fd2"
 let s:gui0F        = "e3488e"
+let g:tinted_gui0F = "e3488e"
+
+" Legacy
+let g:base16_gui00 = "0c1118"
+let g:base16_gui01 = "181c22"
+let g:base16_gui02 = "22262d"
+let g:base16_gui03 = "7b776e"
+let g:base16_gui04 = "949088"
+let g:base16_gui05 = "afaba2"
+let g:base16_gui06 = "cac6bd"
+let g:base16_gui07 = "e7e2d9"
+let g:base16_gui08 = "f04339"
+let g:base16_gui09 = "df5923"
+let g:base16_gui0A = "bb8801"
+let g:base16_gui0B = "7f8b00"
+let g:base16_gui0C = "00948b"
+let g:base16_gui0D = "008dd1"
+let g:base16_gui0E = "6a7fd2"
 let g:base16_gui0F = "e3488e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e7e2d9",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Equilibrium Gray Dark
 " Scheme author: Carlo Abelli
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-equilibrium-gray-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/equilibrium-gray-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/equilibrium-gray-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "111111"
-let g:base16_gui00 = "111111"
+let g:tinted_gui00 = "111111"
 let s:gui01        = "1b1b1b"
-let g:base16_gui01 = "1b1b1b"
+let g:tinted_gui01 = "1b1b1b"
 let s:gui02        = "262626"
-let g:base16_gui02 = "262626"
+let g:tinted_gui02 = "262626"
 let s:gui03        = "777777"
-let g:base16_gui03 = "777777"
+let g:tinted_gui03 = "777777"
 let s:gui04        = "919191"
-let g:base16_gui04 = "919191"
+let g:tinted_gui04 = "919191"
 let s:gui05        = "ababab"
-let g:base16_gui05 = "ababab"
+let g:tinted_gui05 = "ababab"
 let s:gui06        = "c6c6c6"
-let g:base16_gui06 = "c6c6c6"
+let g:tinted_gui06 = "c6c6c6"
 let s:gui07        = "e2e2e2"
-let g:base16_gui07 = "e2e2e2"
+let g:tinted_gui07 = "e2e2e2"
 let s:gui08        = "f04339"
-let g:base16_gui08 = "f04339"
+let g:tinted_gui08 = "f04339"
 let s:gui09        = "df5923"
-let g:base16_gui09 = "df5923"
+let g:tinted_gui09 = "df5923"
 let s:gui0A        = "bb8801"
-let g:base16_gui0A = "bb8801"
+let g:tinted_gui0A = "bb8801"
 let s:gui0B        = "7f8b00"
-let g:base16_gui0B = "7f8b00"
+let g:tinted_gui0B = "7f8b00"
 let s:gui0C        = "00948b"
-let g:base16_gui0C = "00948b"
+let g:tinted_gui0C = "00948b"
 let s:gui0D        = "008dd1"
-let g:base16_gui0D = "008dd1"
+let g:tinted_gui0D = "008dd1"
 let s:gui0E        = "6a7fd2"
-let g:base16_gui0E = "6a7fd2"
+let g:tinted_gui0E = "6a7fd2"
 let s:gui0F        = "e3488e"
+let g:tinted_gui0F = "e3488e"
+
+" Legacy
+let g:base16_gui00 = "111111"
+let g:base16_gui01 = "1b1b1b"
+let g:base16_gui02 = "262626"
+let g:base16_gui03 = "777777"
+let g:base16_gui04 = "919191"
+let g:base16_gui05 = "ababab"
+let g:base16_gui06 = "c6c6c6"
+let g:base16_gui07 = "e2e2e2"
+let g:base16_gui08 = "f04339"
+let g:base16_gui09 = "df5923"
+let g:base16_gui0A = "bb8801"
+let g:base16_gui0B = "7f8b00"
+let g:base16_gui0C = "00948b"
+let g:base16_gui0D = "008dd1"
+let g:base16_gui0E = "6a7fd2"
 let g:base16_gui0F = "e3488e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e2e2e2",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Equilibrium Gray Light
 " Scheme author: Carlo Abelli
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-equilibrium-gray-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/equilibrium-gray-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/equilibrium-gray-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f1f1f1"
-let g:base16_gui00 = "f1f1f1"
+let g:tinted_gui00 = "f1f1f1"
 let s:gui01        = "e2e2e2"
-let g:base16_gui01 = "e2e2e2"
+let g:tinted_gui01 = "e2e2e2"
 let s:gui02        = "d4d4d4"
-let g:base16_gui02 = "d4d4d4"
+let g:tinted_gui02 = "d4d4d4"
 let s:gui03        = "777777"
-let g:base16_gui03 = "777777"
+let g:tinted_gui03 = "777777"
 let s:gui04        = "5e5e5e"
-let g:base16_gui04 = "5e5e5e"
+let g:tinted_gui04 = "5e5e5e"
 let s:gui05        = "474747"
-let g:base16_gui05 = "474747"
+let g:tinted_gui05 = "474747"
 let s:gui06        = "303030"
-let g:base16_gui06 = "303030"
+let g:tinted_gui06 = "303030"
 let s:gui07        = "1b1b1b"
-let g:base16_gui07 = "1b1b1b"
+let g:tinted_gui07 = "1b1b1b"
 let s:gui08        = "d02023"
-let g:base16_gui08 = "d02023"
+let g:tinted_gui08 = "d02023"
 let s:gui09        = "bf3e05"
-let g:base16_gui09 = "bf3e05"
+let g:tinted_gui09 = "bf3e05"
 let s:gui0A        = "9d6f00"
-let g:base16_gui0A = "9d6f00"
+let g:tinted_gui0A = "9d6f00"
 let s:gui0B        = "637200"
-let g:base16_gui0B = "637200"
+let g:tinted_gui0B = "637200"
 let s:gui0C        = "007a72"
-let g:base16_gui0C = "007a72"
+let g:tinted_gui0C = "007a72"
 let s:gui0D        = "0073b5"
-let g:base16_gui0D = "0073b5"
+let g:tinted_gui0D = "0073b5"
 let s:gui0E        = "4e66b6"
-let g:base16_gui0E = "4e66b6"
+let g:tinted_gui0E = "4e66b6"
 let s:gui0F        = "c42775"
+let g:tinted_gui0F = "c42775"
+
+" Legacy
+let g:base16_gui00 = "f1f1f1"
+let g:base16_gui01 = "e2e2e2"
+let g:base16_gui02 = "d4d4d4"
+let g:base16_gui03 = "777777"
+let g:base16_gui04 = "5e5e5e"
+let g:base16_gui05 = "474747"
+let g:base16_gui06 = "303030"
+let g:base16_gui07 = "1b1b1b"
+let g:base16_gui08 = "d02023"
+let g:base16_gui09 = "bf3e05"
+let g:base16_gui0A = "9d6f00"
+let g:base16_gui0B = "637200"
+let g:base16_gui0C = "007a72"
+let g:base16_gui0D = "0073b5"
+let g:base16_gui0E = "4e66b6"
 let g:base16_gui0F = "c42775"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1b1b1b",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Equilibrium Light
 " Scheme author: Carlo Abelli
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-equilibrium-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/equilibrium-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/equilibrium-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f5f0e7"
-let g:base16_gui00 = "f5f0e7"
+let g:tinted_gui00 = "f5f0e7"
 let s:gui01        = "e7e2d9"
-let g:base16_gui01 = "e7e2d9"
+let g:tinted_gui01 = "e7e2d9"
 let s:gui02        = "d8d4cb"
-let g:base16_gui02 = "d8d4cb"
+let g:tinted_gui02 = "d8d4cb"
 let s:gui03        = "73777f"
-let g:base16_gui03 = "73777f"
+let g:tinted_gui03 = "73777f"
 let s:gui04        = "5a5f66"
-let g:base16_gui04 = "5a5f66"
+let g:tinted_gui04 = "5a5f66"
 let s:gui05        = "43474e"
-let g:base16_gui05 = "43474e"
+let g:tinted_gui05 = "43474e"
 let s:gui06        = "2c3138"
-let g:base16_gui06 = "2c3138"
+let g:tinted_gui06 = "2c3138"
 let s:gui07        = "181c22"
-let g:base16_gui07 = "181c22"
+let g:tinted_gui07 = "181c22"
 let s:gui08        = "d02023"
-let g:base16_gui08 = "d02023"
+let g:tinted_gui08 = "d02023"
 let s:gui09        = "bf3e05"
-let g:base16_gui09 = "bf3e05"
+let g:tinted_gui09 = "bf3e05"
 let s:gui0A        = "9d6f00"
-let g:base16_gui0A = "9d6f00"
+let g:tinted_gui0A = "9d6f00"
 let s:gui0B        = "637200"
-let g:base16_gui0B = "637200"
+let g:tinted_gui0B = "637200"
 let s:gui0C        = "007a72"
-let g:base16_gui0C = "007a72"
+let g:tinted_gui0C = "007a72"
 let s:gui0D        = "0073b5"
-let g:base16_gui0D = "0073b5"
+let g:tinted_gui0D = "0073b5"
 let s:gui0E        = "4e66b6"
-let g:base16_gui0E = "4e66b6"
+let g:tinted_gui0E = "4e66b6"
 let s:gui0F        = "c42775"
+let g:tinted_gui0F = "c42775"
+
+" Legacy
+let g:base16_gui00 = "f5f0e7"
+let g:base16_gui01 = "e7e2d9"
+let g:base16_gui02 = "d8d4cb"
+let g:base16_gui03 = "73777f"
+let g:base16_gui04 = "5a5f66"
+let g:base16_gui05 = "43474e"
+let g:base16_gui06 = "2c3138"
+let g:base16_gui07 = "181c22"
+let g:base16_gui08 = "d02023"
+let g:base16_gui09 = "bf3e05"
+let g:base16_gui0A = "9d6f00"
+let g:base16_gui0B = "637200"
+let g:base16_gui0C = "007a72"
+let g:base16_gui0D = "0073b5"
+let g:base16_gui0E = "4e66b6"
 let g:base16_gui0F = "c42775"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#181c22",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-eris.vim
+++ b/colors/base16-eris.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: eris
 " Scheme author: ed (https://codeberg.org/ed)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-eris.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/eris.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/eris.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0a0920"
-let g:base16_gui00 = "0a0920"
+let g:tinted_gui00 = "0a0920"
 let s:gui01        = "13133a"
-let g:base16_gui01 = "13133a"
+let g:tinted_gui01 = "13133a"
 let s:gui02        = "23255a"
-let g:base16_gui02 = "23255a"
+let g:tinted_gui02 = "23255a"
 let s:gui03        = "333773"
-let g:base16_gui03 = "333773"
+let g:tinted_gui03 = "333773"
 let s:gui04        = "4a5293"
-let g:base16_gui04 = "4a5293"
+let g:tinted_gui04 = "4a5293"
 let s:gui05        = "606bac"
-let g:base16_gui05 = "606bac"
+let g:tinted_gui05 = "606bac"
 let s:gui06        = "7986c5"
-let g:base16_gui06 = "7986c5"
+let g:tinted_gui06 = "7986c5"
 let s:gui07        = "9aaae5"
-let g:base16_gui07 = "9aaae5"
+let g:tinted_gui07 = "9aaae5"
 let s:gui08        = "f768a3"
-let g:base16_gui08 = "f768a3"
+let g:tinted_gui08 = "f768a3"
 let s:gui09        = "f768a3"
-let g:base16_gui09 = "f768a3"
+let g:tinted_gui09 = "f768a3"
 let s:gui0A        = "faaea2"
-let g:base16_gui0A = "faaea2"
+let g:tinted_gui0A = "faaea2"
 let s:gui0B        = "faaea2"
-let g:base16_gui0B = "faaea2"
+let g:tinted_gui0B = "faaea2"
 let s:gui0C        = "258fc4"
-let g:base16_gui0C = "258fc4"
+let g:tinted_gui0C = "258fc4"
 let s:gui0D        = "258fc4"
-let g:base16_gui0D = "258fc4"
+let g:tinted_gui0D = "258fc4"
 let s:gui0E        = "f768a3"
-let g:base16_gui0E = "f768a3"
+let g:tinted_gui0E = "f768a3"
 let s:gui0F        = "f768a3"
+let g:tinted_gui0F = "f768a3"
+
+" Legacy
+let g:base16_gui00 = "0a0920"
+let g:base16_gui01 = "13133a"
+let g:base16_gui02 = "23255a"
+let g:base16_gui03 = "333773"
+let g:base16_gui04 = "4a5293"
+let g:base16_gui05 = "606bac"
+let g:base16_gui06 = "7986c5"
+let g:base16_gui07 = "9aaae5"
+let g:base16_gui08 = "f768a3"
+let g:base16_gui09 = "f768a3"
+let g:base16_gui0A = "faaea2"
+let g:base16_gui0B = "faaea2"
+let g:base16_gui0C = "258fc4"
+let g:base16_gui0D = "258fc4"
+let g:base16_gui0E = "f768a3"
 let g:base16_gui0F = "f768a3"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#9aaae5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Espresso
 " Scheme author: Unknown. Maintained by Alex Mirrington (https://github.com/alexmirrington)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-espresso.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/espresso.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/espresso.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2d2d2d"
-let g:base16_gui00 = "2d2d2d"
+let g:tinted_gui00 = "2d2d2d"
 let s:gui01        = "393939"
-let g:base16_gui01 = "393939"
+let g:tinted_gui01 = "393939"
 let s:gui02        = "515151"
-let g:base16_gui02 = "515151"
+let g:tinted_gui02 = "515151"
 let s:gui03        = "777777"
-let g:base16_gui03 = "777777"
+let g:tinted_gui03 = "777777"
 let s:gui04        = "b4b7b4"
-let g:base16_gui04 = "b4b7b4"
+let g:tinted_gui04 = "b4b7b4"
 let s:gui05        = "cccccc"
-let g:base16_gui05 = "cccccc"
+let g:tinted_gui05 = "cccccc"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "d25252"
-let g:base16_gui08 = "d25252"
+let g:tinted_gui08 = "d25252"
 let s:gui09        = "f9a959"
-let g:base16_gui09 = "f9a959"
+let g:tinted_gui09 = "f9a959"
 let s:gui0A        = "ffc66d"
-let g:base16_gui0A = "ffc66d"
+let g:tinted_gui0A = "ffc66d"
 let s:gui0B        = "a5c261"
-let g:base16_gui0B = "a5c261"
+let g:tinted_gui0B = "a5c261"
 let s:gui0C        = "bed6ff"
-let g:base16_gui0C = "bed6ff"
+let g:tinted_gui0C = "bed6ff"
 let s:gui0D        = "6c99bb"
-let g:base16_gui0D = "6c99bb"
+let g:tinted_gui0D = "6c99bb"
 let s:gui0E        = "d197d9"
-let g:base16_gui0E = "d197d9"
+let g:tinted_gui0E = "d197d9"
 let s:gui0F        = "f97394"
+let g:tinted_gui0F = "f97394"
+
+" Legacy
+let g:base16_gui00 = "2d2d2d"
+let g:base16_gui01 = "393939"
+let g:base16_gui02 = "515151"
+let g:base16_gui03 = "777777"
+let g:base16_gui04 = "b4b7b4"
+let g:base16_gui05 = "cccccc"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "d25252"
+let g:base16_gui09 = "f9a959"
+let g:base16_gui0A = "ffc66d"
+let g:base16_gui0B = "a5c261"
+let g:base16_gui0C = "bed6ff"
+let g:base16_gui0D = "6c99bb"
+let g:base16_gui0E = "d197d9"
 let g:base16_gui0F = "f97394"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Eva Dim
 " Scheme author: kjakapat (https://github.com/kjakapat)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-eva-dim.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/eva-dim.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/eva-dim.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2a3b4d"
-let g:base16_gui00 = "2a3b4d"
+let g:tinted_gui00 = "2a3b4d"
 let s:gui01        = "3d566f"
-let g:base16_gui01 = "3d566f"
+let g:tinted_gui01 = "3d566f"
 let s:gui02        = "4b6988"
-let g:base16_gui02 = "4b6988"
+let g:tinted_gui02 = "4b6988"
 let s:gui03        = "55799c"
-let g:base16_gui03 = "55799c"
+let g:tinted_gui03 = "55799c"
 let s:gui04        = "7e90a3"
-let g:base16_gui04 = "7e90a3"
+let g:tinted_gui04 = "7e90a3"
 let s:gui05        = "9fa2a6"
-let g:base16_gui05 = "9fa2a6"
+let g:tinted_gui05 = "9fa2a6"
 let s:gui06        = "d6d7d9"
-let g:base16_gui06 = "d6d7d9"
+let g:tinted_gui06 = "d6d7d9"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "c4676c"
-let g:base16_gui08 = "c4676c"
+let g:tinted_gui08 = "c4676c"
 let s:gui09        = "ff9966"
-let g:base16_gui09 = "ff9966"
+let g:tinted_gui09 = "ff9966"
 let s:gui0A        = "cfd05d"
-let g:base16_gui0A = "cfd05d"
+let g:tinted_gui0A = "cfd05d"
 let s:gui0B        = "5de561"
-let g:base16_gui0B = "5de561"
+let g:tinted_gui0B = "5de561"
 let s:gui0C        = "4b8f77"
-let g:base16_gui0C = "4b8f77"
+let g:tinted_gui0C = "4b8f77"
 let s:gui0D        = "1ae1dc"
-let g:base16_gui0D = "1ae1dc"
+let g:tinted_gui0D = "1ae1dc"
 let s:gui0E        = "9c6cd3"
-let g:base16_gui0E = "9c6cd3"
+let g:tinted_gui0E = "9c6cd3"
 let s:gui0F        = "bb64a9"
+let g:tinted_gui0F = "bb64a9"
+
+" Legacy
+let g:base16_gui00 = "2a3b4d"
+let g:base16_gui01 = "3d566f"
+let g:base16_gui02 = "4b6988"
+let g:base16_gui03 = "55799c"
+let g:base16_gui04 = "7e90a3"
+let g:base16_gui05 = "9fa2a6"
+let g:base16_gui06 = "d6d7d9"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "c4676c"
+let g:base16_gui09 = "ff9966"
+let g:base16_gui0A = "cfd05d"
+let g:base16_gui0B = "5de561"
+let g:base16_gui0C = "4b8f77"
+let g:base16_gui0D = "1ae1dc"
+let g:base16_gui0E = "9c6cd3"
 let g:base16_gui0F = "bb64a9"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Eva
 " Scheme author: kjakapat (https://github.com/kjakapat)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-eva.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/eva.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/eva.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2a3b4d"
-let g:base16_gui00 = "2a3b4d"
+let g:tinted_gui00 = "2a3b4d"
 let s:gui01        = "3d566f"
-let g:base16_gui01 = "3d566f"
+let g:tinted_gui01 = "3d566f"
 let s:gui02        = "4b6988"
-let g:base16_gui02 = "4b6988"
+let g:tinted_gui02 = "4b6988"
 let s:gui03        = "55799c"
-let g:base16_gui03 = "55799c"
+let g:tinted_gui03 = "55799c"
 let s:gui04        = "7e90a3"
-let g:base16_gui04 = "7e90a3"
+let g:tinted_gui04 = "7e90a3"
 let s:gui05        = "9fa2a6"
-let g:base16_gui05 = "9fa2a6"
+let g:tinted_gui05 = "9fa2a6"
 let s:gui06        = "d6d7d9"
-let g:base16_gui06 = "d6d7d9"
+let g:tinted_gui06 = "d6d7d9"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "c4676c"
-let g:base16_gui08 = "c4676c"
+let g:tinted_gui08 = "c4676c"
 let s:gui09        = "ff9966"
-let g:base16_gui09 = "ff9966"
+let g:tinted_gui09 = "ff9966"
 let s:gui0A        = "ffff66"
-let g:base16_gui0A = "ffff66"
+let g:tinted_gui0A = "ffff66"
 let s:gui0B        = "66ff66"
-let g:base16_gui0B = "66ff66"
+let g:tinted_gui0B = "66ff66"
 let s:gui0C        = "4b8f77"
-let g:base16_gui0C = "4b8f77"
+let g:tinted_gui0C = "4b8f77"
 let s:gui0D        = "15f4ee"
-let g:base16_gui0D = "15f4ee"
+let g:tinted_gui0D = "15f4ee"
 let s:gui0E        = "9c6cd3"
-let g:base16_gui0E = "9c6cd3"
+let g:tinted_gui0E = "9c6cd3"
 let s:gui0F        = "bb64a9"
+let g:tinted_gui0F = "bb64a9"
+
+" Legacy
+let g:base16_gui00 = "2a3b4d"
+let g:base16_gui01 = "3d566f"
+let g:base16_gui02 = "4b6988"
+let g:base16_gui03 = "55799c"
+let g:base16_gui04 = "7e90a3"
+let g:base16_gui05 = "9fa2a6"
+let g:base16_gui06 = "d6d7d9"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "c4676c"
+let g:base16_gui09 = "ff9966"
+let g:base16_gui0A = "ffff66"
+let g:base16_gui0B = "66ff66"
+let g:base16_gui0C = "4b8f77"
+let g:base16_gui0D = "15f4ee"
+let g:base16_gui0E = "9c6cd3"
 let g:base16_gui0F = "bb64a9"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-evenok-dark.vim
+++ b/colors/base16-evenok-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Evenok Dark
 " Scheme author: Mekeor Melire
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-evenok-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/evenok-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/evenok-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "202020"
-let g:base16_gui01 = "202020"
+let g:tinted_gui01 = "202020"
 let s:gui02        = "303030"
-let g:base16_gui02 = "303030"
+let g:tinted_gui02 = "303030"
 let s:gui03        = "505050"
-let g:base16_gui03 = "505050"
+let g:tinted_gui03 = "505050"
 let s:gui04        = "b0b0b0"
-let g:base16_gui04 = "b0b0b0"
+let g:tinted_gui04 = "b0b0b0"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f5708a"
-let g:base16_gui08 = "f5708a"
+let g:tinted_gui08 = "f5708a"
 let s:gui09        = "ee8122"
-let g:base16_gui09 = "ee8122"
+let g:tinted_gui09 = "ee8122"
 let s:gui0A        = "b8a300"
-let g:base16_gui0A = "b8a300"
+let g:tinted_gui0A = "b8a300"
 let s:gui0B        = "54bc5c"
-let g:base16_gui0B = "54bc5c"
+let g:tinted_gui0B = "54bc5c"
 let s:gui0C        = "00bab3"
-let g:base16_gui0C = "00bab3"
+let g:tinted_gui0C = "00bab3"
 let s:gui0D        = "00aff2"
-let g:base16_gui0D = "00aff2"
+let g:tinted_gui0D = "00aff2"
 let s:gui0E        = "9095ff"
-let g:base16_gui0E = "9095ff"
+let g:tinted_gui0E = "9095ff"
 let s:gui0F        = "d47ada"
+let g:tinted_gui0F = "d47ada"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "202020"
+let g:base16_gui02 = "303030"
+let g:base16_gui03 = "505050"
+let g:base16_gui04 = "b0b0b0"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f5708a"
+let g:base16_gui09 = "ee8122"
+let g:base16_gui0A = "b8a300"
+let g:base16_gui0B = "54bc5c"
+let g:base16_gui0C = "00bab3"
+let g:base16_gui0D = "00aff2"
+let g:base16_gui0E = "9095ff"
 let g:base16_gui0F = "d47ada"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-everforest-dark-hard.vim
+++ b/colors/base16-everforest-dark-hard.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Everforest Dark Hard
 " Scheme author: Sainnhe Park (https://github.com/sainnhe)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-everforest-dark-hard.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/everforest-dark-hard.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/everforest-dark-hard.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "272e33"
-let g:base16_gui00 = "272e33"
+let g:tinted_gui00 = "272e33"
 let s:gui01        = "2e383c"
-let g:base16_gui01 = "2e383c"
+let g:tinted_gui01 = "2e383c"
 let s:gui02        = "414b50"
-let g:base16_gui02 = "414b50"
+let g:tinted_gui02 = "414b50"
 let s:gui03        = "859289"
-let g:base16_gui03 = "859289"
+let g:tinted_gui03 = "859289"
 let s:gui04        = "9da9a0"
-let g:base16_gui04 = "9da9a0"
+let g:tinted_gui04 = "9da9a0"
 let s:gui05        = "d3c6aa"
-let g:base16_gui05 = "d3c6aa"
+let g:tinted_gui05 = "d3c6aa"
 let s:gui06        = "edeada"
-let g:base16_gui06 = "edeada"
+let g:tinted_gui06 = "edeada"
 let s:gui07        = "fffbef"
-let g:base16_gui07 = "fffbef"
+let g:tinted_gui07 = "fffbef"
 let s:gui08        = "e67e80"
-let g:base16_gui08 = "e67e80"
+let g:tinted_gui08 = "e67e80"
 let s:gui09        = "e69875"
-let g:base16_gui09 = "e69875"
+let g:tinted_gui09 = "e69875"
 let s:gui0A        = "dbbc7f"
-let g:base16_gui0A = "dbbc7f"
+let g:tinted_gui0A = "dbbc7f"
 let s:gui0B        = "a7c080"
-let g:base16_gui0B = "a7c080"
+let g:tinted_gui0B = "a7c080"
 let s:gui0C        = "83c092"
-let g:base16_gui0C = "83c092"
+let g:tinted_gui0C = "83c092"
 let s:gui0D        = "7fbbb3"
-let g:base16_gui0D = "7fbbb3"
+let g:tinted_gui0D = "7fbbb3"
 let s:gui0E        = "d699b6"
-let g:base16_gui0E = "d699b6"
+let g:tinted_gui0E = "d699b6"
 let s:gui0F        = "9da9a0"
+let g:tinted_gui0F = "9da9a0"
+
+" Legacy
+let g:base16_gui00 = "272e33"
+let g:base16_gui01 = "2e383c"
+let g:base16_gui02 = "414b50"
+let g:base16_gui03 = "859289"
+let g:base16_gui04 = "9da9a0"
+let g:base16_gui05 = "d3c6aa"
+let g:base16_gui06 = "edeada"
+let g:base16_gui07 = "fffbef"
+let g:base16_gui08 = "e67e80"
+let g:base16_gui09 = "e69875"
+let g:base16_gui0A = "dbbc7f"
+let g:base16_gui0B = "a7c080"
+let g:base16_gui0C = "83c092"
+let g:base16_gui0D = "7fbbb3"
+let g:base16_gui0E = "d699b6"
 let g:base16_gui0F = "9da9a0"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fffbef",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-everforest.vim
+++ b/colors/base16-everforest.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Everforest
 " Scheme author: Sainnhe Park (https://github.com/sainnhe)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-everforest.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/everforest.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/everforest.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2d353b"
-let g:base16_gui00 = "2d353b"
+let g:tinted_gui00 = "2d353b"
 let s:gui01        = "343f44"
-let g:base16_gui01 = "343f44"
+let g:tinted_gui01 = "343f44"
 let s:gui02        = "475258"
-let g:base16_gui02 = "475258"
+let g:tinted_gui02 = "475258"
 let s:gui03        = "859289"
-let g:base16_gui03 = "859289"
+let g:tinted_gui03 = "859289"
 let s:gui04        = "9da9a0"
-let g:base16_gui04 = "9da9a0"
+let g:tinted_gui04 = "9da9a0"
 let s:gui05        = "d3c6aa"
-let g:base16_gui05 = "d3c6aa"
+let g:tinted_gui05 = "d3c6aa"
 let s:gui06        = "e6e2cc"
-let g:base16_gui06 = "e6e2cc"
+let g:tinted_gui06 = "e6e2cc"
 let s:gui07        = "fdf6e3"
-let g:base16_gui07 = "fdf6e3"
+let g:tinted_gui07 = "fdf6e3"
 let s:gui08        = "e67e80"
-let g:base16_gui08 = "e67e80"
+let g:tinted_gui08 = "e67e80"
 let s:gui09        = "e69875"
-let g:base16_gui09 = "e69875"
+let g:tinted_gui09 = "e69875"
 let s:gui0A        = "dbbc7f"
-let g:base16_gui0A = "dbbc7f"
+let g:tinted_gui0A = "dbbc7f"
 let s:gui0B        = "a7c080"
-let g:base16_gui0B = "a7c080"
+let g:tinted_gui0B = "a7c080"
 let s:gui0C        = "83c092"
-let g:base16_gui0C = "83c092"
+let g:tinted_gui0C = "83c092"
 let s:gui0D        = "7fbbb3"
-let g:base16_gui0D = "7fbbb3"
+let g:tinted_gui0D = "7fbbb3"
 let s:gui0E        = "d699b6"
-let g:base16_gui0E = "d699b6"
+let g:tinted_gui0E = "d699b6"
 let s:gui0F        = "9da9a0"
+let g:tinted_gui0F = "9da9a0"
+
+" Legacy
+let g:base16_gui00 = "2d353b"
+let g:base16_gui01 = "343f44"
+let g:base16_gui02 = "475258"
+let g:base16_gui03 = "859289"
+let g:base16_gui04 = "9da9a0"
+let g:base16_gui05 = "d3c6aa"
+let g:base16_gui06 = "e6e2cc"
+let g:base16_gui07 = "fdf6e3"
+let g:base16_gui08 = "e67e80"
+let g:base16_gui09 = "e69875"
+let g:base16_gui0A = "dbbc7f"
+let g:base16_gui0B = "a7c080"
+let g:base16_gui0C = "83c092"
+let g:base16_gui0D = "7fbbb3"
+let g:base16_gui0E = "d699b6"
 let g:base16_gui0F = "9da9a0"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fdf6e3",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Flat
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-flat.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/flat.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/flat.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2c3e50"
-let g:base16_gui00 = "2c3e50"
+let g:tinted_gui00 = "2c3e50"
 let s:gui01        = "34495e"
-let g:base16_gui01 = "34495e"
+let g:tinted_gui01 = "34495e"
 let s:gui02        = "7f8c8d"
-let g:base16_gui02 = "7f8c8d"
+let g:tinted_gui02 = "7f8c8d"
 let s:gui03        = "95a5a6"
-let g:base16_gui03 = "95a5a6"
+let g:tinted_gui03 = "95a5a6"
 let s:gui04        = "bdc3c7"
-let g:base16_gui04 = "bdc3c7"
+let g:tinted_gui04 = "bdc3c7"
 let s:gui05        = "e0e0e0"
-let g:base16_gui05 = "e0e0e0"
+let g:tinted_gui05 = "e0e0e0"
 let s:gui06        = "f5f5f5"
-let g:base16_gui06 = "f5f5f5"
+let g:tinted_gui06 = "f5f5f5"
 let s:gui07        = "ecf0f1"
-let g:base16_gui07 = "ecf0f1"
+let g:tinted_gui07 = "ecf0f1"
 let s:gui08        = "e74c3c"
-let g:base16_gui08 = "e74c3c"
+let g:tinted_gui08 = "e74c3c"
 let s:gui09        = "e67e22"
-let g:base16_gui09 = "e67e22"
+let g:tinted_gui09 = "e67e22"
 let s:gui0A        = "f1c40f"
-let g:base16_gui0A = "f1c40f"
+let g:tinted_gui0A = "f1c40f"
 let s:gui0B        = "2ecc71"
-let g:base16_gui0B = "2ecc71"
+let g:tinted_gui0B = "2ecc71"
 let s:gui0C        = "1abc9c"
-let g:base16_gui0C = "1abc9c"
+let g:tinted_gui0C = "1abc9c"
 let s:gui0D        = "3498db"
-let g:base16_gui0D = "3498db"
+let g:tinted_gui0D = "3498db"
 let s:gui0E        = "9b59b6"
-let g:base16_gui0E = "9b59b6"
+let g:tinted_gui0E = "9b59b6"
 let s:gui0F        = "be643c"
+let g:tinted_gui0F = "be643c"
+
+" Legacy
+let g:base16_gui00 = "2c3e50"
+let g:base16_gui01 = "34495e"
+let g:base16_gui02 = "7f8c8d"
+let g:base16_gui03 = "95a5a6"
+let g:base16_gui04 = "bdc3c7"
+let g:base16_gui05 = "e0e0e0"
+let g:base16_gui06 = "f5f5f5"
+let g:base16_gui07 = "ecf0f1"
+let g:base16_gui08 = "e74c3c"
+let g:base16_gui09 = "e67e22"
+let g:base16_gui0A = "f1c40f"
+let g:base16_gui0B = "2ecc71"
+let g:base16_gui0C = "1abc9c"
+let g:base16_gui0D = "3498db"
+let g:base16_gui0E = "9b59b6"
 let g:base16_gui0F = "be643c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ecf0f1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Framer
 " Scheme author: Framer (Maintained by Jesse Hoyos)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-framer.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/framer.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/framer.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "181818"
-let g:base16_gui00 = "181818"
+let g:tinted_gui00 = "181818"
 let s:gui01        = "151515"
-let g:base16_gui01 = "151515"
+let g:tinted_gui01 = "151515"
 let s:gui02        = "464646"
-let g:base16_gui02 = "464646"
+let g:tinted_gui02 = "464646"
 let s:gui03        = "747474"
-let g:base16_gui03 = "747474"
+let g:tinted_gui03 = "747474"
 let s:gui04        = "b9b9b9"
-let g:base16_gui04 = "b9b9b9"
+let g:tinted_gui04 = "b9b9b9"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "eeeeee"
-let g:base16_gui07 = "eeeeee"
+let g:tinted_gui07 = "eeeeee"
 let s:gui08        = "fd886b"
-let g:base16_gui08 = "fd886b"
+let g:tinted_gui08 = "fd886b"
 let s:gui09        = "fc4769"
-let g:base16_gui09 = "fc4769"
+let g:tinted_gui09 = "fc4769"
 let s:gui0A        = "fecb6e"
-let g:base16_gui0A = "fecb6e"
+let g:tinted_gui0A = "fecb6e"
 let s:gui0B        = "32ccdc"
-let g:base16_gui0B = "32ccdc"
+let g:tinted_gui0B = "32ccdc"
 let s:gui0C        = "acddfd"
-let g:base16_gui0C = "acddfd"
+let g:tinted_gui0C = "acddfd"
 let s:gui0D        = "20bcfc"
-let g:base16_gui0D = "20bcfc"
+let g:tinted_gui0D = "20bcfc"
 let s:gui0E        = "ba8cfc"
-let g:base16_gui0E = "ba8cfc"
+let g:tinted_gui0E = "ba8cfc"
 let s:gui0F        = "b15f4a"
+let g:tinted_gui0F = "b15f4a"
+
+" Legacy
+let g:base16_gui00 = "181818"
+let g:base16_gui01 = "151515"
+let g:base16_gui02 = "464646"
+let g:base16_gui03 = "747474"
+let g:base16_gui04 = "b9b9b9"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "eeeeee"
+let g:base16_gui08 = "fd886b"
+let g:base16_gui09 = "fc4769"
+let g:base16_gui0A = "fecb6e"
+let g:base16_gui0B = "32ccdc"
+let g:base16_gui0C = "acddfd"
+let g:base16_gui0D = "20bcfc"
+let g:base16_gui0E = "ba8cfc"
 let g:base16_gui0F = "b15f4a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#eeeeee",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Fruit Soda
 " Scheme author: jozip
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-fruit-soda.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/fruit-soda.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/fruit-soda.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f1ecf1"
-let g:base16_gui00 = "f1ecf1"
+let g:tinted_gui00 = "f1ecf1"
 let s:gui01        = "e0dee0"
-let g:base16_gui01 = "e0dee0"
+let g:tinted_gui01 = "e0dee0"
 let s:gui02        = "d8d5d5"
-let g:base16_gui02 = "d8d5d5"
+let g:tinted_gui02 = "d8d5d5"
 let s:gui03        = "b5b4b6"
-let g:base16_gui03 = "b5b4b6"
+let g:tinted_gui03 = "b5b4b6"
 let s:gui04        = "979598"
-let g:base16_gui04 = "979598"
+let g:tinted_gui04 = "979598"
 let s:gui05        = "515151"
-let g:base16_gui05 = "515151"
+let g:tinted_gui05 = "515151"
 let s:gui06        = "474545"
-let g:base16_gui06 = "474545"
+let g:tinted_gui06 = "474545"
 let s:gui07        = "2d2c2c"
-let g:base16_gui07 = "2d2c2c"
+let g:tinted_gui07 = "2d2c2c"
 let s:gui08        = "fe3e31"
-let g:base16_gui08 = "fe3e31"
+let g:tinted_gui08 = "fe3e31"
 let s:gui09        = "fe6d08"
-let g:base16_gui09 = "fe6d08"
+let g:tinted_gui09 = "fe6d08"
 let s:gui0A        = "f7e203"
-let g:base16_gui0A = "f7e203"
+let g:tinted_gui0A = "f7e203"
 let s:gui0B        = "47f74c"
-let g:base16_gui0B = "47f74c"
+let g:tinted_gui0B = "47f74c"
 let s:gui0C        = "0f9cfd"
-let g:base16_gui0C = "0f9cfd"
+let g:tinted_gui0C = "0f9cfd"
 let s:gui0D        = "2931df"
-let g:base16_gui0D = "2931df"
+let g:tinted_gui0D = "2931df"
 let s:gui0E        = "611fce"
-let g:base16_gui0E = "611fce"
+let g:tinted_gui0E = "611fce"
 let s:gui0F        = "b16f40"
+let g:tinted_gui0F = "b16f40"
+
+" Legacy
+let g:base16_gui00 = "f1ecf1"
+let g:base16_gui01 = "e0dee0"
+let g:base16_gui02 = "d8d5d5"
+let g:base16_gui03 = "b5b4b6"
+let g:base16_gui04 = "979598"
+let g:base16_gui05 = "515151"
+let g:base16_gui06 = "474545"
+let g:base16_gui07 = "2d2c2c"
+let g:base16_gui08 = "fe3e31"
+let g:base16_gui09 = "fe6d08"
+let g:base16_gui0A = "f7e203"
+let g:base16_gui0B = "47f74c"
+let g:base16_gui0C = "0f9cfd"
+let g:base16_gui0D = "2931df"
+let g:base16_gui0E = "611fce"
 let g:base16_gui0F = "b16f40"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#2d2c2c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gigavolt
 " Scheme author: Aidan Swope (http://github.com/Whillikers)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gigavolt.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gigavolt.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gigavolt.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "202126"
-let g:base16_gui00 = "202126"
+let g:tinted_gui00 = "202126"
 let s:gui01        = "2d303d"
-let g:base16_gui01 = "2d303d"
+let g:tinted_gui01 = "2d303d"
 let s:gui02        = "5a576e"
-let g:base16_gui02 = "5a576e"
+let g:tinted_gui02 = "5a576e"
 let s:gui03        = "a1d2e6"
-let g:base16_gui03 = "a1d2e6"
+let g:tinted_gui03 = "a1d2e6"
 let s:gui04        = "cad3ff"
-let g:base16_gui04 = "cad3ff"
+let g:tinted_gui04 = "cad3ff"
 let s:gui05        = "e9e7e1"
-let g:base16_gui05 = "e9e7e1"
+let g:tinted_gui05 = "e9e7e1"
 let s:gui06        = "eff0f9"
-let g:base16_gui06 = "eff0f9"
+let g:tinted_gui06 = "eff0f9"
 let s:gui07        = "f2fbff"
-let g:base16_gui07 = "f2fbff"
+let g:tinted_gui07 = "f2fbff"
 let s:gui08        = "ff661a"
-let g:base16_gui08 = "ff661a"
+let g:tinted_gui08 = "ff661a"
 let s:gui09        = "19f988"
-let g:base16_gui09 = "19f988"
+let g:tinted_gui09 = "19f988"
 let s:gui0A        = "ffdc2d"
-let g:base16_gui0A = "ffdc2d"
+let g:tinted_gui0A = "ffdc2d"
 let s:gui0B        = "f2e6a9"
-let g:base16_gui0B = "f2e6a9"
+let g:tinted_gui0B = "f2e6a9"
 let s:gui0C        = "fb6acb"
-let g:base16_gui0C = "fb6acb"
+let g:tinted_gui0C = "fb6acb"
 let s:gui0D        = "40bfff"
-let g:base16_gui0D = "40bfff"
+let g:tinted_gui0D = "40bfff"
 let s:gui0E        = "ae94f9"
-let g:base16_gui0E = "ae94f9"
+let g:tinted_gui0E = "ae94f9"
 let s:gui0F        = "6187ff"
+let g:tinted_gui0F = "6187ff"
+
+" Legacy
+let g:base16_gui00 = "202126"
+let g:base16_gui01 = "2d303d"
+let g:base16_gui02 = "5a576e"
+let g:base16_gui03 = "a1d2e6"
+let g:base16_gui04 = "cad3ff"
+let g:base16_gui05 = "e9e7e1"
+let g:base16_gui06 = "eff0f9"
+let g:base16_gui07 = "f2fbff"
+let g:base16_gui08 = "ff661a"
+let g:base16_gui09 = "19f988"
+let g:base16_gui0A = "ffdc2d"
+let g:base16_gui0B = "f2e6a9"
+let g:base16_gui0C = "fb6acb"
+let g:base16_gui0D = "40bfff"
+let g:base16_gui0E = "ae94f9"
 let g:base16_gui0F = "6187ff"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f2fbff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Github
 " Scheme author: Defman21
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-github.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/github.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/github.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "f5f5f5"
-let g:base16_gui01 = "f5f5f5"
+let g:tinted_gui01 = "f5f5f5"
 let s:gui02        = "c8c8fa"
-let g:base16_gui02 = "c8c8fa"
+let g:tinted_gui02 = "c8c8fa"
 let s:gui03        = "969896"
-let g:base16_gui03 = "969896"
+let g:tinted_gui03 = "969896"
 let s:gui04        = "e8e8e8"
-let g:base16_gui04 = "e8e8e8"
+let g:tinted_gui04 = "e8e8e8"
 let s:gui05        = "333333"
-let g:base16_gui05 = "333333"
+let g:tinted_gui05 = "333333"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ed6a43"
-let g:base16_gui08 = "ed6a43"
+let g:tinted_gui08 = "ed6a43"
 let s:gui09        = "0086b3"
-let g:base16_gui09 = "0086b3"
+let g:tinted_gui09 = "0086b3"
 let s:gui0A        = "795da3"
-let g:base16_gui0A = "795da3"
+let g:tinted_gui0A = "795da3"
 let s:gui0B        = "183691"
-let g:base16_gui0B = "183691"
+let g:tinted_gui0B = "183691"
 let s:gui0C        = "183691"
-let g:base16_gui0C = "183691"
+let g:tinted_gui0C = "183691"
 let s:gui0D        = "795da3"
-let g:base16_gui0D = "795da3"
+let g:tinted_gui0D = "795da3"
 let s:gui0E        = "a71d5d"
-let g:base16_gui0E = "a71d5d"
+let g:tinted_gui0E = "a71d5d"
 let s:gui0F        = "333333"
+let g:tinted_gui0F = "333333"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "f5f5f5"
+let g:base16_gui02 = "c8c8fa"
+let g:base16_gui03 = "969896"
+let g:base16_gui04 = "e8e8e8"
+let g:base16_gui05 = "333333"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ed6a43"
+let g:base16_gui09 = "0086b3"
+let g:base16_gui0A = "795da3"
+let g:base16_gui0B = "183691"
+let g:base16_gui0C = "183691"
+let g:base16_gui0D = "795da3"
+let g:base16_gui0E = "a71d5d"
 let g:base16_gui0F = "333333"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Google Dark
 " Scheme author: Seth Wright (http://sethawright.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-google-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/google-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/google-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1d1f21"
-let g:base16_gui00 = "1d1f21"
+let g:tinted_gui00 = "1d1f21"
 let s:gui01        = "282a2e"
-let g:base16_gui01 = "282a2e"
+let g:tinted_gui01 = "282a2e"
 let s:gui02        = "373b41"
-let g:base16_gui02 = "373b41"
+let g:tinted_gui02 = "373b41"
 let s:gui03        = "969896"
-let g:base16_gui03 = "969896"
+let g:tinted_gui03 = "969896"
 let s:gui04        = "b4b7b4"
-let g:base16_gui04 = "b4b7b4"
+let g:tinted_gui04 = "b4b7b4"
 let s:gui05        = "c5c8c6"
-let g:base16_gui05 = "c5c8c6"
+let g:tinted_gui05 = "c5c8c6"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "cc342b"
-let g:base16_gui08 = "cc342b"
+let g:tinted_gui08 = "cc342b"
 let s:gui09        = "f96a38"
-let g:base16_gui09 = "f96a38"
+let g:tinted_gui09 = "f96a38"
 let s:gui0A        = "fba922"
-let g:base16_gui0A = "fba922"
+let g:tinted_gui0A = "fba922"
 let s:gui0B        = "198844"
-let g:base16_gui0B = "198844"
+let g:tinted_gui0B = "198844"
 let s:gui0C        = "3971ed"
-let g:base16_gui0C = "3971ed"
+let g:tinted_gui0C = "3971ed"
 let s:gui0D        = "3971ed"
-let g:base16_gui0D = "3971ed"
+let g:tinted_gui0D = "3971ed"
 let s:gui0E        = "a36ac7"
-let g:base16_gui0E = "a36ac7"
+let g:tinted_gui0E = "a36ac7"
 let s:gui0F        = "3971ed"
+let g:tinted_gui0F = "3971ed"
+
+" Legacy
+let g:base16_gui00 = "1d1f21"
+let g:base16_gui01 = "282a2e"
+let g:base16_gui02 = "373b41"
+let g:base16_gui03 = "969896"
+let g:base16_gui04 = "b4b7b4"
+let g:base16_gui05 = "c5c8c6"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "cc342b"
+let g:base16_gui09 = "f96a38"
+let g:base16_gui0A = "fba922"
+let g:base16_gui0B = "198844"
+let g:base16_gui0C = "3971ed"
+let g:base16_gui0D = "3971ed"
+let g:base16_gui0E = "a36ac7"
 let g:base16_gui0F = "3971ed"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Google Light
 " Scheme author: Seth Wright (http://sethawright.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-google-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/google-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/google-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "e0e0e0"
-let g:base16_gui01 = "e0e0e0"
+let g:tinted_gui01 = "e0e0e0"
 let s:gui02        = "c5c8c6"
-let g:base16_gui02 = "c5c8c6"
+let g:tinted_gui02 = "c5c8c6"
 let s:gui03        = "b4b7b4"
-let g:base16_gui03 = "b4b7b4"
+let g:tinted_gui03 = "b4b7b4"
 let s:gui04        = "969896"
-let g:base16_gui04 = "969896"
+let g:tinted_gui04 = "969896"
 let s:gui05        = "373b41"
-let g:base16_gui05 = "373b41"
+let g:tinted_gui05 = "373b41"
 let s:gui06        = "282a2e"
-let g:base16_gui06 = "282a2e"
+let g:tinted_gui06 = "282a2e"
 let s:gui07        = "1d1f21"
-let g:base16_gui07 = "1d1f21"
+let g:tinted_gui07 = "1d1f21"
 let s:gui08        = "cc342b"
-let g:base16_gui08 = "cc342b"
+let g:tinted_gui08 = "cc342b"
 let s:gui09        = "f96a38"
-let g:base16_gui09 = "f96a38"
+let g:tinted_gui09 = "f96a38"
 let s:gui0A        = "fba922"
-let g:base16_gui0A = "fba922"
+let g:tinted_gui0A = "fba922"
 let s:gui0B        = "198844"
-let g:base16_gui0B = "198844"
+let g:tinted_gui0B = "198844"
 let s:gui0C        = "3971ed"
-let g:base16_gui0C = "3971ed"
+let g:tinted_gui0C = "3971ed"
 let s:gui0D        = "3971ed"
-let g:base16_gui0D = "3971ed"
+let g:tinted_gui0D = "3971ed"
 let s:gui0E        = "a36ac7"
-let g:base16_gui0E = "a36ac7"
+let g:tinted_gui0E = "a36ac7"
 let s:gui0F        = "3971ed"
+let g:tinted_gui0F = "3971ed"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "e0e0e0"
+let g:base16_gui02 = "c5c8c6"
+let g:base16_gui03 = "b4b7b4"
+let g:base16_gui04 = "969896"
+let g:base16_gui05 = "373b41"
+let g:base16_gui06 = "282a2e"
+let g:base16_gui07 = "1d1f21"
+let g:base16_gui08 = "cc342b"
+let g:base16_gui09 = "f96a38"
+let g:base16_gui0A = "fba922"
+let g:base16_gui0B = "198844"
+let g:base16_gui0C = "3971ed"
+let g:base16_gui0D = "3971ed"
+let g:base16_gui0E = "a36ac7"
 let g:base16_gui0F = "3971ed"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1d1f21",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gotham.vim
+++ b/colors/base16-gotham.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gotham
 " Scheme author: Andrea Leopardi (arranged by Brett Jones)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gotham.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gotham.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gotham.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0c1014"
-let g:base16_gui00 = "0c1014"
+let g:tinted_gui00 = "0c1014"
 let s:gui01        = "11151c"
-let g:base16_gui01 = "11151c"
+let g:tinted_gui01 = "11151c"
 let s:gui02        = "091f2e"
-let g:base16_gui02 = "091f2e"
+let g:tinted_gui02 = "091f2e"
 let s:gui03        = "0a3749"
-let g:base16_gui03 = "0a3749"
+let g:tinted_gui03 = "0a3749"
 let s:gui04        = "245361"
-let g:base16_gui04 = "245361"
+let g:tinted_gui04 = "245361"
 let s:gui05        = "599cab"
-let g:base16_gui05 = "599cab"
+let g:tinted_gui05 = "599cab"
 let s:gui06        = "99d1ce"
-let g:base16_gui06 = "99d1ce"
+let g:tinted_gui06 = "99d1ce"
 let s:gui07        = "d3ebe9"
-let g:base16_gui07 = "d3ebe9"
+let g:tinted_gui07 = "d3ebe9"
 let s:gui08        = "c23127"
-let g:base16_gui08 = "c23127"
+let g:tinted_gui08 = "c23127"
 let s:gui09        = "d26937"
-let g:base16_gui09 = "d26937"
+let g:tinted_gui09 = "d26937"
 let s:gui0A        = "edb443"
-let g:base16_gui0A = "edb443"
+let g:tinted_gui0A = "edb443"
 let s:gui0B        = "33859e"
-let g:base16_gui0B = "33859e"
+let g:tinted_gui0B = "33859e"
 let s:gui0C        = "2aa889"
-let g:base16_gui0C = "2aa889"
+let g:tinted_gui0C = "2aa889"
 let s:gui0D        = "195466"
-let g:base16_gui0D = "195466"
+let g:tinted_gui0D = "195466"
 let s:gui0E        = "888ca6"
-let g:base16_gui0E = "888ca6"
+let g:tinted_gui0E = "888ca6"
 let s:gui0F        = "4e5166"
+let g:tinted_gui0F = "4e5166"
+
+" Legacy
+let g:base16_gui00 = "0c1014"
+let g:base16_gui01 = "11151c"
+let g:base16_gui02 = "091f2e"
+let g:base16_gui03 = "0a3749"
+let g:base16_gui04 = "245361"
+let g:base16_gui05 = "599cab"
+let g:base16_gui06 = "99d1ce"
+let g:base16_gui07 = "d3ebe9"
+let g:base16_gui08 = "c23127"
+let g:base16_gui09 = "d26937"
+let g:base16_gui0A = "edb443"
+let g:base16_gui0B = "33859e"
+let g:base16_gui0C = "2aa889"
+let g:base16_gui0D = "195466"
+let g:base16_gui0E = "888ca6"
 let g:base16_gui0F = "4e5166"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d3ebe9",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Grayscale Dark
 " Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-grayscale-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/grayscale-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/grayscale-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "101010"
-let g:base16_gui00 = "101010"
+let g:tinted_gui00 = "101010"
 let s:gui01        = "252525"
-let g:base16_gui01 = "252525"
+let g:tinted_gui01 = "252525"
 let s:gui02        = "464646"
-let g:base16_gui02 = "464646"
+let g:tinted_gui02 = "464646"
 let s:gui03        = "525252"
-let g:base16_gui03 = "525252"
+let g:tinted_gui03 = "525252"
 let s:gui04        = "ababab"
-let g:base16_gui04 = "ababab"
+let g:tinted_gui04 = "ababab"
 let s:gui05        = "b9b9b9"
-let g:base16_gui05 = "b9b9b9"
+let g:tinted_gui05 = "b9b9b9"
 let s:gui06        = "e3e3e3"
-let g:base16_gui06 = "e3e3e3"
+let g:tinted_gui06 = "e3e3e3"
 let s:gui07        = "f7f7f7"
-let g:base16_gui07 = "f7f7f7"
+let g:tinted_gui07 = "f7f7f7"
 let s:gui08        = "7c7c7c"
-let g:base16_gui08 = "7c7c7c"
+let g:tinted_gui08 = "7c7c7c"
 let s:gui09        = "999999"
-let g:base16_gui09 = "999999"
+let g:tinted_gui09 = "999999"
 let s:gui0A        = "a0a0a0"
-let g:base16_gui0A = "a0a0a0"
+let g:tinted_gui0A = "a0a0a0"
 let s:gui0B        = "8e8e8e"
-let g:base16_gui0B = "8e8e8e"
+let g:tinted_gui0B = "8e8e8e"
 let s:gui0C        = "868686"
-let g:base16_gui0C = "868686"
+let g:tinted_gui0C = "868686"
 let s:gui0D        = "686868"
-let g:base16_gui0D = "686868"
+let g:tinted_gui0D = "686868"
 let s:gui0E        = "747474"
-let g:base16_gui0E = "747474"
+let g:tinted_gui0E = "747474"
 let s:gui0F        = "5e5e5e"
+let g:tinted_gui0F = "5e5e5e"
+
+" Legacy
+let g:base16_gui00 = "101010"
+let g:base16_gui01 = "252525"
+let g:base16_gui02 = "464646"
+let g:base16_gui03 = "525252"
+let g:base16_gui04 = "ababab"
+let g:base16_gui05 = "b9b9b9"
+let g:base16_gui06 = "e3e3e3"
+let g:base16_gui07 = "f7f7f7"
+let g:base16_gui08 = "7c7c7c"
+let g:base16_gui09 = "999999"
+let g:base16_gui0A = "a0a0a0"
+let g:base16_gui0B = "8e8e8e"
+let g:base16_gui0C = "868686"
+let g:base16_gui0D = "686868"
+let g:base16_gui0E = "747474"
 let g:base16_gui0F = "5e5e5e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f7f7f7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Grayscale Light
 " Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-grayscale-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/grayscale-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/grayscale-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f7f7f7"
-let g:base16_gui00 = "f7f7f7"
+let g:tinted_gui00 = "f7f7f7"
 let s:gui01        = "e3e3e3"
-let g:base16_gui01 = "e3e3e3"
+let g:tinted_gui01 = "e3e3e3"
 let s:gui02        = "b9b9b9"
-let g:base16_gui02 = "b9b9b9"
+let g:tinted_gui02 = "b9b9b9"
 let s:gui03        = "ababab"
-let g:base16_gui03 = "ababab"
+let g:tinted_gui03 = "ababab"
 let s:gui04        = "525252"
-let g:base16_gui04 = "525252"
+let g:tinted_gui04 = "525252"
 let s:gui05        = "464646"
-let g:base16_gui05 = "464646"
+let g:tinted_gui05 = "464646"
 let s:gui06        = "252525"
-let g:base16_gui06 = "252525"
+let g:tinted_gui06 = "252525"
 let s:gui07        = "101010"
-let g:base16_gui07 = "101010"
+let g:tinted_gui07 = "101010"
 let s:gui08        = "7c7c7c"
-let g:base16_gui08 = "7c7c7c"
+let g:tinted_gui08 = "7c7c7c"
 let s:gui09        = "999999"
-let g:base16_gui09 = "999999"
+let g:tinted_gui09 = "999999"
 let s:gui0A        = "a0a0a0"
-let g:base16_gui0A = "a0a0a0"
+let g:tinted_gui0A = "a0a0a0"
 let s:gui0B        = "8e8e8e"
-let g:base16_gui0B = "8e8e8e"
+let g:tinted_gui0B = "8e8e8e"
 let s:gui0C        = "868686"
-let g:base16_gui0C = "868686"
+let g:tinted_gui0C = "868686"
 let s:gui0D        = "686868"
-let g:base16_gui0D = "686868"
+let g:tinted_gui0D = "686868"
 let s:gui0E        = "747474"
-let g:base16_gui0E = "747474"
+let g:tinted_gui0E = "747474"
 let s:gui0F        = "5e5e5e"
+let g:tinted_gui0F = "5e5e5e"
+
+" Legacy
+let g:base16_gui00 = "f7f7f7"
+let g:base16_gui01 = "e3e3e3"
+let g:base16_gui02 = "b9b9b9"
+let g:base16_gui03 = "ababab"
+let g:base16_gui04 = "525252"
+let g:base16_gui05 = "464646"
+let g:base16_gui06 = "252525"
+let g:base16_gui07 = "101010"
+let g:base16_gui08 = "7c7c7c"
+let g:base16_gui09 = "999999"
+let g:base16_gui0A = "a0a0a0"
+let g:base16_gui0B = "8e8e8e"
+let g:base16_gui0C = "868686"
+let g:base16_gui0D = "686868"
+let g:base16_gui0E = "747474"
 let g:base16_gui0F = "5e5e5e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#101010",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Green Screen
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-greenscreen.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/greenscreen.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/greenscreen.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "001100"
-let g:base16_gui00 = "001100"
+let g:tinted_gui00 = "001100"
 let s:gui01        = "003300"
-let g:base16_gui01 = "003300"
+let g:tinted_gui01 = "003300"
 let s:gui02        = "005500"
-let g:base16_gui02 = "005500"
+let g:tinted_gui02 = "005500"
 let s:gui03        = "007700"
-let g:base16_gui03 = "007700"
+let g:tinted_gui03 = "007700"
 let s:gui04        = "009900"
-let g:base16_gui04 = "009900"
+let g:tinted_gui04 = "009900"
 let s:gui05        = "00bb00"
-let g:base16_gui05 = "00bb00"
+let g:tinted_gui05 = "00bb00"
 let s:gui06        = "00dd00"
-let g:base16_gui06 = "00dd00"
+let g:tinted_gui06 = "00dd00"
 let s:gui07        = "00ff00"
-let g:base16_gui07 = "00ff00"
+let g:tinted_gui07 = "00ff00"
 let s:gui08        = "007700"
-let g:base16_gui08 = "007700"
+let g:tinted_gui08 = "007700"
 let s:gui09        = "009900"
-let g:base16_gui09 = "009900"
+let g:tinted_gui09 = "009900"
 let s:gui0A        = "007700"
-let g:base16_gui0A = "007700"
+let g:tinted_gui0A = "007700"
 let s:gui0B        = "00bb00"
-let g:base16_gui0B = "00bb00"
+let g:tinted_gui0B = "00bb00"
 let s:gui0C        = "005500"
-let g:base16_gui0C = "005500"
+let g:tinted_gui0C = "005500"
 let s:gui0D        = "009900"
-let g:base16_gui0D = "009900"
+let g:tinted_gui0D = "009900"
 let s:gui0E        = "00bb00"
-let g:base16_gui0E = "00bb00"
+let g:tinted_gui0E = "00bb00"
 let s:gui0F        = "005500"
+let g:tinted_gui0F = "005500"
+
+" Legacy
+let g:base16_gui00 = "001100"
+let g:base16_gui01 = "003300"
+let g:base16_gui02 = "005500"
+let g:base16_gui03 = "007700"
+let g:base16_gui04 = "009900"
+let g:base16_gui05 = "00bb00"
+let g:base16_gui06 = "00dd00"
+let g:base16_gui07 = "00ff00"
+let g:base16_gui08 = "007700"
+let g:base16_gui09 = "009900"
+let g:base16_gui0A = "007700"
+let g:base16_gui0B = "00bb00"
+let g:base16_gui0C = "005500"
+let g:base16_gui0D = "009900"
+let g:base16_gui0E = "00bb00"
 let g:base16_gui0F = "005500"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#00ff00",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruber.vim
+++ b/colors/base16-gruber.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruber
 " Scheme author: Patel, Nimai &lt;nimai.m.patel@gmail.com&gt;, colors from www.github.com/rexim/gruber-darker-theme
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruber.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruber.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruber.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "181818"
-let g:base16_gui00 = "181818"
+let g:tinted_gui00 = "181818"
 let s:gui01        = "453d41"
-let g:base16_gui01 = "453d41"
+let g:tinted_gui01 = "453d41"
 let s:gui02        = "484848"
-let g:base16_gui02 = "484848"
+let g:tinted_gui02 = "484848"
 let s:gui03        = "52494e"
-let g:base16_gui03 = "52494e"
+let g:tinted_gui03 = "52494e"
 let s:gui04        = "e4e4ef"
-let g:base16_gui04 = "e4e4ef"
+let g:tinted_gui04 = "e4e4ef"
 let s:gui05        = "f4f4ff"
-let g:base16_gui05 = "f4f4ff"
+let g:tinted_gui05 = "f4f4ff"
 let s:gui06        = "f5f5f5"
-let g:base16_gui06 = "f5f5f5"
+let g:tinted_gui06 = "f5f5f5"
 let s:gui07        = "e4e4ef"
-let g:base16_gui07 = "e4e4ef"
+let g:tinted_gui07 = "e4e4ef"
 let s:gui08        = "f43841"
-let g:base16_gui08 = "f43841"
+let g:tinted_gui08 = "f43841"
 let s:gui09        = "c73c3f"
-let g:base16_gui09 = "c73c3f"
+let g:tinted_gui09 = "c73c3f"
 let s:gui0A        = "ffdd33"
-let g:base16_gui0A = "ffdd33"
+let g:tinted_gui0A = "ffdd33"
 let s:gui0B        = "73c936"
-let g:base16_gui0B = "73c936"
+let g:tinted_gui0B = "73c936"
 let s:gui0C        = "95a99f"
-let g:base16_gui0C = "95a99f"
+let g:tinted_gui0C = "95a99f"
 let s:gui0D        = "96a6c8"
-let g:base16_gui0D = "96a6c8"
+let g:tinted_gui0D = "96a6c8"
 let s:gui0E        = "9e95c7"
-let g:base16_gui0E = "9e95c7"
+let g:tinted_gui0E = "9e95c7"
 let s:gui0F        = "cc8c3c"
+let g:tinted_gui0F = "cc8c3c"
+
+" Legacy
+let g:base16_gui00 = "181818"
+let g:base16_gui01 = "453d41"
+let g:base16_gui02 = "484848"
+let g:base16_gui03 = "52494e"
+let g:base16_gui04 = "e4e4ef"
+let g:base16_gui05 = "f4f4ff"
+let g:base16_gui06 = "f5f5f5"
+let g:base16_gui07 = "e4e4ef"
+let g:base16_gui08 = "f43841"
+let g:base16_gui09 = "c73c3f"
+let g:base16_gui0A = "ffdd33"
+let g:base16_gui0B = "73c936"
+let g:base16_gui0C = "95a99f"
+let g:base16_gui0D = "96a6c8"
+let g:base16_gui0E = "9e95c7"
 let g:base16_gui0F = "cc8c3c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e4e4ef",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox dark, hard
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-dark-hard.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-dark-hard.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-dark-hard.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1d2021"
-let g:base16_gui00 = "1d2021"
+let g:tinted_gui00 = "1d2021"
 let s:gui01        = "3c3836"
-let g:base16_gui01 = "3c3836"
+let g:tinted_gui01 = "3c3836"
 let s:gui02        = "504945"
-let g:base16_gui02 = "504945"
+let g:tinted_gui02 = "504945"
 let s:gui03        = "665c54"
-let g:base16_gui03 = "665c54"
+let g:tinted_gui03 = "665c54"
 let s:gui04        = "bdae93"
-let g:base16_gui04 = "bdae93"
+let g:tinted_gui04 = "bdae93"
 let s:gui05        = "d5c4a1"
-let g:base16_gui05 = "d5c4a1"
+let g:tinted_gui05 = "d5c4a1"
 let s:gui06        = "ebdbb2"
-let g:base16_gui06 = "ebdbb2"
+let g:tinted_gui06 = "ebdbb2"
 let s:gui07        = "fbf1c7"
-let g:base16_gui07 = "fbf1c7"
+let g:tinted_gui07 = "fbf1c7"
 let s:gui08        = "fb4934"
-let g:base16_gui08 = "fb4934"
+let g:tinted_gui08 = "fb4934"
 let s:gui09        = "fe8019"
-let g:base16_gui09 = "fe8019"
+let g:tinted_gui09 = "fe8019"
 let s:gui0A        = "fabd2f"
-let g:base16_gui0A = "fabd2f"
+let g:tinted_gui0A = "fabd2f"
 let s:gui0B        = "b8bb26"
-let g:base16_gui0B = "b8bb26"
+let g:tinted_gui0B = "b8bb26"
 let s:gui0C        = "8ec07c"
-let g:base16_gui0C = "8ec07c"
+let g:tinted_gui0C = "8ec07c"
 let s:gui0D        = "83a598"
-let g:base16_gui0D = "83a598"
+let g:tinted_gui0D = "83a598"
 let s:gui0E        = "d3869b"
-let g:base16_gui0E = "d3869b"
+let g:tinted_gui0E = "d3869b"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "1d2021"
+let g:base16_gui01 = "3c3836"
+let g:base16_gui02 = "504945"
+let g:base16_gui03 = "665c54"
+let g:base16_gui04 = "bdae93"
+let g:base16_gui05 = "d5c4a1"
+let g:base16_gui06 = "ebdbb2"
+let g:base16_gui07 = "fbf1c7"
+let g:base16_gui08 = "fb4934"
+let g:base16_gui09 = "fe8019"
+let g:base16_gui0A = "fabd2f"
+let g:base16_gui0B = "b8bb26"
+let g:base16_gui0C = "8ec07c"
+let g:base16_gui0D = "83a598"
+let g:base16_gui0E = "d3869b"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbf1c7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox dark, medium
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-dark-medium.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-dark-medium.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-dark-medium.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282828"
-let g:base16_gui00 = "282828"
+let g:tinted_gui00 = "282828"
 let s:gui01        = "3c3836"
-let g:base16_gui01 = "3c3836"
+let g:tinted_gui01 = "3c3836"
 let s:gui02        = "504945"
-let g:base16_gui02 = "504945"
+let g:tinted_gui02 = "504945"
 let s:gui03        = "665c54"
-let g:base16_gui03 = "665c54"
+let g:tinted_gui03 = "665c54"
 let s:gui04        = "bdae93"
-let g:base16_gui04 = "bdae93"
+let g:tinted_gui04 = "bdae93"
 let s:gui05        = "d5c4a1"
-let g:base16_gui05 = "d5c4a1"
+let g:tinted_gui05 = "d5c4a1"
 let s:gui06        = "ebdbb2"
-let g:base16_gui06 = "ebdbb2"
+let g:tinted_gui06 = "ebdbb2"
 let s:gui07        = "fbf1c7"
-let g:base16_gui07 = "fbf1c7"
+let g:tinted_gui07 = "fbf1c7"
 let s:gui08        = "fb4934"
-let g:base16_gui08 = "fb4934"
+let g:tinted_gui08 = "fb4934"
 let s:gui09        = "fe8019"
-let g:base16_gui09 = "fe8019"
+let g:tinted_gui09 = "fe8019"
 let s:gui0A        = "fabd2f"
-let g:base16_gui0A = "fabd2f"
+let g:tinted_gui0A = "fabd2f"
 let s:gui0B        = "b8bb26"
-let g:base16_gui0B = "b8bb26"
+let g:tinted_gui0B = "b8bb26"
 let s:gui0C        = "8ec07c"
-let g:base16_gui0C = "8ec07c"
+let g:tinted_gui0C = "8ec07c"
 let s:gui0D        = "83a598"
-let g:base16_gui0D = "83a598"
+let g:tinted_gui0D = "83a598"
 let s:gui0E        = "d3869b"
-let g:base16_gui0E = "d3869b"
+let g:tinted_gui0E = "d3869b"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "282828"
+let g:base16_gui01 = "3c3836"
+let g:base16_gui02 = "504945"
+let g:base16_gui03 = "665c54"
+let g:base16_gui04 = "bdae93"
+let g:base16_gui05 = "d5c4a1"
+let g:base16_gui06 = "ebdbb2"
+let g:base16_gui07 = "fbf1c7"
+let g:base16_gui08 = "fb4934"
+let g:base16_gui09 = "fe8019"
+let g:base16_gui0A = "fabd2f"
+let g:base16_gui0B = "b8bb26"
+let g:base16_gui0C = "8ec07c"
+let g:base16_gui0D = "83a598"
+let g:base16_gui0E = "d3869b"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbf1c7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox dark, pale
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-dark-pale.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-dark-pale.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-dark-pale.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "262626"
-let g:base16_gui00 = "262626"
+let g:tinted_gui00 = "262626"
 let s:gui01        = "3a3a3a"
-let g:base16_gui01 = "3a3a3a"
+let g:tinted_gui01 = "3a3a3a"
 let s:gui02        = "4e4e4e"
-let g:base16_gui02 = "4e4e4e"
+let g:tinted_gui02 = "4e4e4e"
 let s:gui03        = "8a8a8a"
-let g:base16_gui03 = "8a8a8a"
+let g:tinted_gui03 = "8a8a8a"
 let s:gui04        = "949494"
-let g:base16_gui04 = "949494"
+let g:tinted_gui04 = "949494"
 let s:gui05        = "dab997"
-let g:base16_gui05 = "dab997"
+let g:tinted_gui05 = "dab997"
 let s:gui06        = "d5c4a1"
-let g:base16_gui06 = "d5c4a1"
+let g:tinted_gui06 = "d5c4a1"
 let s:gui07        = "ebdbb2"
-let g:base16_gui07 = "ebdbb2"
+let g:tinted_gui07 = "ebdbb2"
 let s:gui08        = "d75f5f"
-let g:base16_gui08 = "d75f5f"
+let g:tinted_gui08 = "d75f5f"
 let s:gui09        = "ff8700"
-let g:base16_gui09 = "ff8700"
+let g:tinted_gui09 = "ff8700"
 let s:gui0A        = "ffaf00"
-let g:base16_gui0A = "ffaf00"
+let g:tinted_gui0A = "ffaf00"
 let s:gui0B        = "afaf00"
-let g:base16_gui0B = "afaf00"
+let g:tinted_gui0B = "afaf00"
 let s:gui0C        = "85ad85"
-let g:base16_gui0C = "85ad85"
+let g:tinted_gui0C = "85ad85"
 let s:gui0D        = "83adad"
-let g:base16_gui0D = "83adad"
+let g:tinted_gui0D = "83adad"
 let s:gui0E        = "d485ad"
-let g:base16_gui0E = "d485ad"
+let g:tinted_gui0E = "d485ad"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "262626"
+let g:base16_gui01 = "3a3a3a"
+let g:base16_gui02 = "4e4e4e"
+let g:base16_gui03 = "8a8a8a"
+let g:base16_gui04 = "949494"
+let g:base16_gui05 = "dab997"
+let g:base16_gui06 = "d5c4a1"
+let g:base16_gui07 = "ebdbb2"
+let g:base16_gui08 = "d75f5f"
+let g:base16_gui09 = "ff8700"
+let g:base16_gui0A = "ffaf00"
+let g:base16_gui0B = "afaf00"
+let g:base16_gui0C = "85ad85"
+let g:base16_gui0D = "83adad"
+let g:base16_gui0E = "d485ad"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ebdbb2",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox dark, soft
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-dark-soft.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-dark-soft.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-dark-soft.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "32302f"
-let g:base16_gui00 = "32302f"
+let g:tinted_gui00 = "32302f"
 let s:gui01        = "3c3836"
-let g:base16_gui01 = "3c3836"
+let g:tinted_gui01 = "3c3836"
 let s:gui02        = "504945"
-let g:base16_gui02 = "504945"
+let g:tinted_gui02 = "504945"
 let s:gui03        = "665c54"
-let g:base16_gui03 = "665c54"
+let g:tinted_gui03 = "665c54"
 let s:gui04        = "bdae93"
-let g:base16_gui04 = "bdae93"
+let g:tinted_gui04 = "bdae93"
 let s:gui05        = "d5c4a1"
-let g:base16_gui05 = "d5c4a1"
+let g:tinted_gui05 = "d5c4a1"
 let s:gui06        = "ebdbb2"
-let g:base16_gui06 = "ebdbb2"
+let g:tinted_gui06 = "ebdbb2"
 let s:gui07        = "fbf1c7"
-let g:base16_gui07 = "fbf1c7"
+let g:tinted_gui07 = "fbf1c7"
 let s:gui08        = "fb4934"
-let g:base16_gui08 = "fb4934"
+let g:tinted_gui08 = "fb4934"
 let s:gui09        = "fe8019"
-let g:base16_gui09 = "fe8019"
+let g:tinted_gui09 = "fe8019"
 let s:gui0A        = "fabd2f"
-let g:base16_gui0A = "fabd2f"
+let g:tinted_gui0A = "fabd2f"
 let s:gui0B        = "b8bb26"
-let g:base16_gui0B = "b8bb26"
+let g:tinted_gui0B = "b8bb26"
 let s:gui0C        = "8ec07c"
-let g:base16_gui0C = "8ec07c"
+let g:tinted_gui0C = "8ec07c"
 let s:gui0D        = "83a598"
-let g:base16_gui0D = "83a598"
+let g:tinted_gui0D = "83a598"
 let s:gui0E        = "d3869b"
-let g:base16_gui0E = "d3869b"
+let g:tinted_gui0E = "d3869b"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "32302f"
+let g:base16_gui01 = "3c3836"
+let g:base16_gui02 = "504945"
+let g:base16_gui03 = "665c54"
+let g:base16_gui04 = "bdae93"
+let g:base16_gui05 = "d5c4a1"
+let g:base16_gui06 = "ebdbb2"
+let g:base16_gui07 = "fbf1c7"
+let g:base16_gui08 = "fb4934"
+let g:base16_gui09 = "fe8019"
+let g:base16_gui0A = "fabd2f"
+let g:base16_gui0B = "b8bb26"
+let g:base16_gui0C = "8ec07c"
+let g:base16_gui0D = "83a598"
+let g:base16_gui0E = "d3869b"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbf1c7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox light, hard
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-light-hard.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-light-hard.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-light-hard.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f9f5d7"
-let g:base16_gui00 = "f9f5d7"
+let g:tinted_gui00 = "f9f5d7"
 let s:gui01        = "ebdbb2"
-let g:base16_gui01 = "ebdbb2"
+let g:tinted_gui01 = "ebdbb2"
 let s:gui02        = "d5c4a1"
-let g:base16_gui02 = "d5c4a1"
+let g:tinted_gui02 = "d5c4a1"
 let s:gui03        = "bdae93"
-let g:base16_gui03 = "bdae93"
+let g:tinted_gui03 = "bdae93"
 let s:gui04        = "665c54"
-let g:base16_gui04 = "665c54"
+let g:tinted_gui04 = "665c54"
 let s:gui05        = "504945"
-let g:base16_gui05 = "504945"
+let g:tinted_gui05 = "504945"
 let s:gui06        = "3c3836"
-let g:base16_gui06 = "3c3836"
+let g:tinted_gui06 = "3c3836"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "9d0006"
-let g:base16_gui08 = "9d0006"
+let g:tinted_gui08 = "9d0006"
 let s:gui09        = "af3a03"
-let g:base16_gui09 = "af3a03"
+let g:tinted_gui09 = "af3a03"
 let s:gui0A        = "b57614"
-let g:base16_gui0A = "b57614"
+let g:tinted_gui0A = "b57614"
 let s:gui0B        = "79740e"
-let g:base16_gui0B = "79740e"
+let g:tinted_gui0B = "79740e"
 let s:gui0C        = "427b58"
-let g:base16_gui0C = "427b58"
+let g:tinted_gui0C = "427b58"
 let s:gui0D        = "076678"
-let g:base16_gui0D = "076678"
+let g:tinted_gui0D = "076678"
 let s:gui0E        = "8f3f71"
-let g:base16_gui0E = "8f3f71"
+let g:tinted_gui0E = "8f3f71"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "f9f5d7"
+let g:base16_gui01 = "ebdbb2"
+let g:base16_gui02 = "d5c4a1"
+let g:base16_gui03 = "bdae93"
+let g:base16_gui04 = "665c54"
+let g:base16_gui05 = "504945"
+let g:base16_gui06 = "3c3836"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "9d0006"
+let g:base16_gui09 = "af3a03"
+let g:base16_gui0A = "b57614"
+let g:base16_gui0B = "79740e"
+let g:base16_gui0C = "427b58"
+let g:base16_gui0D = "076678"
+let g:base16_gui0E = "8f3f71"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox light, medium
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-light-medium.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-light-medium.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-light-medium.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fbf1c7"
-let g:base16_gui00 = "fbf1c7"
+let g:tinted_gui00 = "fbf1c7"
 let s:gui01        = "ebdbb2"
-let g:base16_gui01 = "ebdbb2"
+let g:tinted_gui01 = "ebdbb2"
 let s:gui02        = "d5c4a1"
-let g:base16_gui02 = "d5c4a1"
+let g:tinted_gui02 = "d5c4a1"
 let s:gui03        = "bdae93"
-let g:base16_gui03 = "bdae93"
+let g:tinted_gui03 = "bdae93"
 let s:gui04        = "665c54"
-let g:base16_gui04 = "665c54"
+let g:tinted_gui04 = "665c54"
 let s:gui05        = "504945"
-let g:base16_gui05 = "504945"
+let g:tinted_gui05 = "504945"
 let s:gui06        = "3c3836"
-let g:base16_gui06 = "3c3836"
+let g:tinted_gui06 = "3c3836"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "9d0006"
-let g:base16_gui08 = "9d0006"
+let g:tinted_gui08 = "9d0006"
 let s:gui09        = "af3a03"
-let g:base16_gui09 = "af3a03"
+let g:tinted_gui09 = "af3a03"
 let s:gui0A        = "b57614"
-let g:base16_gui0A = "b57614"
+let g:tinted_gui0A = "b57614"
 let s:gui0B        = "79740e"
-let g:base16_gui0B = "79740e"
+let g:tinted_gui0B = "79740e"
 let s:gui0C        = "427b58"
-let g:base16_gui0C = "427b58"
+let g:tinted_gui0C = "427b58"
 let s:gui0D        = "076678"
-let g:base16_gui0D = "076678"
+let g:tinted_gui0D = "076678"
 let s:gui0E        = "8f3f71"
-let g:base16_gui0E = "8f3f71"
+let g:tinted_gui0E = "8f3f71"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "fbf1c7"
+let g:base16_gui01 = "ebdbb2"
+let g:base16_gui02 = "d5c4a1"
+let g:base16_gui03 = "bdae93"
+let g:base16_gui04 = "665c54"
+let g:base16_gui05 = "504945"
+let g:base16_gui06 = "3c3836"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "9d0006"
+let g:base16_gui09 = "af3a03"
+let g:base16_gui0A = "b57614"
+let g:base16_gui0B = "79740e"
+let g:base16_gui0C = "427b58"
+let g:base16_gui0D = "076678"
+let g:base16_gui0E = "8f3f71"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox light, soft
 " Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-light-soft.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-light-soft.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-light-soft.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f2e5bc"
-let g:base16_gui00 = "f2e5bc"
+let g:tinted_gui00 = "f2e5bc"
 let s:gui01        = "ebdbb2"
-let g:base16_gui01 = "ebdbb2"
+let g:tinted_gui01 = "ebdbb2"
 let s:gui02        = "d5c4a1"
-let g:base16_gui02 = "d5c4a1"
+let g:tinted_gui02 = "d5c4a1"
 let s:gui03        = "bdae93"
-let g:base16_gui03 = "bdae93"
+let g:tinted_gui03 = "bdae93"
 let s:gui04        = "665c54"
-let g:base16_gui04 = "665c54"
+let g:tinted_gui04 = "665c54"
 let s:gui05        = "504945"
-let g:base16_gui05 = "504945"
+let g:tinted_gui05 = "504945"
 let s:gui06        = "3c3836"
-let g:base16_gui06 = "3c3836"
+let g:tinted_gui06 = "3c3836"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "9d0006"
-let g:base16_gui08 = "9d0006"
+let g:tinted_gui08 = "9d0006"
 let s:gui09        = "af3a03"
-let g:base16_gui09 = "af3a03"
+let g:tinted_gui09 = "af3a03"
 let s:gui0A        = "b57614"
-let g:base16_gui0A = "b57614"
+let g:tinted_gui0A = "b57614"
 let s:gui0B        = "79740e"
-let g:base16_gui0B = "79740e"
+let g:tinted_gui0B = "79740e"
 let s:gui0C        = "427b58"
-let g:base16_gui0C = "427b58"
+let g:tinted_gui0C = "427b58"
 let s:gui0D        = "076678"
-let g:base16_gui0D = "076678"
+let g:tinted_gui0D = "076678"
 let s:gui0E        = "8f3f71"
-let g:base16_gui0E = "8f3f71"
+let g:tinted_gui0E = "8f3f71"
 let s:gui0F        = "d65d0e"
+let g:tinted_gui0F = "d65d0e"
+
+" Legacy
+let g:base16_gui00 = "f2e5bc"
+let g:base16_gui01 = "ebdbb2"
+let g:base16_gui02 = "d5c4a1"
+let g:base16_gui03 = "bdae93"
+let g:base16_gui04 = "665c54"
+let g:base16_gui05 = "504945"
+let g:base16_gui06 = "3c3836"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "9d0006"
+let g:base16_gui09 = "af3a03"
+let g:base16_gui0A = "b57614"
+let g:base16_gui0B = "79740e"
+let g:base16_gui0C = "427b58"
+let g:base16_gui0D = "076678"
+let g:base16_gui0E = "8f3f71"
 let g:base16_gui0F = "d65d0e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-material-dark-hard.vim
+++ b/colors/base16-gruvbox-material-dark-hard.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox Material Dark, Hard
 " Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-material-dark-hard.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-material-dark-hard.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-material-dark-hard.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "202020"
-let g:base16_gui00 = "202020"
+let g:tinted_gui00 = "202020"
 let s:gui01        = "2a2827"
-let g:base16_gui01 = "2a2827"
+let g:tinted_gui01 = "2a2827"
 let s:gui02        = "504945"
-let g:base16_gui02 = "504945"
+let g:tinted_gui02 = "504945"
 let s:gui03        = "5a524c"
-let g:base16_gui03 = "5a524c"
+let g:tinted_gui03 = "5a524c"
 let s:gui04        = "bdae93"
-let g:base16_gui04 = "bdae93"
+let g:tinted_gui04 = "bdae93"
 let s:gui05        = "ddc7a1"
-let g:base16_gui05 = "ddc7a1"
+let g:tinted_gui05 = "ddc7a1"
 let s:gui06        = "ebdbb2"
-let g:base16_gui06 = "ebdbb2"
+let g:tinted_gui06 = "ebdbb2"
 let s:gui07        = "fbf1c7"
-let g:base16_gui07 = "fbf1c7"
+let g:tinted_gui07 = "fbf1c7"
 let s:gui08        = "ea6962"
-let g:base16_gui08 = "ea6962"
+let g:tinted_gui08 = "ea6962"
 let s:gui09        = "e78a4e"
-let g:base16_gui09 = "e78a4e"
+let g:tinted_gui09 = "e78a4e"
 let s:gui0A        = "d8a657"
-let g:base16_gui0A = "d8a657"
+let g:tinted_gui0A = "d8a657"
 let s:gui0B        = "a9b665"
-let g:base16_gui0B = "a9b665"
+let g:tinted_gui0B = "a9b665"
 let s:gui0C        = "89b482"
-let g:base16_gui0C = "89b482"
+let g:tinted_gui0C = "89b482"
 let s:gui0D        = "7daea3"
-let g:base16_gui0D = "7daea3"
+let g:tinted_gui0D = "7daea3"
 let s:gui0E        = "d3869b"
-let g:base16_gui0E = "d3869b"
+let g:tinted_gui0E = "d3869b"
 let s:gui0F        = "bd6f3e"
+let g:tinted_gui0F = "bd6f3e"
+
+" Legacy
+let g:base16_gui00 = "202020"
+let g:base16_gui01 = "2a2827"
+let g:base16_gui02 = "504945"
+let g:base16_gui03 = "5a524c"
+let g:base16_gui04 = "bdae93"
+let g:base16_gui05 = "ddc7a1"
+let g:base16_gui06 = "ebdbb2"
+let g:base16_gui07 = "fbf1c7"
+let g:base16_gui08 = "ea6962"
+let g:base16_gui09 = "e78a4e"
+let g:base16_gui0A = "d8a657"
+let g:base16_gui0B = "a9b665"
+let g:base16_gui0C = "89b482"
+let g:base16_gui0D = "7daea3"
+let g:base16_gui0E = "d3869b"
 let g:base16_gui0F = "bd6f3e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbf1c7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-material-dark-medium.vim
+++ b/colors/base16-gruvbox-material-dark-medium.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox Material Dark, Medium
 " Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-material-dark-medium.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-material-dark-medium.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-material-dark-medium.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "292828"
-let g:base16_gui00 = "292828"
+let g:tinted_gui00 = "292828"
 let s:gui01        = "32302f"
-let g:base16_gui01 = "32302f"
+let g:tinted_gui01 = "32302f"
 let s:gui02        = "504945"
-let g:base16_gui02 = "504945"
+let g:tinted_gui02 = "504945"
 let s:gui03        = "665c54"
-let g:base16_gui03 = "665c54"
+let g:tinted_gui03 = "665c54"
 let s:gui04        = "bdae93"
-let g:base16_gui04 = "bdae93"
+let g:tinted_gui04 = "bdae93"
 let s:gui05        = "ddc7a1"
-let g:base16_gui05 = "ddc7a1"
+let g:tinted_gui05 = "ddc7a1"
 let s:gui06        = "ebdbb2"
-let g:base16_gui06 = "ebdbb2"
+let g:tinted_gui06 = "ebdbb2"
 let s:gui07        = "fbf1c7"
-let g:base16_gui07 = "fbf1c7"
+let g:tinted_gui07 = "fbf1c7"
 let s:gui08        = "ea6962"
-let g:base16_gui08 = "ea6962"
+let g:tinted_gui08 = "ea6962"
 let s:gui09        = "e78a4e"
-let g:base16_gui09 = "e78a4e"
+let g:tinted_gui09 = "e78a4e"
 let s:gui0A        = "d8a657"
-let g:base16_gui0A = "d8a657"
+let g:tinted_gui0A = "d8a657"
 let s:gui0B        = "a9b665"
-let g:base16_gui0B = "a9b665"
+let g:tinted_gui0B = "a9b665"
 let s:gui0C        = "89b482"
-let g:base16_gui0C = "89b482"
+let g:tinted_gui0C = "89b482"
 let s:gui0D        = "7daea3"
-let g:base16_gui0D = "7daea3"
+let g:tinted_gui0D = "7daea3"
 let s:gui0E        = "d3869b"
-let g:base16_gui0E = "d3869b"
+let g:tinted_gui0E = "d3869b"
 let s:gui0F        = "bd6f3e"
+let g:tinted_gui0F = "bd6f3e"
+
+" Legacy
+let g:base16_gui00 = "292828"
+let g:base16_gui01 = "32302f"
+let g:base16_gui02 = "504945"
+let g:base16_gui03 = "665c54"
+let g:base16_gui04 = "bdae93"
+let g:base16_gui05 = "ddc7a1"
+let g:base16_gui06 = "ebdbb2"
+let g:base16_gui07 = "fbf1c7"
+let g:base16_gui08 = "ea6962"
+let g:base16_gui09 = "e78a4e"
+let g:base16_gui0A = "d8a657"
+let g:base16_gui0B = "a9b665"
+let g:base16_gui0C = "89b482"
+let g:base16_gui0D = "7daea3"
+let g:base16_gui0E = "d3869b"
 let g:base16_gui0F = "bd6f3e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbf1c7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-material-dark-soft.vim
+++ b/colors/base16-gruvbox-material-dark-soft.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox Material Dark, Soft
 " Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-material-dark-soft.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-material-dark-soft.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-material-dark-soft.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "32302f"
-let g:base16_gui00 = "32302f"
+let g:tinted_gui00 = "32302f"
 let s:gui01        = "3c3836"
-let g:base16_gui01 = "3c3836"
+let g:tinted_gui01 = "3c3836"
 let s:gui02        = "5a524c"
-let g:base16_gui02 = "5a524c"
+let g:tinted_gui02 = "5a524c"
 let s:gui03        = "7c6f64"
-let g:base16_gui03 = "7c6f64"
+let g:tinted_gui03 = "7c6f64"
 let s:gui04        = "bdae93"
-let g:base16_gui04 = "bdae93"
+let g:tinted_gui04 = "bdae93"
 let s:gui05        = "ddc7a1"
-let g:base16_gui05 = "ddc7a1"
+let g:tinted_gui05 = "ddc7a1"
 let s:gui06        = "ebdbb2"
-let g:base16_gui06 = "ebdbb2"
+let g:tinted_gui06 = "ebdbb2"
 let s:gui07        = "fbf1c7"
-let g:base16_gui07 = "fbf1c7"
+let g:tinted_gui07 = "fbf1c7"
 let s:gui08        = "ea6962"
-let g:base16_gui08 = "ea6962"
+let g:tinted_gui08 = "ea6962"
 let s:gui09        = "e78a4e"
-let g:base16_gui09 = "e78a4e"
+let g:tinted_gui09 = "e78a4e"
 let s:gui0A        = "d8a657"
-let g:base16_gui0A = "d8a657"
+let g:tinted_gui0A = "d8a657"
 let s:gui0B        = "a9b665"
-let g:base16_gui0B = "a9b665"
+let g:tinted_gui0B = "a9b665"
 let s:gui0C        = "89b482"
-let g:base16_gui0C = "89b482"
+let g:tinted_gui0C = "89b482"
 let s:gui0D        = "7daea3"
-let g:base16_gui0D = "7daea3"
+let g:tinted_gui0D = "7daea3"
 let s:gui0E        = "d3869b"
-let g:base16_gui0E = "d3869b"
+let g:tinted_gui0E = "d3869b"
 let s:gui0F        = "bd6f3e"
+let g:tinted_gui0F = "bd6f3e"
+
+" Legacy
+let g:base16_gui00 = "32302f"
+let g:base16_gui01 = "3c3836"
+let g:base16_gui02 = "5a524c"
+let g:base16_gui03 = "7c6f64"
+let g:base16_gui04 = "bdae93"
+let g:base16_gui05 = "ddc7a1"
+let g:base16_gui06 = "ebdbb2"
+let g:base16_gui07 = "fbf1c7"
+let g:base16_gui08 = "ea6962"
+let g:base16_gui09 = "e78a4e"
+let g:base16_gui0A = "d8a657"
+let g:base16_gui0B = "a9b665"
+let g:base16_gui0C = "89b482"
+let g:base16_gui0D = "7daea3"
+let g:base16_gui0E = "d3869b"
 let g:base16_gui0F = "bd6f3e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbf1c7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-material-light-hard.vim
+++ b/colors/base16-gruvbox-material-light-hard.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox Material Light, Hard
 " Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-material-light-hard.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-material-light-hard.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-material-light-hard.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f9f5d7"
-let g:base16_gui00 = "f9f5d7"
+let g:tinted_gui00 = "f9f5d7"
 let s:gui01        = "fbf1c7"
-let g:base16_gui01 = "fbf1c7"
+let g:tinted_gui01 = "fbf1c7"
 let s:gui02        = "e0cfa9"
-let g:base16_gui02 = "e0cfa9"
+let g:tinted_gui02 = "e0cfa9"
 let s:gui03        = "a89984"
-let g:base16_gui03 = "a89984"
+let g:tinted_gui03 = "a89984"
 let s:gui04        = "c9b99a"
-let g:base16_gui04 = "c9b99a"
+let g:tinted_gui04 = "c9b99a"
 let s:gui05        = "654735"
-let g:base16_gui05 = "654735"
+let g:tinted_gui05 = "654735"
 let s:gui06        = "3c3836"
-let g:base16_gui06 = "3c3836"
+let g:tinted_gui06 = "3c3836"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "c14a4a"
-let g:base16_gui08 = "c14a4a"
+let g:tinted_gui08 = "c14a4a"
 let s:gui09        = "c35e0a"
-let g:base16_gui09 = "c35e0a"
+let g:tinted_gui09 = "c35e0a"
 let s:gui0A        = "b47109"
-let g:base16_gui0A = "b47109"
+let g:tinted_gui0A = "b47109"
 let s:gui0B        = "6c782e"
-let g:base16_gui0B = "6c782e"
+let g:tinted_gui0B = "6c782e"
 let s:gui0C        = "4c7a5d"
-let g:base16_gui0C = "4c7a5d"
+let g:tinted_gui0C = "4c7a5d"
 let s:gui0D        = "45707a"
-let g:base16_gui0D = "45707a"
+let g:tinted_gui0D = "45707a"
 let s:gui0E        = "945e80"
-let g:base16_gui0E = "945e80"
+let g:tinted_gui0E = "945e80"
 let s:gui0F        = "e78a4e"
+let g:tinted_gui0F = "e78a4e"
+
+" Legacy
+let g:base16_gui00 = "f9f5d7"
+let g:base16_gui01 = "fbf1c7"
+let g:base16_gui02 = "e0cfa9"
+let g:base16_gui03 = "a89984"
+let g:base16_gui04 = "c9b99a"
+let g:base16_gui05 = "654735"
+let g:base16_gui06 = "3c3836"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "c14a4a"
+let g:base16_gui09 = "c35e0a"
+let g:base16_gui0A = "b47109"
+let g:base16_gui0B = "6c782e"
+let g:base16_gui0C = "4c7a5d"
+let g:base16_gui0D = "45707a"
+let g:base16_gui0E = "945e80"
 let g:base16_gui0F = "e78a4e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-material-light-medium.vim
+++ b/colors/base16-gruvbox-material-light-medium.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox Material Light, Medium
 " Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-material-light-medium.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-material-light-medium.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-material-light-medium.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fbf1c7"
-let g:base16_gui00 = "fbf1c7"
+let g:tinted_gui00 = "fbf1c7"
 let s:gui01        = "f2e5bc"
-let g:base16_gui01 = "f2e5bc"
+let g:tinted_gui01 = "f2e5bc"
 let s:gui02        = "d5c4a1"
-let g:base16_gui02 = "d5c4a1"
+let g:tinted_gui02 = "d5c4a1"
 let s:gui03        = "bdae93"
-let g:base16_gui03 = "bdae93"
+let g:tinted_gui03 = "bdae93"
 let s:gui04        = "665c54"
-let g:base16_gui04 = "665c54"
+let g:tinted_gui04 = "665c54"
 let s:gui05        = "654735"
-let g:base16_gui05 = "654735"
+let g:tinted_gui05 = "654735"
 let s:gui06        = "3c3836"
-let g:base16_gui06 = "3c3836"
+let g:tinted_gui06 = "3c3836"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "c14a4a"
-let g:base16_gui08 = "c14a4a"
+let g:tinted_gui08 = "c14a4a"
 let s:gui09        = "c35e0a"
-let g:base16_gui09 = "c35e0a"
+let g:tinted_gui09 = "c35e0a"
 let s:gui0A        = "b47109"
-let g:base16_gui0A = "b47109"
+let g:tinted_gui0A = "b47109"
 let s:gui0B        = "6c782e"
-let g:base16_gui0B = "6c782e"
+let g:tinted_gui0B = "6c782e"
 let s:gui0C        = "4c7a5d"
-let g:base16_gui0C = "4c7a5d"
+let g:tinted_gui0C = "4c7a5d"
 let s:gui0D        = "45707a"
-let g:base16_gui0D = "45707a"
+let g:tinted_gui0D = "45707a"
 let s:gui0E        = "945e80"
-let g:base16_gui0E = "945e80"
+let g:tinted_gui0E = "945e80"
 let s:gui0F        = "e78a4e"
+let g:tinted_gui0F = "e78a4e"
+
+" Legacy
+let g:base16_gui00 = "fbf1c7"
+let g:base16_gui01 = "f2e5bc"
+let g:base16_gui02 = "d5c4a1"
+let g:base16_gui03 = "bdae93"
+let g:base16_gui04 = "665c54"
+let g:base16_gui05 = "654735"
+let g:base16_gui06 = "3c3836"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "c14a4a"
+let g:base16_gui09 = "c35e0a"
+let g:base16_gui0A = "b47109"
+let g:base16_gui0B = "6c782e"
+let g:base16_gui0C = "4c7a5d"
+let g:base16_gui0D = "45707a"
+let g:base16_gui0E = "945e80"
 let g:base16_gui0F = "e78a4e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-gruvbox-material-light-soft.vim
+++ b/colors/base16-gruvbox-material-light-soft.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Gruvbox Material Light, Soft
 " Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-gruvbox-material-light-soft.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/gruvbox-material-light-soft.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/gruvbox-material-light-soft.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f2e5bc"
-let g:base16_gui00 = "f2e5bc"
+let g:tinted_gui00 = "f2e5bc"
 let s:gui01        = "ebdbb2"
-let g:base16_gui01 = "ebdbb2"
+let g:tinted_gui01 = "ebdbb2"
 let s:gui02        = "c9b99a"
-let g:base16_gui02 = "c9b99a"
+let g:tinted_gui02 = "c9b99a"
 let s:gui03        = "a89984"
-let g:base16_gui03 = "a89984"
+let g:tinted_gui03 = "a89984"
 let s:gui04        = "665c54"
-let g:base16_gui04 = "665c54"
+let g:tinted_gui04 = "665c54"
 let s:gui05        = "654735"
-let g:base16_gui05 = "654735"
+let g:tinted_gui05 = "654735"
 let s:gui06        = "3c3836"
-let g:base16_gui06 = "3c3836"
+let g:tinted_gui06 = "3c3836"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "c14a4a"
-let g:base16_gui08 = "c14a4a"
+let g:tinted_gui08 = "c14a4a"
 let s:gui09        = "c35e0a"
-let g:base16_gui09 = "c35e0a"
+let g:tinted_gui09 = "c35e0a"
 let s:gui0A        = "b47109"
-let g:base16_gui0A = "b47109"
+let g:tinted_gui0A = "b47109"
 let s:gui0B        = "6c782e"
-let g:base16_gui0B = "6c782e"
+let g:tinted_gui0B = "6c782e"
 let s:gui0C        = "4c7a5d"
-let g:base16_gui0C = "4c7a5d"
+let g:tinted_gui0C = "4c7a5d"
 let s:gui0D        = "45707a"
-let g:base16_gui0D = "45707a"
+let g:tinted_gui0D = "45707a"
 let s:gui0E        = "945e80"
-let g:base16_gui0E = "945e80"
+let g:tinted_gui0E = "945e80"
 let s:gui0F        = "e78a4e"
+let g:tinted_gui0F = "e78a4e"
+
+" Legacy
+let g:base16_gui00 = "f2e5bc"
+let g:base16_gui01 = "ebdbb2"
+let g:base16_gui02 = "c9b99a"
+let g:base16_gui03 = "a89984"
+let g:base16_gui04 = "665c54"
+let g:base16_gui05 = "654735"
+let g:base16_gui06 = "3c3836"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "c14a4a"
+let g:base16_gui09 = "c35e0a"
+let g:base16_gui0A = "b47109"
+let g:base16_gui0B = "6c782e"
+let g:base16_gui0C = "4c7a5d"
+let g:base16_gui0D = "45707a"
+let g:base16_gui0E = "945e80"
 let g:base16_gui0F = "e78a4e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Hardcore
 " Scheme author: Chris Caller
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-hardcore.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/hardcore.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/hardcore.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "212121"
-let g:base16_gui00 = "212121"
+let g:tinted_gui00 = "212121"
 let s:gui01        = "303030"
-let g:base16_gui01 = "303030"
+let g:tinted_gui01 = "303030"
 let s:gui02        = "353535"
-let g:base16_gui02 = "353535"
+let g:tinted_gui02 = "353535"
 let s:gui03        = "4a4a4a"
-let g:base16_gui03 = "4a4a4a"
+let g:tinted_gui03 = "4a4a4a"
 let s:gui04        = "707070"
-let g:base16_gui04 = "707070"
+let g:tinted_gui04 = "707070"
 let s:gui05        = "cdcdcd"
-let g:base16_gui05 = "cdcdcd"
+let g:tinted_gui05 = "cdcdcd"
 let s:gui06        = "e5e5e5"
-let g:base16_gui06 = "e5e5e5"
+let g:tinted_gui06 = "e5e5e5"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f92672"
-let g:base16_gui08 = "f92672"
+let g:tinted_gui08 = "f92672"
 let s:gui09        = "fd971f"
-let g:base16_gui09 = "fd971f"
+let g:tinted_gui09 = "fd971f"
 let s:gui0A        = "e6db74"
-let g:base16_gui0A = "e6db74"
+let g:tinted_gui0A = "e6db74"
 let s:gui0B        = "a6e22e"
-let g:base16_gui0B = "a6e22e"
+let g:tinted_gui0B = "a6e22e"
 let s:gui0C        = "708387"
-let g:base16_gui0C = "708387"
+let g:tinted_gui0C = "708387"
 let s:gui0D        = "66d9ef"
-let g:base16_gui0D = "66d9ef"
+let g:tinted_gui0D = "66d9ef"
 let s:gui0E        = "9e6ffe"
-let g:base16_gui0E = "9e6ffe"
+let g:tinted_gui0E = "9e6ffe"
 let s:gui0F        = "e8b882"
+let g:tinted_gui0F = "e8b882"
+
+" Legacy
+let g:base16_gui00 = "212121"
+let g:base16_gui01 = "303030"
+let g:base16_gui02 = "353535"
+let g:base16_gui03 = "4a4a4a"
+let g:base16_gui04 = "707070"
+let g:base16_gui05 = "cdcdcd"
+let g:base16_gui06 = "e5e5e5"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f92672"
+let g:base16_gui09 = "fd971f"
+let g:base16_gui0A = "e6db74"
+let g:base16_gui0B = "a6e22e"
+let g:base16_gui0C = "708387"
+let g:base16_gui0D = "66d9ef"
+let g:base16_gui0E = "9e6ffe"
 let g:base16_gui0F = "e8b882"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-harmonic16-dark.vim
+++ b/colors/base16-harmonic16-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Harmonic16 Dark
 " Scheme author: Jannik Siebert (https://github.com/janniks)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-harmonic16-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/harmonic16-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/harmonic16-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0b1c2c"
-let g:base16_gui00 = "0b1c2c"
+let g:tinted_gui00 = "0b1c2c"
 let s:gui01        = "223b54"
-let g:base16_gui01 = "223b54"
+let g:tinted_gui01 = "223b54"
 let s:gui02        = "405c79"
-let g:base16_gui02 = "405c79"
+let g:tinted_gui02 = "405c79"
 let s:gui03        = "627e99"
-let g:base16_gui03 = "627e99"
+let g:tinted_gui03 = "627e99"
 let s:gui04        = "aabcce"
-let g:base16_gui04 = "aabcce"
+let g:tinted_gui04 = "aabcce"
 let s:gui05        = "cbd6e2"
-let g:base16_gui05 = "cbd6e2"
+let g:tinted_gui05 = "cbd6e2"
 let s:gui06        = "e5ebf1"
-let g:base16_gui06 = "e5ebf1"
+let g:tinted_gui06 = "e5ebf1"
 let s:gui07        = "f7f9fb"
-let g:base16_gui07 = "f7f9fb"
+let g:tinted_gui07 = "f7f9fb"
 let s:gui08        = "bf8b56"
-let g:base16_gui08 = "bf8b56"
+let g:tinted_gui08 = "bf8b56"
 let s:gui09        = "bfbf56"
-let g:base16_gui09 = "bfbf56"
+let g:tinted_gui09 = "bfbf56"
 let s:gui0A        = "8bbf56"
-let g:base16_gui0A = "8bbf56"
+let g:tinted_gui0A = "8bbf56"
 let s:gui0B        = "56bf8b"
-let g:base16_gui0B = "56bf8b"
+let g:tinted_gui0B = "56bf8b"
 let s:gui0C        = "568bbf"
-let g:base16_gui0C = "568bbf"
+let g:tinted_gui0C = "568bbf"
 let s:gui0D        = "8b56bf"
-let g:base16_gui0D = "8b56bf"
+let g:tinted_gui0D = "8b56bf"
 let s:gui0E        = "bf568b"
-let g:base16_gui0E = "bf568b"
+let g:tinted_gui0E = "bf568b"
 let s:gui0F        = "bf5656"
+let g:tinted_gui0F = "bf5656"
+
+" Legacy
+let g:base16_gui00 = "0b1c2c"
+let g:base16_gui01 = "223b54"
+let g:base16_gui02 = "405c79"
+let g:base16_gui03 = "627e99"
+let g:base16_gui04 = "aabcce"
+let g:base16_gui05 = "cbd6e2"
+let g:base16_gui06 = "e5ebf1"
+let g:base16_gui07 = "f7f9fb"
+let g:base16_gui08 = "bf8b56"
+let g:base16_gui09 = "bfbf56"
+let g:base16_gui0A = "8bbf56"
+let g:base16_gui0B = "56bf8b"
+let g:base16_gui0C = "568bbf"
+let g:base16_gui0D = "8b56bf"
+let g:base16_gui0E = "bf568b"
 let g:base16_gui0F = "bf5656"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f7f9fb",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-harmonic16-light.vim
+++ b/colors/base16-harmonic16-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Harmonic16 Light
 " Scheme author: Jannik Siebert (https://github.com/janniks)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-harmonic16-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/harmonic16-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/harmonic16-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f7f9fb"
-let g:base16_gui00 = "f7f9fb"
+let g:tinted_gui00 = "f7f9fb"
 let s:gui01        = "e5ebf1"
-let g:base16_gui01 = "e5ebf1"
+let g:tinted_gui01 = "e5ebf1"
 let s:gui02        = "cbd6e2"
-let g:base16_gui02 = "cbd6e2"
+let g:tinted_gui02 = "cbd6e2"
 let s:gui03        = "aabcce"
-let g:base16_gui03 = "aabcce"
+let g:tinted_gui03 = "aabcce"
 let s:gui04        = "627e99"
-let g:base16_gui04 = "627e99"
+let g:tinted_gui04 = "627e99"
 let s:gui05        = "405c79"
-let g:base16_gui05 = "405c79"
+let g:tinted_gui05 = "405c79"
 let s:gui06        = "223b54"
-let g:base16_gui06 = "223b54"
+let g:tinted_gui06 = "223b54"
 let s:gui07        = "0b1c2c"
-let g:base16_gui07 = "0b1c2c"
+let g:tinted_gui07 = "0b1c2c"
 let s:gui08        = "bf8b56"
-let g:base16_gui08 = "bf8b56"
+let g:tinted_gui08 = "bf8b56"
 let s:gui09        = "bfbf56"
-let g:base16_gui09 = "bfbf56"
+let g:tinted_gui09 = "bfbf56"
 let s:gui0A        = "8bbf56"
-let g:base16_gui0A = "8bbf56"
+let g:tinted_gui0A = "8bbf56"
 let s:gui0B        = "56bf8b"
-let g:base16_gui0B = "56bf8b"
+let g:tinted_gui0B = "56bf8b"
 let s:gui0C        = "568bbf"
-let g:base16_gui0C = "568bbf"
+let g:tinted_gui0C = "568bbf"
 let s:gui0D        = "8b56bf"
-let g:base16_gui0D = "8b56bf"
+let g:tinted_gui0D = "8b56bf"
 let s:gui0E        = "bf568b"
-let g:base16_gui0E = "bf568b"
+let g:tinted_gui0E = "bf568b"
 let s:gui0F        = "bf5656"
+let g:tinted_gui0F = "bf5656"
+
+" Legacy
+let g:base16_gui00 = "f7f9fb"
+let g:base16_gui01 = "e5ebf1"
+let g:base16_gui02 = "cbd6e2"
+let g:base16_gui03 = "aabcce"
+let g:base16_gui04 = "627e99"
+let g:base16_gui05 = "405c79"
+let g:base16_gui06 = "223b54"
+let g:base16_gui07 = "0b1c2c"
+let g:base16_gui08 = "bf8b56"
+let g:base16_gui09 = "bfbf56"
+let g:base16_gui0A = "8bbf56"
+let g:base16_gui0B = "56bf8b"
+let g:base16_gui0C = "568bbf"
+let g:base16_gui0D = "8b56bf"
+let g:base16_gui0E = "bf568b"
 let g:base16_gui0F = "bf5656"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#0b1c2c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Heetch Light
 " Scheme author: Geoffrey Teale (tealeg@gmail.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-heetch-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/heetch-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/heetch-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "feffff"
-let g:base16_gui00 = "feffff"
+let g:tinted_gui00 = "feffff"
 let s:gui01        = "392551"
-let g:base16_gui01 = "392551"
+let g:tinted_gui01 = "392551"
 let s:gui02        = "7b6d8b"
-let g:base16_gui02 = "7b6d8b"
+let g:tinted_gui02 = "7b6d8b"
 let s:gui03        = "9c92a8"
-let g:base16_gui03 = "9c92a8"
+let g:tinted_gui03 = "9c92a8"
 let s:gui04        = "ddd6e5"
-let g:base16_gui04 = "ddd6e5"
+let g:tinted_gui04 = "ddd6e5"
 let s:gui05        = "5a496e"
-let g:base16_gui05 = "5a496e"
+let g:tinted_gui05 = "5a496e"
 let s:gui06        = "470546"
-let g:base16_gui06 = "470546"
+let g:tinted_gui06 = "470546"
 let s:gui07        = "190134"
-let g:base16_gui07 = "190134"
+let g:tinted_gui07 = "190134"
 let s:gui08        = "27d9d5"
-let g:base16_gui08 = "27d9d5"
+let g:tinted_gui08 = "27d9d5"
 let s:gui09        = "bdb6c5"
-let g:base16_gui09 = "bdb6c5"
+let g:tinted_gui09 = "bdb6c5"
 let s:gui0A        = "5ba2b6"
-let g:base16_gui0A = "5ba2b6"
+let g:tinted_gui0A = "5ba2b6"
 let s:gui0B        = "f80059"
-let g:base16_gui0B = "f80059"
+let g:tinted_gui0B = "f80059"
 let s:gui0C        = "c33678"
-let g:base16_gui0C = "c33678"
+let g:tinted_gui0C = "c33678"
 let s:gui0D        = "47f9f5"
-let g:base16_gui0D = "47f9f5"
+let g:tinted_gui0D = "47f9f5"
 let s:gui0E        = "bd0152"
-let g:base16_gui0E = "bd0152"
+let g:tinted_gui0E = "bd0152"
 let s:gui0F        = "dedae2"
+let g:tinted_gui0F = "dedae2"
+
+" Legacy
+let g:base16_gui00 = "feffff"
+let g:base16_gui01 = "392551"
+let g:base16_gui02 = "7b6d8b"
+let g:base16_gui03 = "9c92a8"
+let g:base16_gui04 = "ddd6e5"
+let g:base16_gui05 = "5a496e"
+let g:base16_gui06 = "470546"
+let g:base16_gui07 = "190134"
+let g:base16_gui08 = "27d9d5"
+let g:base16_gui09 = "bdb6c5"
+let g:base16_gui0A = "5ba2b6"
+let g:base16_gui0B = "f80059"
+let g:base16_gui0C = "c33678"
+let g:base16_gui0D = "47f9f5"
+let g:base16_gui0E = "bd0152"
 let g:base16_gui0F = "dedae2"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#190134",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Heetch Dark
 " Scheme author: Geoffrey Teale (tealeg@gmail.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-heetch.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/heetch.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/heetch.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "190134"
-let g:base16_gui00 = "190134"
+let g:tinted_gui00 = "190134"
 let s:gui01        = "392551"
-let g:base16_gui01 = "392551"
+let g:tinted_gui01 = "392551"
 let s:gui02        = "5a496e"
-let g:base16_gui02 = "5a496e"
+let g:tinted_gui02 = "5a496e"
 let s:gui03        = "7b6d8b"
-let g:base16_gui03 = "7b6d8b"
+let g:tinted_gui03 = "7b6d8b"
 let s:gui04        = "9c92a8"
-let g:base16_gui04 = "9c92a8"
+let g:tinted_gui04 = "9c92a8"
 let s:gui05        = "bdb6c5"
-let g:base16_gui05 = "bdb6c5"
+let g:tinted_gui05 = "bdb6c5"
 let s:gui06        = "dedae2"
-let g:base16_gui06 = "dedae2"
+let g:tinted_gui06 = "dedae2"
 let s:gui07        = "feffff"
-let g:base16_gui07 = "feffff"
+let g:tinted_gui07 = "feffff"
 let s:gui08        = "27d9d5"
-let g:base16_gui08 = "27d9d5"
+let g:tinted_gui08 = "27d9d5"
 let s:gui09        = "5ba2b6"
-let g:base16_gui09 = "5ba2b6"
+let g:tinted_gui09 = "5ba2b6"
 let s:gui0A        = "8f6c97"
-let g:base16_gui0A = "8f6c97"
+let g:tinted_gui0A = "8f6c97"
 let s:gui0B        = "c33678"
-let g:base16_gui0B = "c33678"
+let g:tinted_gui0B = "c33678"
 let s:gui0C        = "f80059"
-let g:base16_gui0C = "f80059"
+let g:tinted_gui0C = "f80059"
 let s:gui0D        = "bd0152"
-let g:base16_gui0D = "bd0152"
+let g:tinted_gui0D = "bd0152"
 let s:gui0E        = "82034c"
-let g:base16_gui0E = "82034c"
+let g:tinted_gui0E = "82034c"
 let s:gui0F        = "470546"
+let g:tinted_gui0F = "470546"
+
+" Legacy
+let g:base16_gui00 = "190134"
+let g:base16_gui01 = "392551"
+let g:base16_gui02 = "5a496e"
+let g:base16_gui03 = "7b6d8b"
+let g:base16_gui04 = "9c92a8"
+let g:base16_gui05 = "bdb6c5"
+let g:base16_gui06 = "dedae2"
+let g:base16_gui07 = "feffff"
+let g:base16_gui08 = "27d9d5"
+let g:base16_gui09 = "5ba2b6"
+let g:base16_gui0A = "8f6c97"
+let g:base16_gui0B = "c33678"
+let g:base16_gui0C = "f80059"
+let g:base16_gui0D = "bd0152"
+let g:base16_gui0E = "82034c"
 let g:base16_gui0F = "470546"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#feffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Helios
 " Scheme author: Alex Meyer (https://github.com/reyemxela)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-helios.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/helios.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/helios.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1d2021"
-let g:base16_gui00 = "1d2021"
+let g:tinted_gui00 = "1d2021"
 let s:gui01        = "383c3e"
-let g:base16_gui01 = "383c3e"
+let g:tinted_gui01 = "383c3e"
 let s:gui02        = "53585b"
-let g:base16_gui02 = "53585b"
+let g:tinted_gui02 = "53585b"
 let s:gui03        = "6f7579"
-let g:base16_gui03 = "6f7579"
+let g:tinted_gui03 = "6f7579"
 let s:gui04        = "cdcdcd"
-let g:base16_gui04 = "cdcdcd"
+let g:tinted_gui04 = "cdcdcd"
 let s:gui05        = "d5d5d5"
-let g:base16_gui05 = "d5d5d5"
+let g:tinted_gui05 = "d5d5d5"
 let s:gui06        = "dddddd"
-let g:base16_gui06 = "dddddd"
+let g:tinted_gui06 = "dddddd"
 let s:gui07        = "e5e5e5"
-let g:base16_gui07 = "e5e5e5"
+let g:tinted_gui07 = "e5e5e5"
 let s:gui08        = "d72638"
-let g:base16_gui08 = "d72638"
+let g:tinted_gui08 = "d72638"
 let s:gui09        = "eb8413"
-let g:base16_gui09 = "eb8413"
+let g:tinted_gui09 = "eb8413"
 let s:gui0A        = "f19d1a"
-let g:base16_gui0A = "f19d1a"
+let g:tinted_gui0A = "f19d1a"
 let s:gui0B        = "88b92d"
-let g:base16_gui0B = "88b92d"
+let g:tinted_gui0B = "88b92d"
 let s:gui0C        = "1ba595"
-let g:base16_gui0C = "1ba595"
+let g:tinted_gui0C = "1ba595"
 let s:gui0D        = "1e8bac"
-let g:base16_gui0D = "1e8bac"
+let g:tinted_gui0D = "1e8bac"
 let s:gui0E        = "be4264"
-let g:base16_gui0E = "be4264"
+let g:tinted_gui0E = "be4264"
 let s:gui0F        = "c85e0d"
+let g:tinted_gui0F = "c85e0d"
+
+" Legacy
+let g:base16_gui00 = "1d2021"
+let g:base16_gui01 = "383c3e"
+let g:base16_gui02 = "53585b"
+let g:base16_gui03 = "6f7579"
+let g:base16_gui04 = "cdcdcd"
+let g:base16_gui05 = "d5d5d5"
+let g:base16_gui06 = "dddddd"
+let g:base16_gui07 = "e5e5e5"
+let g:base16_gui08 = "d72638"
+let g:base16_gui09 = "eb8413"
+let g:base16_gui0A = "f19d1a"
+let g:base16_gui0B = "88b92d"
+let g:base16_gui0C = "1ba595"
+let g:base16_gui0D = "1e8bac"
+let g:base16_gui0E = "be4264"
 let g:base16_gui0F = "c85e0d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e5e5e5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Hopscotch
 " Scheme author: Jan T. Sott
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-hopscotch.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/hopscotch.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/hopscotch.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "322931"
-let g:base16_gui00 = "322931"
+let g:tinted_gui00 = "322931"
 let s:gui01        = "433b42"
-let g:base16_gui01 = "433b42"
+let g:tinted_gui01 = "433b42"
 let s:gui02        = "5c545b"
-let g:base16_gui02 = "5c545b"
+let g:tinted_gui02 = "5c545b"
 let s:gui03        = "797379"
-let g:base16_gui03 = "797379"
+let g:tinted_gui03 = "797379"
 let s:gui04        = "989498"
-let g:base16_gui04 = "989498"
+let g:tinted_gui04 = "989498"
 let s:gui05        = "b9b5b8"
-let g:base16_gui05 = "b9b5b8"
+let g:tinted_gui05 = "b9b5b8"
 let s:gui06        = "d5d3d5"
-let g:base16_gui06 = "d5d3d5"
+let g:tinted_gui06 = "d5d3d5"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "dd464c"
-let g:base16_gui08 = "dd464c"
+let g:tinted_gui08 = "dd464c"
 let s:gui09        = "fd8b19"
-let g:base16_gui09 = "fd8b19"
+let g:tinted_gui09 = "fd8b19"
 let s:gui0A        = "fdcc59"
-let g:base16_gui0A = "fdcc59"
+let g:tinted_gui0A = "fdcc59"
 let s:gui0B        = "8fc13e"
-let g:base16_gui0B = "8fc13e"
+let g:tinted_gui0B = "8fc13e"
 let s:gui0C        = "149b93"
-let g:base16_gui0C = "149b93"
+let g:tinted_gui0C = "149b93"
 let s:gui0D        = "1290bf"
-let g:base16_gui0D = "1290bf"
+let g:tinted_gui0D = "1290bf"
 let s:gui0E        = "c85e7c"
-let g:base16_gui0E = "c85e7c"
+let g:tinted_gui0E = "c85e7c"
 let s:gui0F        = "b33508"
+let g:tinted_gui0F = "b33508"
+
+" Legacy
+let g:base16_gui00 = "322931"
+let g:base16_gui01 = "433b42"
+let g:base16_gui02 = "5c545b"
+let g:base16_gui03 = "797379"
+let g:base16_gui04 = "989498"
+let g:base16_gui05 = "b9b5b8"
+let g:base16_gui06 = "d5d3d5"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "dd464c"
+let g:base16_gui09 = "fd8b19"
+let g:base16_gui0A = "fdcc59"
+let g:base16_gui0B = "8fc13e"
+let g:base16_gui0C = "149b93"
+let g:base16_gui0D = "1290bf"
+let g:base16_gui0E = "c85e7c"
 let g:base16_gui0F = "b33508"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Horizon Dark
 " Scheme author: Michaël Ball (http://github.com/michael-ball/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/horizon-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/horizon-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c1e26"
-let g:base16_gui00 = "1c1e26"
+let g:tinted_gui00 = "1c1e26"
 let s:gui01        = "232530"
-let g:base16_gui01 = "232530"
+let g:tinted_gui01 = "232530"
 let s:gui02        = "2e303e"
-let g:base16_gui02 = "2e303e"
+let g:tinted_gui02 = "2e303e"
 let s:gui03        = "6f6f70"
-let g:base16_gui03 = "6f6f70"
+let g:tinted_gui03 = "6f6f70"
 let s:gui04        = "9da0a2"
-let g:base16_gui04 = "9da0a2"
+let g:tinted_gui04 = "9da0a2"
 let s:gui05        = "cbced0"
-let g:base16_gui05 = "cbced0"
+let g:tinted_gui05 = "cbced0"
 let s:gui06        = "dcdfe4"
-let g:base16_gui06 = "dcdfe4"
+let g:tinted_gui06 = "dcdfe4"
 let s:gui07        = "e3e6ee"
-let g:base16_gui07 = "e3e6ee"
+let g:tinted_gui07 = "e3e6ee"
 let s:gui08        = "e93c58"
-let g:base16_gui08 = "e93c58"
+let g:tinted_gui08 = "e93c58"
 let s:gui09        = "e58d7d"
-let g:base16_gui09 = "e58d7d"
+let g:tinted_gui09 = "e58d7d"
 let s:gui0A        = "efb993"
-let g:base16_gui0A = "efb993"
+let g:tinted_gui0A = "efb993"
 let s:gui0B        = "efaf8e"
-let g:base16_gui0B = "efaf8e"
+let g:tinted_gui0B = "efaf8e"
 let s:gui0C        = "24a8b4"
-let g:base16_gui0C = "24a8b4"
+let g:tinted_gui0C = "24a8b4"
 let s:gui0D        = "df5273"
-let g:base16_gui0D = "df5273"
+let g:tinted_gui0D = "df5273"
 let s:gui0E        = "b072d1"
-let g:base16_gui0E = "b072d1"
+let g:tinted_gui0E = "b072d1"
 let s:gui0F        = "e4a382"
+let g:tinted_gui0F = "e4a382"
+
+" Legacy
+let g:base16_gui00 = "1c1e26"
+let g:base16_gui01 = "232530"
+let g:base16_gui02 = "2e303e"
+let g:base16_gui03 = "6f6f70"
+let g:base16_gui04 = "9da0a2"
+let g:base16_gui05 = "cbced0"
+let g:base16_gui06 = "dcdfe4"
+let g:base16_gui07 = "e3e6ee"
+let g:base16_gui08 = "e93c58"
+let g:base16_gui09 = "e58d7d"
+let g:base16_gui0A = "efb993"
+let g:base16_gui0B = "efaf8e"
+let g:base16_gui0C = "24a8b4"
+let g:base16_gui0D = "df5273"
+let g:base16_gui0E = "b072d1"
 let g:base16_gui0F = "e4a382"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e3e6ee",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Horizon Light
 " Scheme author: Michaël Ball (http://github.com/michael-ball/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/horizon-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/horizon-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fdf0ed"
-let g:base16_gui00 = "fdf0ed"
+let g:tinted_gui00 = "fdf0ed"
 let s:gui01        = "fadad1"
-let g:base16_gui01 = "fadad1"
+let g:tinted_gui01 = "fadad1"
 let s:gui02        = "f9cbbe"
-let g:base16_gui02 = "f9cbbe"
+let g:tinted_gui02 = "f9cbbe"
 let s:gui03        = "bdb3b1"
-let g:base16_gui03 = "bdb3b1"
+let g:tinted_gui03 = "bdb3b1"
 let s:gui04        = "948c8a"
-let g:base16_gui04 = "948c8a"
+let g:tinted_gui04 = "948c8a"
 let s:gui05        = "403c3d"
-let g:base16_gui05 = "403c3d"
+let g:tinted_gui05 = "403c3d"
 let s:gui06        = "302c2d"
-let g:base16_gui06 = "302c2d"
+let g:tinted_gui06 = "302c2d"
 let s:gui07        = "201c1d"
-let g:base16_gui07 = "201c1d"
+let g:tinted_gui07 = "201c1d"
 let s:gui08        = "f7939b"
-let g:base16_gui08 = "f7939b"
+let g:tinted_gui08 = "f7939b"
 let s:gui09        = "f6661e"
-let g:base16_gui09 = "f6661e"
+let g:tinted_gui09 = "f6661e"
 let s:gui0A        = "fbe0d9"
-let g:base16_gui0A = "fbe0d9"
+let g:tinted_gui0A = "fbe0d9"
 let s:gui0B        = "94e1b0"
-let g:base16_gui0B = "94e1b0"
+let g:tinted_gui0B = "94e1b0"
 let s:gui0C        = "dc3318"
-let g:base16_gui0C = "dc3318"
+let g:tinted_gui0C = "dc3318"
 let s:gui0D        = "da103f"
-let g:base16_gui0D = "da103f"
+let g:tinted_gui0D = "da103f"
 let s:gui0E        = "1d8991"
-let g:base16_gui0E = "1d8991"
+let g:tinted_gui0E = "1d8991"
 let s:gui0F        = "e58c92"
+let g:tinted_gui0F = "e58c92"
+
+" Legacy
+let g:base16_gui00 = "fdf0ed"
+let g:base16_gui01 = "fadad1"
+let g:base16_gui02 = "f9cbbe"
+let g:base16_gui03 = "bdb3b1"
+let g:base16_gui04 = "948c8a"
+let g:base16_gui05 = "403c3d"
+let g:base16_gui06 = "302c2d"
+let g:base16_gui07 = "201c1d"
+let g:base16_gui08 = "f7939b"
+let g:base16_gui09 = "f6661e"
+let g:base16_gui0A = "fbe0d9"
+let g:base16_gui0B = "94e1b0"
+let g:base16_gui0C = "dc3318"
+let g:base16_gui0D = "da103f"
+let g:base16_gui0E = "1d8991"
 let g:base16_gui0F = "e58c92"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#201c1d",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Horizon Terminal Dark
 " Scheme author: Michaël Ball (http://github.com/michael-ball/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-terminal-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/horizon-terminal-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/horizon-terminal-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c1e26"
-let g:base16_gui00 = "1c1e26"
+let g:tinted_gui00 = "1c1e26"
 let s:gui01        = "232530"
-let g:base16_gui01 = "232530"
+let g:tinted_gui01 = "232530"
 let s:gui02        = "2e303e"
-let g:base16_gui02 = "2e303e"
+let g:tinted_gui02 = "2e303e"
 let s:gui03        = "6f6f70"
-let g:base16_gui03 = "6f6f70"
+let g:tinted_gui03 = "6f6f70"
 let s:gui04        = "9da0a2"
-let g:base16_gui04 = "9da0a2"
+let g:tinted_gui04 = "9da0a2"
 let s:gui05        = "cbced0"
-let g:base16_gui05 = "cbced0"
+let g:tinted_gui05 = "cbced0"
 let s:gui06        = "dcdfe4"
-let g:base16_gui06 = "dcdfe4"
+let g:tinted_gui06 = "dcdfe4"
 let s:gui07        = "e3e6ee"
-let g:base16_gui07 = "e3e6ee"
+let g:tinted_gui07 = "e3e6ee"
 let s:gui08        = "e95678"
-let g:base16_gui08 = "e95678"
+let g:tinted_gui08 = "e95678"
 let s:gui09        = "fab795"
-let g:base16_gui09 = "fab795"
+let g:tinted_gui09 = "fab795"
 let s:gui0A        = "fac29a"
-let g:base16_gui0A = "fac29a"
+let g:tinted_gui0A = "fac29a"
 let s:gui0B        = "29d398"
-let g:base16_gui0B = "29d398"
+let g:tinted_gui0B = "29d398"
 let s:gui0C        = "59e1e3"
-let g:base16_gui0C = "59e1e3"
+let g:tinted_gui0C = "59e1e3"
 let s:gui0D        = "26bbd9"
-let g:base16_gui0D = "26bbd9"
+let g:tinted_gui0D = "26bbd9"
 let s:gui0E        = "ee64ac"
-let g:base16_gui0E = "ee64ac"
+let g:tinted_gui0E = "ee64ac"
 let s:gui0F        = "f09383"
+let g:tinted_gui0F = "f09383"
+
+" Legacy
+let g:base16_gui00 = "1c1e26"
+let g:base16_gui01 = "232530"
+let g:base16_gui02 = "2e303e"
+let g:base16_gui03 = "6f6f70"
+let g:base16_gui04 = "9da0a2"
+let g:base16_gui05 = "cbced0"
+let g:base16_gui06 = "dcdfe4"
+let g:base16_gui07 = "e3e6ee"
+let g:base16_gui08 = "e95678"
+let g:base16_gui09 = "fab795"
+let g:base16_gui0A = "fac29a"
+let g:base16_gui0B = "29d398"
+let g:base16_gui0C = "59e1e3"
+let g:base16_gui0D = "26bbd9"
+let g:base16_gui0E = "ee64ac"
 let g:base16_gui0F = "f09383"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e3e6ee",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Horizon Terminal Light
 " Scheme author: Michaël Ball (http://github.com/michael-ball/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-terminal-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/horizon-terminal-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/horizon-terminal-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fdf0ed"
-let g:base16_gui00 = "fdf0ed"
+let g:tinted_gui00 = "fdf0ed"
 let s:gui01        = "fadad1"
-let g:base16_gui01 = "fadad1"
+let g:tinted_gui01 = "fadad1"
 let s:gui02        = "f9cbbe"
-let g:base16_gui02 = "f9cbbe"
+let g:tinted_gui02 = "f9cbbe"
 let s:gui03        = "bdb3b1"
-let g:base16_gui03 = "bdb3b1"
+let g:tinted_gui03 = "bdb3b1"
 let s:gui04        = "948c8a"
-let g:base16_gui04 = "948c8a"
+let g:tinted_gui04 = "948c8a"
 let s:gui05        = "403c3d"
-let g:base16_gui05 = "403c3d"
+let g:tinted_gui05 = "403c3d"
 let s:gui06        = "302c2d"
-let g:base16_gui06 = "302c2d"
+let g:tinted_gui06 = "302c2d"
 let s:gui07        = "201c1d"
-let g:base16_gui07 = "201c1d"
+let g:tinted_gui07 = "201c1d"
 let s:gui08        = "e95678"
-let g:base16_gui08 = "e95678"
+let g:tinted_gui08 = "e95678"
 let s:gui09        = "f9cec3"
-let g:base16_gui09 = "f9cec3"
+let g:tinted_gui09 = "f9cec3"
 let s:gui0A        = "fadad1"
-let g:base16_gui0A = "fadad1"
+let g:tinted_gui0A = "fadad1"
 let s:gui0B        = "29d398"
-let g:base16_gui0B = "29d398"
+let g:tinted_gui0B = "29d398"
 let s:gui0C        = "59e1e3"
-let g:base16_gui0C = "59e1e3"
+let g:tinted_gui0C = "59e1e3"
 let s:gui0D        = "26bbd9"
-let g:base16_gui0D = "26bbd9"
+let g:tinted_gui0D = "26bbd9"
 let s:gui0E        = "ee64ac"
-let g:base16_gui0E = "ee64ac"
+let g:tinted_gui0E = "ee64ac"
 let s:gui0F        = "f9cbbe"
+let g:tinted_gui0F = "f9cbbe"
+
+" Legacy
+let g:base16_gui00 = "fdf0ed"
+let g:base16_gui01 = "fadad1"
+let g:base16_gui02 = "f9cbbe"
+let g:base16_gui03 = "bdb3b1"
+let g:base16_gui04 = "948c8a"
+let g:base16_gui05 = "403c3d"
+let g:base16_gui06 = "302c2d"
+let g:base16_gui07 = "201c1d"
+let g:base16_gui08 = "e95678"
+let g:base16_gui09 = "f9cec3"
+let g:base16_gui0A = "fadad1"
+let g:base16_gui0B = "29d398"
+let g:base16_gui0C = "59e1e3"
+let g:base16_gui0D = "26bbd9"
+let g:base16_gui0E = "ee64ac"
 let g:base16_gui0F = "f9cbbe"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#201c1d",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Humanoid dark
 " Scheme author: Thomas (tasmo) Friese
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-humanoid-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/humanoid-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/humanoid-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "232629"
-let g:base16_gui00 = "232629"
+let g:tinted_gui00 = "232629"
 let s:gui01        = "333b3d"
-let g:base16_gui01 = "333b3d"
+let g:tinted_gui01 = "333b3d"
 let s:gui02        = "484e54"
-let g:base16_gui02 = "484e54"
+let g:tinted_gui02 = "484e54"
 let s:gui03        = "60615d"
-let g:base16_gui03 = "60615d"
+let g:tinted_gui03 = "60615d"
 let s:gui04        = "c0c0bd"
-let g:base16_gui04 = "c0c0bd"
+let g:tinted_gui04 = "c0c0bd"
 let s:gui05        = "f8f8f2"
-let g:base16_gui05 = "f8f8f2"
+let g:tinted_gui05 = "f8f8f2"
 let s:gui06        = "fcfcf6"
-let g:base16_gui06 = "fcfcf6"
+let g:tinted_gui06 = "fcfcf6"
 let s:gui07        = "fcfcfc"
-let g:base16_gui07 = "fcfcfc"
+let g:tinted_gui07 = "fcfcfc"
 let s:gui08        = "f11235"
-let g:base16_gui08 = "f11235"
+let g:tinted_gui08 = "f11235"
 let s:gui09        = "ff9505"
-let g:base16_gui09 = "ff9505"
+let g:tinted_gui09 = "ff9505"
 let s:gui0A        = "ffb627"
-let g:base16_gui0A = "ffb627"
+let g:tinted_gui0A = "ffb627"
 let s:gui0B        = "02d849"
-let g:base16_gui0B = "02d849"
+let g:tinted_gui0B = "02d849"
 let s:gui0C        = "0dd9d6"
-let g:base16_gui0C = "0dd9d6"
+let g:tinted_gui0C = "0dd9d6"
 let s:gui0D        = "00a6fb"
-let g:base16_gui0D = "00a6fb"
+let g:tinted_gui0D = "00a6fb"
 let s:gui0E        = "f15ee3"
-let g:base16_gui0E = "f15ee3"
+let g:tinted_gui0E = "f15ee3"
 let s:gui0F        = "b27701"
+let g:tinted_gui0F = "b27701"
+
+" Legacy
+let g:base16_gui00 = "232629"
+let g:base16_gui01 = "333b3d"
+let g:base16_gui02 = "484e54"
+let g:base16_gui03 = "60615d"
+let g:base16_gui04 = "c0c0bd"
+let g:base16_gui05 = "f8f8f2"
+let g:base16_gui06 = "fcfcf6"
+let g:base16_gui07 = "fcfcfc"
+let g:base16_gui08 = "f11235"
+let g:base16_gui09 = "ff9505"
+let g:base16_gui0A = "ffb627"
+let g:base16_gui0B = "02d849"
+let g:base16_gui0C = "0dd9d6"
+let g:base16_gui0D = "00a6fb"
+let g:base16_gui0E = "f15ee3"
 let g:base16_gui0F = "b27701"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fcfcfc",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Humanoid light
 " Scheme author: Thomas (tasmo) Friese
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-humanoid-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/humanoid-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/humanoid-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f8f8f2"
-let g:base16_gui00 = "f8f8f2"
+let g:tinted_gui00 = "f8f8f2"
 let s:gui01        = "efefe9"
-let g:base16_gui01 = "efefe9"
+let g:tinted_gui01 = "efefe9"
 let s:gui02        = "deded8"
-let g:base16_gui02 = "deded8"
+let g:tinted_gui02 = "deded8"
 let s:gui03        = "c0c0bd"
-let g:base16_gui03 = "c0c0bd"
+let g:tinted_gui03 = "c0c0bd"
 let s:gui04        = "60615d"
-let g:base16_gui04 = "60615d"
+let g:tinted_gui04 = "60615d"
 let s:gui05        = "232629"
-let g:base16_gui05 = "232629"
+let g:tinted_gui05 = "232629"
 let s:gui06        = "2f3337"
-let g:base16_gui06 = "2f3337"
+let g:tinted_gui06 = "2f3337"
 let s:gui07        = "070708"
-let g:base16_gui07 = "070708"
+let g:tinted_gui07 = "070708"
 let s:gui08        = "b0151a"
-let g:base16_gui08 = "b0151a"
+let g:tinted_gui08 = "b0151a"
 let s:gui09        = "ff3d00"
-let g:base16_gui09 = "ff3d00"
+let g:tinted_gui09 = "ff3d00"
 let s:gui0A        = "ffb627"
-let g:base16_gui0A = "ffb627"
+let g:tinted_gui0A = "ffb627"
 let s:gui0B        = "388e3c"
-let g:base16_gui0B = "388e3c"
+let g:tinted_gui0B = "388e3c"
 let s:gui0C        = "008e8e"
-let g:base16_gui0C = "008e8e"
+let g:tinted_gui0C = "008e8e"
 let s:gui0D        = "0082c9"
-let g:base16_gui0D = "0082c9"
+let g:tinted_gui0D = "0082c9"
 let s:gui0E        = "700f98"
-let g:base16_gui0E = "700f98"
+let g:tinted_gui0E = "700f98"
 let s:gui0F        = "b27701"
+let g:tinted_gui0F = "b27701"
+
+" Legacy
+let g:base16_gui00 = "f8f8f2"
+let g:base16_gui01 = "efefe9"
+let g:base16_gui02 = "deded8"
+let g:base16_gui03 = "c0c0bd"
+let g:base16_gui04 = "60615d"
+let g:base16_gui05 = "232629"
+let g:base16_gui06 = "2f3337"
+let g:base16_gui07 = "070708"
+let g:base16_gui08 = "b0151a"
+let g:base16_gui09 = "ff3d00"
+let g:base16_gui0A = "ffb627"
+let g:base16_gui0B = "388e3c"
+let g:base16_gui0C = "008e8e"
+let g:base16_gui0D = "0082c9"
+let g:base16_gui0E = "700f98"
 let g:base16_gui0F = "b27701"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#070708",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: iA Dark
 " Scheme author: iA Inc. (modified by aramisgithub)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ia-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ia-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ia-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1a1a1a"
-let g:base16_gui00 = "1a1a1a"
+let g:tinted_gui00 = "1a1a1a"
 let s:gui01        = "222222"
-let g:base16_gui01 = "222222"
+let g:tinted_gui01 = "222222"
 let s:gui02        = "1d414d"
-let g:base16_gui02 = "1d414d"
+let g:tinted_gui02 = "1d414d"
 let s:gui03        = "767676"
-let g:base16_gui03 = "767676"
+let g:tinted_gui03 = "767676"
 let s:gui04        = "b8b8b8"
-let g:base16_gui04 = "b8b8b8"
+let g:tinted_gui04 = "b8b8b8"
 let s:gui05        = "cccccc"
-let g:base16_gui05 = "cccccc"
+let g:tinted_gui05 = "cccccc"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "f8f8f8"
-let g:base16_gui07 = "f8f8f8"
+let g:tinted_gui07 = "f8f8f8"
 let s:gui08        = "d88568"
-let g:base16_gui08 = "d88568"
+let g:tinted_gui08 = "d88568"
 let s:gui09        = "d86868"
-let g:base16_gui09 = "d86868"
+let g:tinted_gui09 = "d86868"
 let s:gui0A        = "b99353"
-let g:base16_gui0A = "b99353"
+let g:tinted_gui0A = "b99353"
 let s:gui0B        = "83a471"
-let g:base16_gui0B = "83a471"
+let g:tinted_gui0B = "83a471"
 let s:gui0C        = "7c9cae"
-let g:base16_gui0C = "7c9cae"
+let g:tinted_gui0C = "7c9cae"
 let s:gui0D        = "8eccdd"
-let g:base16_gui0D = "8eccdd"
+let g:tinted_gui0D = "8eccdd"
 let s:gui0E        = "b98eb2"
-let g:base16_gui0E = "b98eb2"
+let g:tinted_gui0E = "b98eb2"
 let s:gui0F        = "8b6c37"
+let g:tinted_gui0F = "8b6c37"
+
+" Legacy
+let g:base16_gui00 = "1a1a1a"
+let g:base16_gui01 = "222222"
+let g:base16_gui02 = "1d414d"
+let g:base16_gui03 = "767676"
+let g:base16_gui04 = "b8b8b8"
+let g:base16_gui05 = "cccccc"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "f8f8f8"
+let g:base16_gui08 = "d88568"
+let g:base16_gui09 = "d86868"
+let g:base16_gui0A = "b99353"
+let g:base16_gui0B = "83a471"
+let g:base16_gui0C = "7c9cae"
+let g:base16_gui0D = "8eccdd"
+let g:base16_gui0E = "b98eb2"
 let g:base16_gui0F = "8b6c37"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8f8f8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: iA Light
 " Scheme author: iA Inc. (modified by aramisgithub)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ia-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ia-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ia-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f6f6f6"
-let g:base16_gui00 = "f6f6f6"
+let g:tinted_gui00 = "f6f6f6"
 let s:gui01        = "dedede"
-let g:base16_gui01 = "dedede"
+let g:tinted_gui01 = "dedede"
 let s:gui02        = "bde5f2"
-let g:base16_gui02 = "bde5f2"
+let g:tinted_gui02 = "bde5f2"
 let s:gui03        = "898989"
-let g:base16_gui03 = "898989"
+let g:tinted_gui03 = "898989"
 let s:gui04        = "767676"
-let g:base16_gui04 = "767676"
+let g:tinted_gui04 = "767676"
 let s:gui05        = "181818"
-let g:base16_gui05 = "181818"
+let g:tinted_gui05 = "181818"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "f8f8f8"
-let g:base16_gui07 = "f8f8f8"
+let g:tinted_gui07 = "f8f8f8"
 let s:gui08        = "9c5a02"
-let g:base16_gui08 = "9c5a02"
+let g:tinted_gui08 = "9c5a02"
 let s:gui09        = "c43e18"
-let g:base16_gui09 = "c43e18"
+let g:tinted_gui09 = "c43e18"
 let s:gui0A        = "c48218"
-let g:base16_gui0A = "c48218"
+let g:tinted_gui0A = "c48218"
 let s:gui0B        = "38781c"
-let g:base16_gui0B = "38781c"
+let g:tinted_gui0B = "38781c"
 let s:gui0C        = "2d6bb1"
-let g:base16_gui0C = "2d6bb1"
+let g:tinted_gui0C = "2d6bb1"
 let s:gui0D        = "48bac2"
-let g:base16_gui0D = "48bac2"
+let g:tinted_gui0D = "48bac2"
 let s:gui0E        = "a94598"
-let g:base16_gui0E = "a94598"
+let g:tinted_gui0E = "a94598"
 let s:gui0F        = "8b6c37"
+let g:tinted_gui0F = "8b6c37"
+
+" Legacy
+let g:base16_gui00 = "f6f6f6"
+let g:base16_gui01 = "dedede"
+let g:base16_gui02 = "bde5f2"
+let g:base16_gui03 = "898989"
+let g:base16_gui04 = "767676"
+let g:base16_gui05 = "181818"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "f8f8f8"
+let g:base16_gui08 = "9c5a02"
+let g:base16_gui09 = "c43e18"
+let g:base16_gui0A = "c48218"
+let g:base16_gui0B = "38781c"
+let g:base16_gui0C = "2d6bb1"
+let g:base16_gui0D = "48bac2"
+let g:base16_gui0E = "a94598"
 let g:base16_gui0F = "8b6c37"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8f8f8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Icy Dark
 " Scheme author: icyphox (https://icyphox.ga)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-icy.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/icy.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/icy.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "021012"
-let g:base16_gui00 = "021012"
+let g:tinted_gui00 = "021012"
 let s:gui01        = "031619"
-let g:base16_gui01 = "031619"
+let g:tinted_gui01 = "031619"
 let s:gui02        = "041f23"
-let g:base16_gui02 = "041f23"
+let g:tinted_gui02 = "041f23"
 let s:gui03        = "052e34"
-let g:base16_gui03 = "052e34"
+let g:tinted_gui03 = "052e34"
 let s:gui04        = "064048"
-let g:base16_gui04 = "064048"
+let g:tinted_gui04 = "064048"
 let s:gui05        = "095b67"
-let g:base16_gui05 = "095b67"
+let g:tinted_gui05 = "095b67"
 let s:gui06        = "0c7c8c"
-let g:base16_gui06 = "0c7c8c"
+let g:tinted_gui06 = "0c7c8c"
 let s:gui07        = "109cb0"
-let g:base16_gui07 = "109cb0"
+let g:tinted_gui07 = "109cb0"
 let s:gui08        = "16c1d9"
-let g:base16_gui08 = "16c1d9"
+let g:tinted_gui08 = "16c1d9"
 let s:gui09        = "b3ebf2"
-let g:base16_gui09 = "b3ebf2"
+let g:tinted_gui09 = "b3ebf2"
 let s:gui0A        = "80deea"
-let g:base16_gui0A = "80deea"
+let g:tinted_gui0A = "80deea"
 let s:gui0B        = "4dd0e1"
-let g:base16_gui0B = "4dd0e1"
+let g:tinted_gui0B = "4dd0e1"
 let s:gui0C        = "26c6da"
-let g:base16_gui0C = "26c6da"
+let g:tinted_gui0C = "26c6da"
 let s:gui0D        = "00bcd4"
-let g:base16_gui0D = "00bcd4"
+let g:tinted_gui0D = "00bcd4"
 let s:gui0E        = "00acc1"
-let g:base16_gui0E = "00acc1"
+let g:tinted_gui0E = "00acc1"
 let s:gui0F        = "0097a7"
+let g:tinted_gui0F = "0097a7"
+
+" Legacy
+let g:base16_gui00 = "021012"
+let g:base16_gui01 = "031619"
+let g:base16_gui02 = "041f23"
+let g:base16_gui03 = "052e34"
+let g:base16_gui04 = "064048"
+let g:base16_gui05 = "095b67"
+let g:base16_gui06 = "0c7c8c"
+let g:base16_gui07 = "109cb0"
+let g:base16_gui08 = "16c1d9"
+let g:base16_gui09 = "b3ebf2"
+let g:base16_gui0A = "80deea"
+let g:base16_gui0B = "4dd0e1"
+let g:base16_gui0C = "26c6da"
+let g:base16_gui0D = "00bcd4"
+let g:base16_gui0E = "00acc1"
 let g:base16_gui0F = "0097a7"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#109cb0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: IR Black
 " Scheme author: Timothée Poisot (http://timotheepoisot.fr)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-irblack.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/irblack.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/irblack.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "242422"
-let g:base16_gui01 = "242422"
+let g:tinted_gui01 = "242422"
 let s:gui02        = "484844"
-let g:base16_gui02 = "484844"
+let g:tinted_gui02 = "484844"
 let s:gui03        = "6c6c66"
-let g:base16_gui03 = "6c6c66"
+let g:tinted_gui03 = "6c6c66"
 let s:gui04        = "918f88"
-let g:base16_gui04 = "918f88"
+let g:tinted_gui04 = "918f88"
 let s:gui05        = "b5b3aa"
-let g:base16_gui05 = "b5b3aa"
+let g:tinted_gui05 = "b5b3aa"
 let s:gui06        = "d9d7cc"
-let g:base16_gui06 = "d9d7cc"
+let g:tinted_gui06 = "d9d7cc"
 let s:gui07        = "fdfbee"
-let g:base16_gui07 = "fdfbee"
+let g:tinted_gui07 = "fdfbee"
 let s:gui08        = "ff6c60"
-let g:base16_gui08 = "ff6c60"
+let g:tinted_gui08 = "ff6c60"
 let s:gui09        = "e9c062"
-let g:base16_gui09 = "e9c062"
+let g:tinted_gui09 = "e9c062"
 let s:gui0A        = "ffffb6"
-let g:base16_gui0A = "ffffb6"
+let g:tinted_gui0A = "ffffb6"
 let s:gui0B        = "a8ff60"
-let g:base16_gui0B = "a8ff60"
+let g:tinted_gui0B = "a8ff60"
 let s:gui0C        = "c6c5fe"
-let g:base16_gui0C = "c6c5fe"
+let g:tinted_gui0C = "c6c5fe"
 let s:gui0D        = "96cbfe"
-let g:base16_gui0D = "96cbfe"
+let g:tinted_gui0D = "96cbfe"
 let s:gui0E        = "ff73fd"
-let g:base16_gui0E = "ff73fd"
+let g:tinted_gui0E = "ff73fd"
 let s:gui0F        = "b18a3d"
+let g:tinted_gui0F = "b18a3d"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "242422"
+let g:base16_gui02 = "484844"
+let g:base16_gui03 = "6c6c66"
+let g:base16_gui04 = "918f88"
+let g:base16_gui05 = "b5b3aa"
+let g:base16_gui06 = "d9d7cc"
+let g:base16_gui07 = "fdfbee"
+let g:base16_gui08 = "ff6c60"
+let g:base16_gui09 = "e9c062"
+let g:base16_gui0A = "ffffb6"
+let g:base16_gui0B = "a8ff60"
+let g:base16_gui0C = "c6c5fe"
+let g:base16_gui0D = "96cbfe"
+let g:base16_gui0E = "ff73fd"
 let g:base16_gui0F = "b18a3d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fdfbee",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Isotope
 " Scheme author: Jan T. Sott
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-isotope.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/isotope.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/isotope.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "404040"
-let g:base16_gui01 = "404040"
+let g:tinted_gui01 = "404040"
 let s:gui02        = "606060"
-let g:base16_gui02 = "606060"
+let g:tinted_gui02 = "606060"
 let s:gui03        = "808080"
-let g:base16_gui03 = "808080"
+let g:tinted_gui03 = "808080"
 let s:gui04        = "c0c0c0"
-let g:base16_gui04 = "c0c0c0"
+let g:tinted_gui04 = "c0c0c0"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff0000"
-let g:base16_gui08 = "ff0000"
+let g:tinted_gui08 = "ff0000"
 let s:gui09        = "ff9900"
-let g:base16_gui09 = "ff9900"
+let g:tinted_gui09 = "ff9900"
 let s:gui0A        = "ff0099"
-let g:base16_gui0A = "ff0099"
+let g:tinted_gui0A = "ff0099"
 let s:gui0B        = "33ff00"
-let g:base16_gui0B = "33ff00"
+let g:tinted_gui0B = "33ff00"
 let s:gui0C        = "00ffff"
-let g:base16_gui0C = "00ffff"
+let g:tinted_gui0C = "00ffff"
 let s:gui0D        = "0066ff"
-let g:base16_gui0D = "0066ff"
+let g:tinted_gui0D = "0066ff"
 let s:gui0E        = "cc00ff"
-let g:base16_gui0E = "cc00ff"
+let g:tinted_gui0E = "cc00ff"
 let s:gui0F        = "3300ff"
+let g:tinted_gui0F = "3300ff"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "404040"
+let g:base16_gui02 = "606060"
+let g:base16_gui03 = "808080"
+let g:base16_gui04 = "c0c0c0"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff0000"
+let g:base16_gui09 = "ff9900"
+let g:base16_gui0A = "ff0099"
+let g:base16_gui0B = "33ff00"
+let g:base16_gui0C = "00ffff"
+let g:base16_gui0D = "0066ff"
+let g:base16_gui0E = "cc00ff"
 let g:base16_gui0F = "3300ff"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-jabuti.vim
+++ b/colors/base16-jabuti.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Jabuti
 " Scheme author: https://github.com/notusknot
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-jabuti.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/jabuti.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/jabuti.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "292a37"
-let g:base16_gui00 = "292a37"
+let g:tinted_gui00 = "292a37"
 let s:gui01        = "343545"
-let g:base16_gui01 = "343545"
+let g:tinted_gui01 = "343545"
 let s:gui02        = "3c3e51"
-let g:base16_gui02 = "3c3e51"
+let g:tinted_gui02 = "3c3e51"
 let s:gui03        = "45475d"
-let g:base16_gui03 = "45475d"
+let g:tinted_gui03 = "45475d"
 let s:gui04        = "50526b"
-let g:base16_gui04 = "50526b"
+let g:tinted_gui04 = "50526b"
 let s:gui05        = "c0cbe3"
-let g:base16_gui05 = "c0cbe3"
+let g:tinted_gui05 = "c0cbe3"
 let s:gui06        = "d9e0ee"
-let g:base16_gui06 = "d9e0ee"
+let g:tinted_gui06 = "d9e0ee"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ec6a88"
-let g:base16_gui08 = "ec6a88"
+let g:tinted_gui08 = "ec6a88"
 let s:gui09        = "efb993"
-let g:base16_gui09 = "efb993"
+let g:tinted_gui09 = "efb993"
 let s:gui0A        = "e1c697"
-let g:base16_gui0A = "e1c697"
+let g:tinted_gui0A = "e1c697"
 let s:gui0B        = "3fdaa4"
-let g:base16_gui0B = "3fdaa4"
+let g:tinted_gui0B = "3fdaa4"
 let s:gui0C        = "ff7eb6"
-let g:base16_gui0C = "ff7eb6"
+let g:tinted_gui0C = "ff7eb6"
 let s:gui0D        = "3fc6de"
-let g:base16_gui0D = "3fc6de"
+let g:tinted_gui0D = "3fc6de"
 let s:gui0E        = "be95ff"
-let g:base16_gui0E = "be95ff"
+let g:tinted_gui0E = "be95ff"
 let s:gui0F        = "8b8da9"
+let g:tinted_gui0F = "8b8da9"
+
+" Legacy
+let g:base16_gui00 = "292a37"
+let g:base16_gui01 = "343545"
+let g:base16_gui02 = "3c3e51"
+let g:base16_gui03 = "45475d"
+let g:base16_gui04 = "50526b"
+let g:base16_gui05 = "c0cbe3"
+let g:base16_gui06 = "d9e0ee"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ec6a88"
+let g:base16_gui09 = "efb993"
+let g:base16_gui0A = "e1c697"
+let g:base16_gui0B = "3fdaa4"
+let g:base16_gui0C = "ff7eb6"
+let g:base16_gui0D = "3fc6de"
+let g:base16_gui0E = "be95ff"
 let g:base16_gui0F = "8b8da9"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-kanagawa.vim
+++ b/colors/base16-kanagawa.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Kanagawa
 " Scheme author: Tommaso Laurenzi (https://github.com/rebelot)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-kanagawa.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/kanagawa.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/kanagawa.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1f1f28"
-let g:base16_gui00 = "1f1f28"
+let g:tinted_gui00 = "1f1f28"
 let s:gui01        = "16161d"
-let g:base16_gui01 = "16161d"
+let g:tinted_gui01 = "16161d"
 let s:gui02        = "223249"
-let g:base16_gui02 = "223249"
+let g:tinted_gui02 = "223249"
 let s:gui03        = "54546d"
-let g:base16_gui03 = "54546d"
+let g:tinted_gui03 = "54546d"
 let s:gui04        = "727169"
-let g:base16_gui04 = "727169"
+let g:tinted_gui04 = "727169"
 let s:gui05        = "dcd7ba"
-let g:base16_gui05 = "dcd7ba"
+let g:tinted_gui05 = "dcd7ba"
 let s:gui06        = "c8c093"
-let g:base16_gui06 = "c8c093"
+let g:tinted_gui06 = "c8c093"
 let s:gui07        = "717c7c"
-let g:base16_gui07 = "717c7c"
+let g:tinted_gui07 = "717c7c"
 let s:gui08        = "c34043"
-let g:base16_gui08 = "c34043"
+let g:tinted_gui08 = "c34043"
 let s:gui09        = "ffa066"
-let g:base16_gui09 = "ffa066"
+let g:tinted_gui09 = "ffa066"
 let s:gui0A        = "c0a36e"
-let g:base16_gui0A = "c0a36e"
+let g:tinted_gui0A = "c0a36e"
 let s:gui0B        = "76946a"
-let g:base16_gui0B = "76946a"
+let g:tinted_gui0B = "76946a"
 let s:gui0C        = "6a9589"
-let g:base16_gui0C = "6a9589"
+let g:tinted_gui0C = "6a9589"
 let s:gui0D        = "7e9cd8"
-let g:base16_gui0D = "7e9cd8"
+let g:tinted_gui0D = "7e9cd8"
 let s:gui0E        = "957fb8"
-let g:base16_gui0E = "957fb8"
+let g:tinted_gui0E = "957fb8"
 let s:gui0F        = "d27e99"
+let g:tinted_gui0F = "d27e99"
+
+" Legacy
+let g:base16_gui00 = "1f1f28"
+let g:base16_gui01 = "16161d"
+let g:base16_gui02 = "223249"
+let g:base16_gui03 = "54546d"
+let g:base16_gui04 = "727169"
+let g:base16_gui05 = "dcd7ba"
+let g:base16_gui06 = "c8c093"
+let g:base16_gui07 = "717c7c"
+let g:base16_gui08 = "c34043"
+let g:base16_gui09 = "ffa066"
+let g:base16_gui0A = "c0a36e"
+let g:base16_gui0B = "76946a"
+let g:base16_gui0C = "6a9589"
+let g:base16_gui0D = "7e9cd8"
+let g:base16_gui0E = "957fb8"
 let g:base16_gui0F = "d27e99"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#717c7c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-katy.vim
+++ b/colors/base16-katy.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Katy
 " Scheme author: George Essig (https://github.com/gessig)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-katy.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/katy.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/katy.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "292d3e"
-let g:base16_gui00 = "292d3e"
+let g:tinted_gui00 = "292d3e"
 let s:gui01        = "444267"
-let g:base16_gui01 = "444267"
+let g:tinted_gui01 = "444267"
 let s:gui02        = "5c598b"
-let g:base16_gui02 = "5c598b"
+let g:tinted_gui02 = "5c598b"
 let s:gui03        = "676e95"
-let g:base16_gui03 = "676e95"
+let g:tinted_gui03 = "676e95"
 let s:gui04        = "8796b0"
-let g:base16_gui04 = "8796b0"
+let g:tinted_gui04 = "8796b0"
 let s:gui05        = "959dcb"
-let g:base16_gui05 = "959dcb"
+let g:tinted_gui05 = "959dcb"
 let s:gui06        = "959dcb"
-let g:base16_gui06 = "959dcb"
+let g:tinted_gui06 = "959dcb"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "6e98e1"
-let g:base16_gui08 = "6e98e1"
+let g:tinted_gui08 = "6e98e1"
 let s:gui09        = "f78c6c"
-let g:base16_gui09 = "f78c6c"
+let g:tinted_gui09 = "f78c6c"
 let s:gui0A        = "e0a557"
-let g:base16_gui0A = "e0a557"
+let g:tinted_gui0A = "e0a557"
 let s:gui0B        = "78c06e"
-let g:base16_gui0B = "78c06e"
+let g:tinted_gui0B = "78c06e"
 let s:gui0C        = "83b7e5"
-let g:base16_gui0C = "83b7e5"
+let g:tinted_gui0C = "83b7e5"
 let s:gui0D        = "82aaff"
-let g:base16_gui0D = "82aaff"
+let g:tinted_gui0D = "82aaff"
 let s:gui0E        = "c792ea"
-let g:base16_gui0E = "c792ea"
+let g:tinted_gui0E = "c792ea"
 let s:gui0F        = "ff5370"
+let g:tinted_gui0F = "ff5370"
+
+" Legacy
+let g:base16_gui00 = "292d3e"
+let g:base16_gui01 = "444267"
+let g:base16_gui02 = "5c598b"
+let g:base16_gui03 = "676e95"
+let g:base16_gui04 = "8796b0"
+let g:base16_gui05 = "959dcb"
+let g:base16_gui06 = "959dcb"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "6e98e1"
+let g:base16_gui09 = "f78c6c"
+let g:base16_gui0A = "e0a557"
+let g:base16_gui0B = "78c06e"
+let g:base16_gui0C = "83b7e5"
+let g:base16_gui0D = "82aaff"
+let g:base16_gui0E = "c792ea"
 let g:base16_gui0F = "ff5370"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Kimber
 " Scheme author: Mishka Nguyen (https://github.com/akhsiM)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-kimber.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/kimber.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/kimber.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "222222"
-let g:base16_gui00 = "222222"
+let g:tinted_gui00 = "222222"
 let s:gui01        = "313131"
-let g:base16_gui01 = "313131"
+let g:tinted_gui01 = "313131"
 let s:gui02        = "555d55"
-let g:base16_gui02 = "555d55"
+let g:tinted_gui02 = "555d55"
 let s:gui03        = "644646"
-let g:base16_gui03 = "644646"
+let g:tinted_gui03 = "644646"
 let s:gui04        = "5a5a5a"
-let g:base16_gui04 = "5a5a5a"
+let g:tinted_gui04 = "5a5a5a"
 let s:gui05        = "dedee7"
-let g:base16_gui05 = "dedee7"
+let g:tinted_gui05 = "dedee7"
 let s:gui06        = "c3c3b4"
-let g:base16_gui06 = "c3c3b4"
+let g:tinted_gui06 = "c3c3b4"
 let s:gui07        = "ffffe6"
-let g:base16_gui07 = "ffffe6"
+let g:tinted_gui07 = "ffffe6"
 let s:gui08        = "c88c8c"
-let g:base16_gui08 = "c88c8c"
+let g:tinted_gui08 = "c88c8c"
 let s:gui09        = "476c88"
-let g:base16_gui09 = "476c88"
+let g:tinted_gui09 = "476c88"
 let s:gui0A        = "d8b56d"
-let g:base16_gui0A = "d8b56d"
+let g:tinted_gui0A = "d8b56d"
 let s:gui0B        = "99c899"
-let g:base16_gui0B = "99c899"
+let g:tinted_gui0B = "99c899"
 let s:gui0C        = "78b4b4"
-let g:base16_gui0C = "78b4b4"
+let g:tinted_gui0C = "78b4b4"
 let s:gui0D        = "537c9c"
-let g:base16_gui0D = "537c9c"
+let g:tinted_gui0D = "537c9c"
 let s:gui0E        = "86cacd"
-let g:base16_gui0E = "86cacd"
+let g:tinted_gui0E = "86cacd"
 let s:gui0F        = "704f4f"
+let g:tinted_gui0F = "704f4f"
+
+" Legacy
+let g:base16_gui00 = "222222"
+let g:base16_gui01 = "313131"
+let g:base16_gui02 = "555d55"
+let g:base16_gui03 = "644646"
+let g:base16_gui04 = "5a5a5a"
+let g:base16_gui05 = "dedee7"
+let g:base16_gui06 = "c3c3b4"
+let g:base16_gui07 = "ffffe6"
+let g:base16_gui08 = "c88c8c"
+let g:base16_gui09 = "476c88"
+let g:base16_gui0A = "d8b56d"
+let g:base16_gui0B = "99c899"
+let g:base16_gui0C = "78b4b4"
+let g:base16_gui0D = "537c9c"
+let g:base16_gui0E = "86cacd"
 let g:base16_gui0F = "704f4f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffe6",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-lime.vim
+++ b/colors/base16-lime.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: lime
 " Scheme author: limelier
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-lime.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/lime.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/lime.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1a1a2f"
-let g:base16_gui00 = "1a1a2f"
+let g:tinted_gui00 = "1a1a2f"
 let s:gui01        = "202030"
-let g:base16_gui01 = "202030"
+let g:tinted_gui01 = "202030"
 let s:gui02        = "2a2a3f"
-let g:base16_gui02 = "2a2a3f"
+let g:tinted_gui02 = "2a2a3f"
 let s:gui03        = "313140"
-let g:base16_gui03 = "313140"
+let g:tinted_gui03 = "313140"
 let s:gui04        = "515155"
-let g:base16_gui04 = "515155"
+let g:tinted_gui04 = "515155"
 let s:gui05        = "818175"
-let g:base16_gui05 = "818175"
+let g:tinted_gui05 = "818175"
 let s:gui06        = "fff2d1"
-let g:base16_gui06 = "fff2d1"
+let g:tinted_gui06 = "fff2d1"
 let s:gui07        = "fff8e1"
-let g:base16_gui07 = "fff8e1"
+let g:tinted_gui07 = "fff8e1"
 let s:gui08        = "ff662a"
-let g:base16_gui08 = "ff662a"
+let g:tinted_gui08 = "ff662a"
 let s:gui09        = "ff773a"
-let g:base16_gui09 = "ff773a"
+let g:tinted_gui09 = "ff773a"
 let s:gui0A        = "ffd15e"
-let g:base16_gui0A = "ffd15e"
+let g:tinted_gui0A = "ffd15e"
 let s:gui0B        = "8cd97c"
-let g:base16_gui0B = "8cd97c"
+let g:tinted_gui0B = "8cd97c"
 let s:gui0C        = "4cad83"
-let g:base16_gui0C = "4cad83"
+let g:tinted_gui0C = "4cad83"
 let s:gui0D        = "2b926f"
-let g:base16_gui0D = "2b926f"
+let g:tinted_gui0D = "2b926f"
 let s:gui0E        = "1b825f"
-let g:base16_gui0E = "1b825f"
+let g:tinted_gui0E = "1b825f"
 let s:gui0F        = "b4d97c"
+let g:tinted_gui0F = "b4d97c"
+
+" Legacy
+let g:base16_gui00 = "1a1a2f"
+let g:base16_gui01 = "202030"
+let g:base16_gui02 = "2a2a3f"
+let g:base16_gui03 = "313140"
+let g:base16_gui04 = "515155"
+let g:base16_gui05 = "818175"
+let g:base16_gui06 = "fff2d1"
+let g:base16_gui07 = "fff8e1"
+let g:base16_gui08 = "ff662a"
+let g:base16_gui09 = "ff773a"
+let g:base16_gui0A = "ffd15e"
+let g:base16_gui0B = "8cd97c"
+let g:base16_gui0C = "4cad83"
+let g:base16_gui0D = "2b926f"
+let g:base16_gui0E = "1b825f"
 let g:base16_gui0F = "b4d97c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fff8e1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Macintosh
 " Scheme author: Rebecca Bettencourt (http://www.kreativekorp.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-macintosh.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/macintosh.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/macintosh.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "404040"
-let g:base16_gui01 = "404040"
+let g:tinted_gui01 = "404040"
 let s:gui02        = "404040"
-let g:base16_gui02 = "404040"
+let g:tinted_gui02 = "404040"
 let s:gui03        = "808080"
-let g:base16_gui03 = "808080"
+let g:tinted_gui03 = "808080"
 let s:gui04        = "808080"
-let g:base16_gui04 = "808080"
+let g:tinted_gui04 = "808080"
 let s:gui05        = "c0c0c0"
-let g:base16_gui05 = "c0c0c0"
+let g:tinted_gui05 = "c0c0c0"
 let s:gui06        = "c0c0c0"
-let g:base16_gui06 = "c0c0c0"
+let g:tinted_gui06 = "c0c0c0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "dd0907"
-let g:base16_gui08 = "dd0907"
+let g:tinted_gui08 = "dd0907"
 let s:gui09        = "ff6403"
-let g:base16_gui09 = "ff6403"
+let g:tinted_gui09 = "ff6403"
 let s:gui0A        = "fbf305"
-let g:base16_gui0A = "fbf305"
+let g:tinted_gui0A = "fbf305"
 let s:gui0B        = "1fb714"
-let g:base16_gui0B = "1fb714"
+let g:tinted_gui0B = "1fb714"
 let s:gui0C        = "02abea"
-let g:base16_gui0C = "02abea"
+let g:tinted_gui0C = "02abea"
 let s:gui0D        = "0000d3"
-let g:base16_gui0D = "0000d3"
+let g:tinted_gui0D = "0000d3"
 let s:gui0E        = "4700a5"
-let g:base16_gui0E = "4700a5"
+let g:tinted_gui0E = "4700a5"
 let s:gui0F        = "90713a"
+let g:tinted_gui0F = "90713a"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "404040"
+let g:base16_gui02 = "404040"
+let g:base16_gui03 = "808080"
+let g:base16_gui04 = "808080"
+let g:base16_gui05 = "c0c0c0"
+let g:base16_gui06 = "c0c0c0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "dd0907"
+let g:base16_gui09 = "ff6403"
+let g:base16_gui0A = "fbf305"
+let g:base16_gui0B = "1fb714"
+let g:base16_gui0C = "02abea"
+let g:base16_gui0D = "0000d3"
+let g:base16_gui0E = "4700a5"
 let g:base16_gui0F = "90713a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Marrakesh
 " Scheme author: Alexandre Gavioli (http://github.com/Alexx2/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-marrakesh.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/marrakesh.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/marrakesh.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "201602"
-let g:base16_gui00 = "201602"
+let g:tinted_gui00 = "201602"
 let s:gui01        = "302e00"
-let g:base16_gui01 = "302e00"
+let g:tinted_gui01 = "302e00"
 let s:gui02        = "5f5b17"
-let g:base16_gui02 = "5f5b17"
+let g:tinted_gui02 = "5f5b17"
 let s:gui03        = "6c6823"
-let g:base16_gui03 = "6c6823"
+let g:tinted_gui03 = "6c6823"
 let s:gui04        = "86813b"
-let g:base16_gui04 = "86813b"
+let g:tinted_gui04 = "86813b"
 let s:gui05        = "948e48"
-let g:base16_gui05 = "948e48"
+let g:tinted_gui05 = "948e48"
 let s:gui06        = "ccc37a"
-let g:base16_gui06 = "ccc37a"
+let g:tinted_gui06 = "ccc37a"
 let s:gui07        = "faf0a5"
-let g:base16_gui07 = "faf0a5"
+let g:tinted_gui07 = "faf0a5"
 let s:gui08        = "c35359"
-let g:base16_gui08 = "c35359"
+let g:tinted_gui08 = "c35359"
 let s:gui09        = "b36144"
-let g:base16_gui09 = "b36144"
+let g:tinted_gui09 = "b36144"
 let s:gui0A        = "a88339"
-let g:base16_gui0A = "a88339"
+let g:tinted_gui0A = "a88339"
 let s:gui0B        = "18974e"
-let g:base16_gui0B = "18974e"
+let g:tinted_gui0B = "18974e"
 let s:gui0C        = "75a738"
-let g:base16_gui0C = "75a738"
+let g:tinted_gui0C = "75a738"
 let s:gui0D        = "477ca1"
-let g:base16_gui0D = "477ca1"
+let g:tinted_gui0D = "477ca1"
 let s:gui0E        = "8868b3"
-let g:base16_gui0E = "8868b3"
+let g:tinted_gui0E = "8868b3"
 let s:gui0F        = "b3588e"
+let g:tinted_gui0F = "b3588e"
+
+" Legacy
+let g:base16_gui00 = "201602"
+let g:base16_gui01 = "302e00"
+let g:base16_gui02 = "5f5b17"
+let g:base16_gui03 = "6c6823"
+let g:base16_gui04 = "86813b"
+let g:base16_gui05 = "948e48"
+let g:base16_gui06 = "ccc37a"
+let g:base16_gui07 = "faf0a5"
+let g:base16_gui08 = "c35359"
+let g:base16_gui09 = "b36144"
+let g:base16_gui0A = "a88339"
+let g:base16_gui0B = "18974e"
+let g:base16_gui0C = "75a738"
+let g:base16_gui0D = "477ca1"
+let g:base16_gui0E = "8868b3"
 let g:base16_gui0F = "b3588e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#faf0a5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Materia
 " Scheme author: Defman21
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-materia.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/materia.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/materia.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "263238"
-let g:base16_gui00 = "263238"
+let g:tinted_gui00 = "263238"
 let s:gui01        = "2c393f"
-let g:base16_gui01 = "2c393f"
+let g:tinted_gui01 = "2c393f"
 let s:gui02        = "37474f"
-let g:base16_gui02 = "37474f"
+let g:tinted_gui02 = "37474f"
 let s:gui03        = "707880"
-let g:base16_gui03 = "707880"
+let g:tinted_gui03 = "707880"
 let s:gui04        = "c9ccd3"
-let g:base16_gui04 = "c9ccd3"
+let g:tinted_gui04 = "c9ccd3"
 let s:gui05        = "cdd3de"
-let g:base16_gui05 = "cdd3de"
+let g:tinted_gui05 = "cdd3de"
 let s:gui06        = "d5dbe5"
-let g:base16_gui06 = "d5dbe5"
+let g:tinted_gui06 = "d5dbe5"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ec5f67"
-let g:base16_gui08 = "ec5f67"
+let g:tinted_gui08 = "ec5f67"
 let s:gui09        = "ea9560"
-let g:base16_gui09 = "ea9560"
+let g:tinted_gui09 = "ea9560"
 let s:gui0A        = "ffcc00"
-let g:base16_gui0A = "ffcc00"
+let g:tinted_gui0A = "ffcc00"
 let s:gui0B        = "8bd649"
-let g:base16_gui0B = "8bd649"
+let g:tinted_gui0B = "8bd649"
 let s:gui0C        = "80cbc4"
-let g:base16_gui0C = "80cbc4"
+let g:tinted_gui0C = "80cbc4"
 let s:gui0D        = "89ddff"
-let g:base16_gui0D = "89ddff"
+let g:tinted_gui0D = "89ddff"
 let s:gui0E        = "82aaff"
-let g:base16_gui0E = "82aaff"
+let g:tinted_gui0E = "82aaff"
 let s:gui0F        = "ec5f67"
+let g:tinted_gui0F = "ec5f67"
+
+" Legacy
+let g:base16_gui00 = "263238"
+let g:base16_gui01 = "2c393f"
+let g:base16_gui02 = "37474f"
+let g:base16_gui03 = "707880"
+let g:base16_gui04 = "c9ccd3"
+let g:base16_gui05 = "cdd3de"
+let g:base16_gui06 = "d5dbe5"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ec5f67"
+let g:base16_gui09 = "ea9560"
+let g:base16_gui0A = "ffcc00"
+let g:base16_gui0B = "8bd649"
+let g:base16_gui0C = "80cbc4"
+let g:base16_gui0D = "89ddff"
+let g:base16_gui0E = "82aaff"
 let g:base16_gui0F = "ec5f67"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Material Darker
 " Scheme author: Nate Peterson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-material-darker.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/material-darker.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/material-darker.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "212121"
-let g:base16_gui00 = "212121"
+let g:tinted_gui00 = "212121"
 let s:gui01        = "303030"
-let g:base16_gui01 = "303030"
+let g:tinted_gui01 = "303030"
 let s:gui02        = "353535"
-let g:base16_gui02 = "353535"
+let g:tinted_gui02 = "353535"
 let s:gui03        = "4a4a4a"
-let g:base16_gui03 = "4a4a4a"
+let g:tinted_gui03 = "4a4a4a"
 let s:gui04        = "b2ccd6"
-let g:base16_gui04 = "b2ccd6"
+let g:tinted_gui04 = "b2ccd6"
 let s:gui05        = "eeffff"
-let g:base16_gui05 = "eeffff"
+let g:tinted_gui05 = "eeffff"
 let s:gui06        = "eeffff"
-let g:base16_gui06 = "eeffff"
+let g:tinted_gui06 = "eeffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f07178"
-let g:base16_gui08 = "f07178"
+let g:tinted_gui08 = "f07178"
 let s:gui09        = "f78c6c"
-let g:base16_gui09 = "f78c6c"
+let g:tinted_gui09 = "f78c6c"
 let s:gui0A        = "ffcb6b"
-let g:base16_gui0A = "ffcb6b"
+let g:tinted_gui0A = "ffcb6b"
 let s:gui0B        = "c3e88d"
-let g:base16_gui0B = "c3e88d"
+let g:tinted_gui0B = "c3e88d"
 let s:gui0C        = "89ddff"
-let g:base16_gui0C = "89ddff"
+let g:tinted_gui0C = "89ddff"
 let s:gui0D        = "82aaff"
-let g:base16_gui0D = "82aaff"
+let g:tinted_gui0D = "82aaff"
 let s:gui0E        = "c792ea"
-let g:base16_gui0E = "c792ea"
+let g:tinted_gui0E = "c792ea"
 let s:gui0F        = "ff5370"
+let g:tinted_gui0F = "ff5370"
+
+" Legacy
+let g:base16_gui00 = "212121"
+let g:base16_gui01 = "303030"
+let g:base16_gui02 = "353535"
+let g:base16_gui03 = "4a4a4a"
+let g:base16_gui04 = "b2ccd6"
+let g:base16_gui05 = "eeffff"
+let g:base16_gui06 = "eeffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f07178"
+let g:base16_gui09 = "f78c6c"
+let g:base16_gui0A = "ffcb6b"
+let g:base16_gui0B = "c3e88d"
+let g:base16_gui0C = "89ddff"
+let g:base16_gui0D = "82aaff"
+let g:base16_gui0E = "c792ea"
 let g:base16_gui0F = "ff5370"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Material Lighter
 " Scheme author: Nate Peterson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-material-lighter.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/material-lighter.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/material-lighter.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fafafa"
-let g:base16_gui00 = "fafafa"
+let g:tinted_gui00 = "fafafa"
 let s:gui01        = "e7eaec"
-let g:base16_gui01 = "e7eaec"
+let g:tinted_gui01 = "e7eaec"
 let s:gui02        = "cceae7"
-let g:base16_gui02 = "cceae7"
+let g:tinted_gui02 = "cceae7"
 let s:gui03        = "ccd7da"
-let g:base16_gui03 = "ccd7da"
+let g:tinted_gui03 = "ccd7da"
 let s:gui04        = "8796b0"
-let g:base16_gui04 = "8796b0"
+let g:tinted_gui04 = "8796b0"
 let s:gui05        = "80cbc4"
-let g:base16_gui05 = "80cbc4"
+let g:tinted_gui05 = "80cbc4"
 let s:gui06        = "80cbc4"
-let g:base16_gui06 = "80cbc4"
+let g:tinted_gui06 = "80cbc4"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff5370"
-let g:base16_gui08 = "ff5370"
+let g:tinted_gui08 = "ff5370"
 let s:gui09        = "f76d47"
-let g:base16_gui09 = "f76d47"
+let g:tinted_gui09 = "f76d47"
 let s:gui0A        = "ffb62c"
-let g:base16_gui0A = "ffb62c"
+let g:tinted_gui0A = "ffb62c"
 let s:gui0B        = "91b859"
-let g:base16_gui0B = "91b859"
+let g:tinted_gui0B = "91b859"
 let s:gui0C        = "39adb5"
-let g:base16_gui0C = "39adb5"
+let g:tinted_gui0C = "39adb5"
 let s:gui0D        = "6182b8"
-let g:base16_gui0D = "6182b8"
+let g:tinted_gui0D = "6182b8"
 let s:gui0E        = "7c4dff"
-let g:base16_gui0E = "7c4dff"
+let g:tinted_gui0E = "7c4dff"
 let s:gui0F        = "e53935"
+let g:tinted_gui0F = "e53935"
+
+" Legacy
+let g:base16_gui00 = "fafafa"
+let g:base16_gui01 = "e7eaec"
+let g:base16_gui02 = "cceae7"
+let g:base16_gui03 = "ccd7da"
+let g:base16_gui04 = "8796b0"
+let g:base16_gui05 = "80cbc4"
+let g:base16_gui06 = "80cbc4"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff5370"
+let g:base16_gui09 = "f76d47"
+let g:base16_gui0A = "ffb62c"
+let g:base16_gui0B = "91b859"
+let g:base16_gui0C = "39adb5"
+let g:base16_gui0D = "6182b8"
+let g:base16_gui0E = "7c4dff"
 let g:base16_gui0F = "e53935"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Material Palenight
 " Scheme author: Nate Peterson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-material-palenight.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/material-palenight.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/material-palenight.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "292d3e"
-let g:base16_gui00 = "292d3e"
+let g:tinted_gui00 = "292d3e"
 let s:gui01        = "444267"
-let g:base16_gui01 = "444267"
+let g:tinted_gui01 = "444267"
 let s:gui02        = "32374d"
-let g:base16_gui02 = "32374d"
+let g:tinted_gui02 = "32374d"
 let s:gui03        = "676e95"
-let g:base16_gui03 = "676e95"
+let g:tinted_gui03 = "676e95"
 let s:gui04        = "8796b0"
-let g:base16_gui04 = "8796b0"
+let g:tinted_gui04 = "8796b0"
 let s:gui05        = "959dcb"
-let g:base16_gui05 = "959dcb"
+let g:tinted_gui05 = "959dcb"
 let s:gui06        = "959dcb"
-let g:base16_gui06 = "959dcb"
+let g:tinted_gui06 = "959dcb"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f07178"
-let g:base16_gui08 = "f07178"
+let g:tinted_gui08 = "f07178"
 let s:gui09        = "f78c6c"
-let g:base16_gui09 = "f78c6c"
+let g:tinted_gui09 = "f78c6c"
 let s:gui0A        = "ffcb6b"
-let g:base16_gui0A = "ffcb6b"
+let g:tinted_gui0A = "ffcb6b"
 let s:gui0B        = "c3e88d"
-let g:base16_gui0B = "c3e88d"
+let g:tinted_gui0B = "c3e88d"
 let s:gui0C        = "89ddff"
-let g:base16_gui0C = "89ddff"
+let g:tinted_gui0C = "89ddff"
 let s:gui0D        = "82aaff"
-let g:base16_gui0D = "82aaff"
+let g:tinted_gui0D = "82aaff"
 let s:gui0E        = "c792ea"
-let g:base16_gui0E = "c792ea"
+let g:tinted_gui0E = "c792ea"
 let s:gui0F        = "ff5370"
+let g:tinted_gui0F = "ff5370"
+
+" Legacy
+let g:base16_gui00 = "292d3e"
+let g:base16_gui01 = "444267"
+let g:base16_gui02 = "32374d"
+let g:base16_gui03 = "676e95"
+let g:base16_gui04 = "8796b0"
+let g:base16_gui05 = "959dcb"
+let g:base16_gui06 = "959dcb"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f07178"
+let g:base16_gui09 = "f78c6c"
+let g:base16_gui0A = "ffcb6b"
+let g:base16_gui0B = "c3e88d"
+let g:base16_gui0C = "89ddff"
+let g:base16_gui0D = "82aaff"
+let g:base16_gui0E = "c792ea"
 let g:base16_gui0F = "ff5370"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Material Vivid
 " Scheme author: joshyrobot
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-material-vivid.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/material-vivid.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/material-vivid.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "202124"
-let g:base16_gui00 = "202124"
+let g:tinted_gui00 = "202124"
 let s:gui01        = "27292c"
-let g:base16_gui01 = "27292c"
+let g:tinted_gui01 = "27292c"
 let s:gui02        = "323639"
-let g:base16_gui02 = "323639"
+let g:tinted_gui02 = "323639"
 let s:gui03        = "44464d"
-let g:base16_gui03 = "44464d"
+let g:tinted_gui03 = "44464d"
 let s:gui04        = "676c71"
-let g:base16_gui04 = "676c71"
+let g:tinted_gui04 = "676c71"
 let s:gui05        = "80868b"
-let g:base16_gui05 = "80868b"
+let g:tinted_gui05 = "80868b"
 let s:gui06        = "9e9e9e"
-let g:base16_gui06 = "9e9e9e"
+let g:tinted_gui06 = "9e9e9e"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f44336"
-let g:base16_gui08 = "f44336"
+let g:tinted_gui08 = "f44336"
 let s:gui09        = "ff9800"
-let g:base16_gui09 = "ff9800"
+let g:tinted_gui09 = "ff9800"
 let s:gui0A        = "ffeb3b"
-let g:base16_gui0A = "ffeb3b"
+let g:tinted_gui0A = "ffeb3b"
 let s:gui0B        = "00e676"
-let g:base16_gui0B = "00e676"
+let g:tinted_gui0B = "00e676"
 let s:gui0C        = "00bcd4"
-let g:base16_gui0C = "00bcd4"
+let g:tinted_gui0C = "00bcd4"
 let s:gui0D        = "2196f3"
-let g:base16_gui0D = "2196f3"
+let g:tinted_gui0D = "2196f3"
 let s:gui0E        = "673ab7"
-let g:base16_gui0E = "673ab7"
+let g:tinted_gui0E = "673ab7"
 let s:gui0F        = "8d6e63"
+let g:tinted_gui0F = "8d6e63"
+
+" Legacy
+let g:base16_gui00 = "202124"
+let g:base16_gui01 = "27292c"
+let g:base16_gui02 = "323639"
+let g:base16_gui03 = "44464d"
+let g:base16_gui04 = "676c71"
+let g:base16_gui05 = "80868b"
+let g:base16_gui06 = "9e9e9e"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f44336"
+let g:base16_gui09 = "ff9800"
+let g:base16_gui0A = "ffeb3b"
+let g:base16_gui0B = "00e676"
+let g:base16_gui0C = "00bcd4"
+let g:base16_gui0D = "2196f3"
+let g:base16_gui0E = "673ab7"
 let g:base16_gui0F = "8d6e63"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Material
 " Scheme author: Nate Peterson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-material.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/material.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/material.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "263238"
-let g:base16_gui00 = "263238"
+let g:tinted_gui00 = "263238"
 let s:gui01        = "2e3c43"
-let g:base16_gui01 = "2e3c43"
+let g:tinted_gui01 = "2e3c43"
 let s:gui02        = "314549"
-let g:base16_gui02 = "314549"
+let g:tinted_gui02 = "314549"
 let s:gui03        = "546e7a"
-let g:base16_gui03 = "546e7a"
+let g:tinted_gui03 = "546e7a"
 let s:gui04        = "b2ccd6"
-let g:base16_gui04 = "b2ccd6"
+let g:tinted_gui04 = "b2ccd6"
 let s:gui05        = "eeffff"
-let g:base16_gui05 = "eeffff"
+let g:tinted_gui05 = "eeffff"
 let s:gui06        = "eeffff"
-let g:base16_gui06 = "eeffff"
+let g:tinted_gui06 = "eeffff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f07178"
-let g:base16_gui08 = "f07178"
+let g:tinted_gui08 = "f07178"
 let s:gui09        = "f78c6c"
-let g:base16_gui09 = "f78c6c"
+let g:tinted_gui09 = "f78c6c"
 let s:gui0A        = "ffcb6b"
-let g:base16_gui0A = "ffcb6b"
+let g:tinted_gui0A = "ffcb6b"
 let s:gui0B        = "c3e88d"
-let g:base16_gui0B = "c3e88d"
+let g:tinted_gui0B = "c3e88d"
 let s:gui0C        = "89ddff"
-let g:base16_gui0C = "89ddff"
+let g:tinted_gui0C = "89ddff"
 let s:gui0D        = "82aaff"
-let g:base16_gui0D = "82aaff"
+let g:tinted_gui0D = "82aaff"
 let s:gui0E        = "c792ea"
-let g:base16_gui0E = "c792ea"
+let g:tinted_gui0E = "c792ea"
 let s:gui0F        = "ff5370"
+let g:tinted_gui0F = "ff5370"
+
+" Legacy
+let g:base16_gui00 = "263238"
+let g:base16_gui01 = "2e3c43"
+let g:base16_gui02 = "314549"
+let g:base16_gui03 = "546e7a"
+let g:base16_gui04 = "b2ccd6"
+let g:base16_gui05 = "eeffff"
+let g:base16_gui06 = "eeffff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f07178"
+let g:base16_gui09 = "f78c6c"
+let g:base16_gui0A = "ffcb6b"
+let g:base16_gui0B = "c3e88d"
+let g:base16_gui0C = "89ddff"
+let g:base16_gui0D = "82aaff"
+let g:base16_gui0E = "c792ea"
 let g:base16_gui0F = "ff5370"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-measured-dark.vim
+++ b/colors/base16-measured-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Measured Dark
 " Scheme author: Measured (https://measured.co)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-measured-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/measured-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/measured-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "00211f"
-let g:base16_gui00 = "00211f"
+let g:tinted_gui00 = "00211f"
 let s:gui01        = "003a38"
-let g:base16_gui01 = "003a38"
+let g:tinted_gui01 = "003a38"
 let s:gui02        = "005453"
-let g:base16_gui02 = "005453"
+let g:tinted_gui02 = "005453"
 let s:gui03        = "ababab"
-let g:base16_gui03 = "ababab"
+let g:tinted_gui03 = "ababab"
 let s:gui04        = "c3c3c3"
-let g:base16_gui04 = "c3c3c3"
+let g:tinted_gui04 = "c3c3c3"
 let s:gui05        = "dcdcdc"
-let g:base16_gui05 = "dcdcdc"
+let g:tinted_gui05 = "dcdcdc"
 let s:gui06        = "efefef"
-let g:base16_gui06 = "efefef"
+let g:tinted_gui06 = "efefef"
 let s:gui07        = "f5f5f5"
-let g:base16_gui07 = "f5f5f5"
+let g:tinted_gui07 = "f5f5f5"
 let s:gui08        = "ce7e8e"
-let g:base16_gui08 = "ce7e8e"
+let g:tinted_gui08 = "ce7e8e"
 let s:gui09        = "dca37c"
-let g:base16_gui09 = "dca37c"
+let g:tinted_gui09 = "dca37c"
 let s:gui0A        = "bfac4e"
-let g:base16_gui0A = "bfac4e"
+let g:tinted_gui0A = "bfac4e"
 let s:gui0B        = "56c16f"
-let g:base16_gui0B = "56c16f"
+let g:tinted_gui0B = "56c16f"
 let s:gui0C        = "62c0be"
-let g:base16_gui0C = "62c0be"
+let g:tinted_gui0C = "62c0be"
 let s:gui0D        = "88b0da"
-let g:base16_gui0D = "88b0da"
+let g:tinted_gui0D = "88b0da"
 let s:gui0E        = "b39be0"
-let g:base16_gui0E = "b39be0"
+let g:tinted_gui0E = "b39be0"
 let s:gui0F        = "d89aba"
+let g:tinted_gui0F = "d89aba"
+
+" Legacy
+let g:base16_gui00 = "00211f"
+let g:base16_gui01 = "003a38"
+let g:base16_gui02 = "005453"
+let g:base16_gui03 = "ababab"
+let g:base16_gui04 = "c3c3c3"
+let g:base16_gui05 = "dcdcdc"
+let g:base16_gui06 = "efefef"
+let g:base16_gui07 = "f5f5f5"
+let g:base16_gui08 = "ce7e8e"
+let g:base16_gui09 = "dca37c"
+let g:base16_gui0A = "bfac4e"
+let g:base16_gui0B = "56c16f"
+let g:base16_gui0C = "62c0be"
+let g:base16_gui0D = "88b0da"
+let g:base16_gui0E = "b39be0"
 let g:base16_gui0F = "d89aba"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f5f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-measured-light.vim
+++ b/colors/base16-measured-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Measured Light
 " Scheme author: Measured (https://measured.co)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-measured-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/measured-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/measured-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fdf9f5"
-let g:base16_gui00 = "fdf9f5"
+let g:tinted_gui00 = "fdf9f5"
 let s:gui01        = "f9f5f1"
-let g:base16_gui01 = "f9f5f1"
+let g:tinted_gui01 = "f9f5f1"
 let s:gui02        = "ffeada"
-let g:base16_gui02 = "ffeada"
+let g:tinted_gui02 = "ffeada"
 let s:gui03        = "5a5a5a"
-let g:base16_gui03 = "5a5a5a"
+let g:tinted_gui03 = "5a5a5a"
 let s:gui04        = "404040"
-let g:base16_gui04 = "404040"
+let g:tinted_gui04 = "404040"
 let s:gui05        = "292929"
-let g:base16_gui05 = "292929"
+let g:tinted_gui05 = "292929"
 let s:gui06        = "181818"
-let g:base16_gui06 = "181818"
+let g:tinted_gui06 = "181818"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "ac1f35"
-let g:base16_gui08 = "ac1f35"
+let g:tinted_gui08 = "ac1f35"
 let s:gui09        = "ad5601"
-let g:base16_gui09 = "ad5601"
+let g:tinted_gui09 = "ad5601"
 let s:gui0A        = "645a00"
-let g:base16_gui0A = "645a00"
+let g:tinted_gui0A = "645a00"
 let s:gui0B        = "0c680c"
-let g:base16_gui0B = "0c680c"
+let g:tinted_gui0B = "0c680c"
 let s:gui0C        = "01716f"
-let g:base16_gui0C = "01716f"
+let g:tinted_gui0C = "01716f"
 let s:gui0D        = "0158ad"
-let g:base16_gui0D = "0158ad"
+let g:tinted_gui0D = "0158ad"
 let s:gui0E        = "6645c2"
-let g:base16_gui0E = "6645c2"
+let g:tinted_gui0E = "6645c2"
 let s:gui0F        = "a81a66"
+let g:tinted_gui0F = "a81a66"
+
+" Legacy
+let g:base16_gui00 = "fdf9f5"
+let g:base16_gui01 = "f9f5f1"
+let g:base16_gui02 = "ffeada"
+let g:base16_gui03 = "5a5a5a"
+let g:base16_gui04 = "404040"
+let g:base16_gui05 = "292929"
+let g:base16_gui06 = "181818"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "ac1f35"
+let g:base16_gui09 = "ad5601"
+let g:base16_gui0A = "645a00"
+let g:base16_gui0B = "0c680c"
+let g:base16_gui0C = "01716f"
+let g:base16_gui0D = "0158ad"
+let g:base16_gui0E = "6645c2"
 let g:base16_gui0F = "a81a66"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Mellow Purple
 " Scheme author: gidsi
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-mellow-purple.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/mellow-purple.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/mellow-purple.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1e0528"
-let g:base16_gui00 = "1e0528"
+let g:tinted_gui00 = "1e0528"
 let s:gui01        = "1a092d"
-let g:base16_gui01 = "1a092d"
+let g:tinted_gui01 = "1a092d"
 let s:gui02        = "331354"
-let g:base16_gui02 = "331354"
+let g:tinted_gui02 = "331354"
 let s:gui03        = "320f55"
-let g:base16_gui03 = "320f55"
+let g:tinted_gui03 = "320f55"
 let s:gui04        = "873582"
-let g:base16_gui04 = "873582"
+let g:tinted_gui04 = "873582"
 let s:gui05        = "ffeeff"
-let g:base16_gui05 = "ffeeff"
+let g:tinted_gui05 = "ffeeff"
 let s:gui06        = "ffeeff"
-let g:base16_gui06 = "ffeeff"
+let g:tinted_gui06 = "ffeeff"
 let s:gui07        = "f8c0ff"
-let g:base16_gui07 = "f8c0ff"
+let g:tinted_gui07 = "f8c0ff"
 let s:gui08        = "00d9e9"
-let g:base16_gui08 = "00d9e9"
+let g:tinted_gui08 = "00d9e9"
 let s:gui09        = "aa00a3"
-let g:base16_gui09 = "aa00a3"
+let g:tinted_gui09 = "aa00a3"
 let s:gui0A        = "955ae7"
-let g:base16_gui0A = "955ae7"
+let g:tinted_gui0A = "955ae7"
 let s:gui0B        = "05cb0d"
-let g:base16_gui0B = "05cb0d"
+let g:tinted_gui0B = "05cb0d"
 let s:gui0C        = "b900b1"
-let g:base16_gui0C = "b900b1"
+let g:tinted_gui0C = "b900b1"
 let s:gui0D        = "550068"
-let g:base16_gui0D = "550068"
+let g:tinted_gui0D = "550068"
 let s:gui0E        = "8991bb"
-let g:base16_gui0E = "8991bb"
+let g:tinted_gui0E = "8991bb"
 let s:gui0F        = "4d6fff"
+let g:tinted_gui0F = "4d6fff"
+
+" Legacy
+let g:base16_gui00 = "1e0528"
+let g:base16_gui01 = "1a092d"
+let g:base16_gui02 = "331354"
+let g:base16_gui03 = "320f55"
+let g:base16_gui04 = "873582"
+let g:base16_gui05 = "ffeeff"
+let g:base16_gui06 = "ffeeff"
+let g:base16_gui07 = "f8c0ff"
+let g:base16_gui08 = "00d9e9"
+let g:base16_gui09 = "aa00a3"
+let g:base16_gui0A = "955ae7"
+let g:base16_gui0B = "05cb0d"
+let g:base16_gui0C = "b900b1"
+let g:base16_gui0D = "550068"
+let g:base16_gui0E = "8991bb"
 let g:base16_gui0F = "4d6fff"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8c0ff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Mexico Light
 " Scheme author: Sheldon Johnson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-mexico-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/mexico-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/mexico-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f8f8f8"
-let g:base16_gui00 = "f8f8f8"
+let g:tinted_gui00 = "f8f8f8"
 let s:gui01        = "e8e8e8"
-let g:base16_gui01 = "e8e8e8"
+let g:tinted_gui01 = "e8e8e8"
 let s:gui02        = "d8d8d8"
-let g:base16_gui02 = "d8d8d8"
+let g:tinted_gui02 = "d8d8d8"
 let s:gui03        = "b8b8b8"
-let g:base16_gui03 = "b8b8b8"
+let g:tinted_gui03 = "b8b8b8"
 let s:gui04        = "585858"
-let g:base16_gui04 = "585858"
+let g:tinted_gui04 = "585858"
 let s:gui05        = "383838"
-let g:base16_gui05 = "383838"
+let g:tinted_gui05 = "383838"
 let s:gui06        = "282828"
-let g:base16_gui06 = "282828"
+let g:tinted_gui06 = "282828"
 let s:gui07        = "181818"
-let g:base16_gui07 = "181818"
+let g:tinted_gui07 = "181818"
 let s:gui08        = "ab4642"
-let g:base16_gui08 = "ab4642"
+let g:tinted_gui08 = "ab4642"
 let s:gui09        = "dc9656"
-let g:base16_gui09 = "dc9656"
+let g:tinted_gui09 = "dc9656"
 let s:gui0A        = "f79a0e"
-let g:base16_gui0A = "f79a0e"
+let g:tinted_gui0A = "f79a0e"
 let s:gui0B        = "538947"
-let g:base16_gui0B = "538947"
+let g:tinted_gui0B = "538947"
 let s:gui0C        = "4b8093"
-let g:base16_gui0C = "4b8093"
+let g:tinted_gui0C = "4b8093"
 let s:gui0D        = "7cafc2"
-let g:base16_gui0D = "7cafc2"
+let g:tinted_gui0D = "7cafc2"
 let s:gui0E        = "96609e"
-let g:base16_gui0E = "96609e"
+let g:tinted_gui0E = "96609e"
 let s:gui0F        = "a16946"
+let g:tinted_gui0F = "a16946"
+
+" Legacy
+let g:base16_gui00 = "f8f8f8"
+let g:base16_gui01 = "e8e8e8"
+let g:base16_gui02 = "d8d8d8"
+let g:base16_gui03 = "b8b8b8"
+let g:base16_gui04 = "585858"
+let g:base16_gui05 = "383838"
+let g:base16_gui06 = "282828"
+let g:base16_gui07 = "181818"
+let g:base16_gui08 = "ab4642"
+let g:base16_gui09 = "dc9656"
+let g:base16_gui0A = "f79a0e"
+let g:base16_gui0B = "538947"
+let g:base16_gui0C = "4b8093"
+let g:base16_gui0D = "7cafc2"
+let g:base16_gui0E = "96609e"
 let g:base16_gui0F = "a16946"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#181818",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Mocha
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-mocha.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/mocha.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/mocha.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "3b3228"
-let g:base16_gui00 = "3b3228"
+let g:tinted_gui00 = "3b3228"
 let s:gui01        = "534636"
-let g:base16_gui01 = "534636"
+let g:tinted_gui01 = "534636"
 let s:gui02        = "645240"
-let g:base16_gui02 = "645240"
+let g:tinted_gui02 = "645240"
 let s:gui03        = "7e705a"
-let g:base16_gui03 = "7e705a"
+let g:tinted_gui03 = "7e705a"
 let s:gui04        = "b8afad"
-let g:base16_gui04 = "b8afad"
+let g:tinted_gui04 = "b8afad"
 let s:gui05        = "d0c8c6"
-let g:base16_gui05 = "d0c8c6"
+let g:tinted_gui05 = "d0c8c6"
 let s:gui06        = "e9e1dd"
-let g:base16_gui06 = "e9e1dd"
+let g:tinted_gui06 = "e9e1dd"
 let s:gui07        = "f5eeeb"
-let g:base16_gui07 = "f5eeeb"
+let g:tinted_gui07 = "f5eeeb"
 let s:gui08        = "cb6077"
-let g:base16_gui08 = "cb6077"
+let g:tinted_gui08 = "cb6077"
 let s:gui09        = "d28b71"
-let g:base16_gui09 = "d28b71"
+let g:tinted_gui09 = "d28b71"
 let s:gui0A        = "f4bc87"
-let g:base16_gui0A = "f4bc87"
+let g:tinted_gui0A = "f4bc87"
 let s:gui0B        = "beb55b"
-let g:base16_gui0B = "beb55b"
+let g:tinted_gui0B = "beb55b"
 let s:gui0C        = "7bbda4"
-let g:base16_gui0C = "7bbda4"
+let g:tinted_gui0C = "7bbda4"
 let s:gui0D        = "8ab3b5"
-let g:base16_gui0D = "8ab3b5"
+let g:tinted_gui0D = "8ab3b5"
 let s:gui0E        = "a89bb9"
-let g:base16_gui0E = "a89bb9"
+let g:tinted_gui0E = "a89bb9"
 let s:gui0F        = "bb9584"
+let g:tinted_gui0F = "bb9584"
+
+" Legacy
+let g:base16_gui00 = "3b3228"
+let g:base16_gui01 = "534636"
+let g:base16_gui02 = "645240"
+let g:base16_gui03 = "7e705a"
+let g:base16_gui04 = "b8afad"
+let g:base16_gui05 = "d0c8c6"
+let g:base16_gui06 = "e9e1dd"
+let g:base16_gui07 = "f5eeeb"
+let g:base16_gui08 = "cb6077"
+let g:base16_gui09 = "d28b71"
+let g:base16_gui0A = "f4bc87"
+let g:base16_gui0B = "beb55b"
+let g:base16_gui0C = "7bbda4"
+let g:base16_gui0D = "8ab3b5"
+let g:base16_gui0E = "a89bb9"
 let g:base16_gui0F = "bb9584"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5eeeb",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Monokai
 " Scheme author: Wimer Hazenberg (http://www.monokai.nl)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-monokai.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/monokai.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/monokai.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "272822"
-let g:base16_gui00 = "272822"
+let g:tinted_gui00 = "272822"
 let s:gui01        = "383830"
-let g:base16_gui01 = "383830"
+let g:tinted_gui01 = "383830"
 let s:gui02        = "49483e"
-let g:base16_gui02 = "49483e"
+let g:tinted_gui02 = "49483e"
 let s:gui03        = "75715e"
-let g:base16_gui03 = "75715e"
+let g:tinted_gui03 = "75715e"
 let s:gui04        = "a59f85"
-let g:base16_gui04 = "a59f85"
+let g:tinted_gui04 = "a59f85"
 let s:gui05        = "f8f8f2"
-let g:base16_gui05 = "f8f8f2"
+let g:tinted_gui05 = "f8f8f2"
 let s:gui06        = "f5f4f1"
-let g:base16_gui06 = "f5f4f1"
+let g:tinted_gui06 = "f5f4f1"
 let s:gui07        = "f9f8f5"
-let g:base16_gui07 = "f9f8f5"
+let g:tinted_gui07 = "f9f8f5"
 let s:gui08        = "f92672"
-let g:base16_gui08 = "f92672"
+let g:tinted_gui08 = "f92672"
 let s:gui09        = "fd971f"
-let g:base16_gui09 = "fd971f"
+let g:tinted_gui09 = "fd971f"
 let s:gui0A        = "f4bf75"
-let g:base16_gui0A = "f4bf75"
+let g:tinted_gui0A = "f4bf75"
 let s:gui0B        = "a6e22e"
-let g:base16_gui0B = "a6e22e"
+let g:tinted_gui0B = "a6e22e"
 let s:gui0C        = "a1efe4"
-let g:base16_gui0C = "a1efe4"
+let g:tinted_gui0C = "a1efe4"
 let s:gui0D        = "66d9ef"
-let g:base16_gui0D = "66d9ef"
+let g:tinted_gui0D = "66d9ef"
 let s:gui0E        = "ae81ff"
-let g:base16_gui0E = "ae81ff"
+let g:tinted_gui0E = "ae81ff"
 let s:gui0F        = "cc6633"
+let g:tinted_gui0F = "cc6633"
+
+" Legacy
+let g:base16_gui00 = "272822"
+let g:base16_gui01 = "383830"
+let g:base16_gui02 = "49483e"
+let g:base16_gui03 = "75715e"
+let g:base16_gui04 = "a59f85"
+let g:base16_gui05 = "f8f8f2"
+let g:base16_gui06 = "f5f4f1"
+let g:base16_gui07 = "f9f8f5"
+let g:base16_gui08 = "f92672"
+let g:base16_gui09 = "fd971f"
+let g:base16_gui0A = "f4bf75"
+let g:base16_gui0B = "a6e22e"
+let g:base16_gui0C = "a1efe4"
+let g:base16_gui0D = "66d9ef"
+let g:base16_gui0E = "ae81ff"
 let g:base16_gui0F = "cc6633"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f9f8f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-moonlight.vim
+++ b/colors/base16-moonlight.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Moonlight
 " Scheme author: Jeremy Swinarton (https://github.com/jswinarton)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-moonlight.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/moonlight.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/moonlight.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "212337"
-let g:base16_gui00 = "212337"
+let g:tinted_gui00 = "212337"
 let s:gui01        = "403c64"
-let g:base16_gui01 = "403c64"
+let g:tinted_gui01 = "403c64"
 let s:gui02        = "596399"
-let g:base16_gui02 = "596399"
+let g:tinted_gui02 = "596399"
 let s:gui03        = "748cd6"
-let g:base16_gui03 = "748cd6"
+let g:tinted_gui03 = "748cd6"
 let s:gui04        = "a1abe0"
-let g:base16_gui04 = "a1abe0"
+let g:tinted_gui04 = "a1abe0"
 let s:gui05        = "a3ace1"
-let g:base16_gui05 = "a3ace1"
+let g:tinted_gui05 = "a3ace1"
 let s:gui06        = "b4a4f4"
-let g:base16_gui06 = "b4a4f4"
+let g:tinted_gui06 = "b4a4f4"
 let s:gui07        = "ef43fa"
-let g:base16_gui07 = "ef43fa"
+let g:tinted_gui07 = "ef43fa"
 let s:gui08        = "ff5370"
-let g:base16_gui08 = "ff5370"
+let g:tinted_gui08 = "ff5370"
 let s:gui09        = "f67f81"
-let g:base16_gui09 = "f67f81"
+let g:tinted_gui09 = "f67f81"
 let s:gui0A        = "ffc777"
-let g:base16_gui0A = "ffc777"
+let g:tinted_gui0A = "ffc777"
 let s:gui0B        = "2df4c0"
-let g:base16_gui0B = "2df4c0"
+let g:tinted_gui0B = "2df4c0"
 let s:gui0C        = "04d1f9"
-let g:base16_gui0C = "04d1f9"
+let g:tinted_gui0C = "04d1f9"
 let s:gui0D        = "40ffff"
-let g:base16_gui0D = "40ffff"
+let g:tinted_gui0D = "40ffff"
 let s:gui0E        = "b994f1"
-let g:base16_gui0E = "b994f1"
+let g:tinted_gui0E = "b994f1"
 let s:gui0F        = "ecb2f0"
+let g:tinted_gui0F = "ecb2f0"
+
+" Legacy
+let g:base16_gui00 = "212337"
+let g:base16_gui01 = "403c64"
+let g:base16_gui02 = "596399"
+let g:base16_gui03 = "748cd6"
+let g:base16_gui04 = "a1abe0"
+let g:base16_gui05 = "a3ace1"
+let g:base16_gui06 = "b4a4f4"
+let g:base16_gui07 = "ef43fa"
+let g:base16_gui08 = "ff5370"
+let g:base16_gui09 = "f67f81"
+let g:base16_gui0A = "ffc777"
+let g:base16_gui0B = "2df4c0"
+let g:base16_gui0C = "04d1f9"
+let g:base16_gui0D = "40ffff"
+let g:base16_gui0E = "b994f1"
 let g:base16_gui0F = "ecb2f0"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ef43fa",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-mountain.vim
+++ b/colors/base16-mountain.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Mountain
 " Scheme author: gnsfujiwara (https://github.com/gnsfujiwara)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-mountain.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/mountain.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/mountain.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0f0f0f"
-let g:base16_gui00 = "0f0f0f"
+let g:tinted_gui00 = "0f0f0f"
 let s:gui01        = "191919"
-let g:base16_gui01 = "191919"
+let g:tinted_gui01 = "191919"
 let s:gui02        = "262626"
-let g:base16_gui02 = "262626"
+let g:tinted_gui02 = "262626"
 let s:gui03        = "4c4c4c"
-let g:base16_gui03 = "4c4c4c"
+let g:tinted_gui03 = "4c4c4c"
 let s:gui04        = "ac8a8c"
-let g:base16_gui04 = "ac8a8c"
+let g:tinted_gui04 = "ac8a8c"
 let s:gui05        = "cacaca"
-let g:base16_gui05 = "cacaca"
+let g:tinted_gui05 = "cacaca"
 let s:gui06        = "e7e7e7"
-let g:base16_gui06 = "e7e7e7"
+let g:tinted_gui06 = "e7e7e7"
 let s:gui07        = "f0f0f0"
-let g:base16_gui07 = "f0f0f0"
+let g:tinted_gui07 = "f0f0f0"
 let s:gui08        = "ac8a8c"
-let g:base16_gui08 = "ac8a8c"
+let g:tinted_gui08 = "ac8a8c"
 let s:gui09        = "ceb188"
-let g:base16_gui09 = "ceb188"
+let g:tinted_gui09 = "ceb188"
 let s:gui0A        = "aca98a"
-let g:base16_gui0A = "aca98a"
+let g:tinted_gui0A = "aca98a"
 let s:gui0B        = "8aac8b"
-let g:base16_gui0B = "8aac8b"
+let g:tinted_gui0B = "8aac8b"
 let s:gui0C        = "8aabac"
-let g:base16_gui0C = "8aabac"
+let g:tinted_gui0C = "8aabac"
 let s:gui0D        = "8f8aac"
-let g:base16_gui0D = "8f8aac"
+let g:tinted_gui0D = "8f8aac"
 let s:gui0E        = "ac8aac"
-let g:base16_gui0E = "ac8aac"
+let g:tinted_gui0E = "ac8aac"
 let s:gui0F        = "ac8a8c"
+let g:tinted_gui0F = "ac8a8c"
+
+" Legacy
+let g:base16_gui00 = "0f0f0f"
+let g:base16_gui01 = "191919"
+let g:base16_gui02 = "262626"
+let g:base16_gui03 = "4c4c4c"
+let g:base16_gui04 = "ac8a8c"
+let g:base16_gui05 = "cacaca"
+let g:base16_gui06 = "e7e7e7"
+let g:base16_gui07 = "f0f0f0"
+let g:base16_gui08 = "ac8a8c"
+let g:base16_gui09 = "ceb188"
+let g:base16_gui0A = "aca98a"
+let g:base16_gui0B = "8aac8b"
+let g:base16_gui0C = "8aabac"
+let g:base16_gui0D = "8f8aac"
+let g:base16_gui0E = "ac8aac"
 let g:base16_gui0F = "ac8a8c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f0f0f0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Nebula
 " Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-nebula.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/nebula.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/nebula.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "22273b"
-let g:base16_gui00 = "22273b"
+let g:tinted_gui00 = "22273b"
 let s:gui01        = "414f60"
-let g:base16_gui01 = "414f60"
+let g:tinted_gui01 = "414f60"
 let s:gui02        = "5a8380"
-let g:base16_gui02 = "5a8380"
+let g:tinted_gui02 = "5a8380"
 let s:gui03        = "6e6f72"
-let g:base16_gui03 = "6e6f72"
+let g:tinted_gui03 = "6e6f72"
 let s:gui04        = "87888b"
-let g:base16_gui04 = "87888b"
+let g:tinted_gui04 = "87888b"
 let s:gui05        = "a4a6a9"
-let g:base16_gui05 = "a4a6a9"
+let g:tinted_gui05 = "a4a6a9"
 let s:gui06        = "c7c9cd"
-let g:base16_gui06 = "c7c9cd"
+let g:tinted_gui06 = "c7c9cd"
 let s:gui07        = "8dbdaa"
-let g:base16_gui07 = "8dbdaa"
+let g:tinted_gui07 = "8dbdaa"
 let s:gui08        = "777abc"
-let g:base16_gui08 = "777abc"
+let g:tinted_gui08 = "777abc"
 let s:gui09        = "94929e"
-let g:base16_gui09 = "94929e"
+let g:tinted_gui09 = "94929e"
 let s:gui0A        = "4f9062"
-let g:base16_gui0A = "4f9062"
+let g:tinted_gui0A = "4f9062"
 let s:gui0B        = "6562a8"
-let g:base16_gui0B = "6562a8"
+let g:tinted_gui0B = "6562a8"
 let s:gui0C        = "226f68"
-let g:base16_gui0C = "226f68"
+let g:tinted_gui0C = "226f68"
 let s:gui0D        = "4d6bb6"
-let g:base16_gui0D = "4d6bb6"
+let g:tinted_gui0D = "4d6bb6"
 let s:gui0E        = "716cae"
-let g:base16_gui0E = "716cae"
+let g:tinted_gui0E = "716cae"
 let s:gui0F        = "8c70a7"
+let g:tinted_gui0F = "8c70a7"
+
+" Legacy
+let g:base16_gui00 = "22273b"
+let g:base16_gui01 = "414f60"
+let g:base16_gui02 = "5a8380"
+let g:base16_gui03 = "6e6f72"
+let g:base16_gui04 = "87888b"
+let g:base16_gui05 = "a4a6a9"
+let g:base16_gui06 = "c7c9cd"
+let g:base16_gui07 = "8dbdaa"
+let g:base16_gui08 = "777abc"
+let g:base16_gui09 = "94929e"
+let g:base16_gui0A = "4f9062"
+let g:base16_gui0B = "6562a8"
+let g:base16_gui0C = "226f68"
+let g:base16_gui0D = "4d6bb6"
+let g:base16_gui0E = "716cae"
 let g:base16_gui0F = "8c70a7"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#8dbdaa",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-nord-light.vim
+++ b/colors/base16-nord-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Nord Light
 " Scheme author: threddast, based on fuxialexander&#39;s doom-nord-light-theme (Doom Emacs)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-nord-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/nord-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/nord-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "e5e9f0"
-let g:base16_gui00 = "e5e9f0"
+let g:tinted_gui00 = "e5e9f0"
 let s:gui01        = "c2d0e7"
-let g:base16_gui01 = "c2d0e7"
+let g:tinted_gui01 = "c2d0e7"
 let s:gui02        = "b8c5db"
-let g:base16_gui02 = "b8c5db"
+let g:tinted_gui02 = "b8c5db"
 let s:gui03        = "aebacf"
-let g:base16_gui03 = "aebacf"
+let g:tinted_gui03 = "aebacf"
 let s:gui04        = "60728c"
-let g:base16_gui04 = "60728c"
+let g:tinted_gui04 = "60728c"
 let s:gui05        = "2e3440"
-let g:base16_gui05 = "2e3440"
+let g:tinted_gui05 = "2e3440"
 let s:gui06        = "3b4252"
-let g:base16_gui06 = "3b4252"
+let g:tinted_gui06 = "3b4252"
 let s:gui07        = "29838d"
-let g:base16_gui07 = "29838d"
+let g:tinted_gui07 = "29838d"
 let s:gui08        = "99324b"
-let g:base16_gui08 = "99324b"
+let g:tinted_gui08 = "99324b"
 let s:gui09        = "ac4426"
-let g:base16_gui09 = "ac4426"
+let g:tinted_gui09 = "ac4426"
 let s:gui0A        = "9a7500"
-let g:base16_gui0A = "9a7500"
+let g:tinted_gui0A = "9a7500"
 let s:gui0B        = "4f894c"
-let g:base16_gui0B = "4f894c"
+let g:tinted_gui0B = "4f894c"
 let s:gui0C        = "398eac"
-let g:base16_gui0C = "398eac"
+let g:tinted_gui0C = "398eac"
 let s:gui0D        = "3b6ea8"
-let g:base16_gui0D = "3b6ea8"
+let g:tinted_gui0D = "3b6ea8"
 let s:gui0E        = "97365b"
-let g:base16_gui0E = "97365b"
+let g:tinted_gui0E = "97365b"
 let s:gui0F        = "5272af"
+let g:tinted_gui0F = "5272af"
+
+" Legacy
+let g:base16_gui00 = "e5e9f0"
+let g:base16_gui01 = "c2d0e7"
+let g:base16_gui02 = "b8c5db"
+let g:base16_gui03 = "aebacf"
+let g:base16_gui04 = "60728c"
+let g:base16_gui05 = "2e3440"
+let g:base16_gui06 = "3b4252"
+let g:base16_gui07 = "29838d"
+let g:base16_gui08 = "99324b"
+let g:base16_gui09 = "ac4426"
+let g:base16_gui0A = "9a7500"
+let g:base16_gui0B = "4f894c"
+let g:base16_gui0C = "398eac"
+let g:base16_gui0D = "3b6ea8"
+let g:base16_gui0E = "97365b"
 let g:base16_gui0F = "5272af"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#29838d",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Nord
 " Scheme author: arcticicestudio
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-nord.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/nord.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/nord.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2e3440"
-let g:base16_gui00 = "2e3440"
+let g:tinted_gui00 = "2e3440"
 let s:gui01        = "3b4252"
-let g:base16_gui01 = "3b4252"
+let g:tinted_gui01 = "3b4252"
 let s:gui02        = "434c5e"
-let g:base16_gui02 = "434c5e"
+let g:tinted_gui02 = "434c5e"
 let s:gui03        = "4c566a"
-let g:base16_gui03 = "4c566a"
+let g:tinted_gui03 = "4c566a"
 let s:gui04        = "d8dee9"
-let g:base16_gui04 = "d8dee9"
+let g:tinted_gui04 = "d8dee9"
 let s:gui05        = "e5e9f0"
-let g:base16_gui05 = "e5e9f0"
+let g:tinted_gui05 = "e5e9f0"
 let s:gui06        = "eceff4"
-let g:base16_gui06 = "eceff4"
+let g:tinted_gui06 = "eceff4"
 let s:gui07        = "8fbcbb"
-let g:base16_gui07 = "8fbcbb"
+let g:tinted_gui07 = "8fbcbb"
 let s:gui08        = "bf616a"
-let g:base16_gui08 = "bf616a"
+let g:tinted_gui08 = "bf616a"
 let s:gui09        = "d08770"
-let g:base16_gui09 = "d08770"
+let g:tinted_gui09 = "d08770"
 let s:gui0A        = "ebcb8b"
-let g:base16_gui0A = "ebcb8b"
+let g:tinted_gui0A = "ebcb8b"
 let s:gui0B        = "a3be8c"
-let g:base16_gui0B = "a3be8c"
+let g:tinted_gui0B = "a3be8c"
 let s:gui0C        = "88c0d0"
-let g:base16_gui0C = "88c0d0"
+let g:tinted_gui0C = "88c0d0"
 let s:gui0D        = "81a1c1"
-let g:base16_gui0D = "81a1c1"
+let g:tinted_gui0D = "81a1c1"
 let s:gui0E        = "b48ead"
-let g:base16_gui0E = "b48ead"
+let g:tinted_gui0E = "b48ead"
 let s:gui0F        = "5e81ac"
+let g:tinted_gui0F = "5e81ac"
+
+" Legacy
+let g:base16_gui00 = "2e3440"
+let g:base16_gui01 = "3b4252"
+let g:base16_gui02 = "434c5e"
+let g:base16_gui03 = "4c566a"
+let g:base16_gui04 = "d8dee9"
+let g:base16_gui05 = "e5e9f0"
+let g:base16_gui06 = "eceff4"
+let g:base16_gui07 = "8fbcbb"
+let g:base16_gui08 = "bf616a"
+let g:base16_gui09 = "d08770"
+let g:base16_gui0A = "ebcb8b"
+let g:base16_gui0B = "a3be8c"
+let g:base16_gui0C = "88c0d0"
+let g:base16_gui0D = "81a1c1"
+let g:base16_gui0E = "b48ead"
 let g:base16_gui0F = "5e81ac"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#8fbcbb",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Nova
 " Scheme author: George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-nova.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/nova.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/nova.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "3c4c55"
-let g:base16_gui00 = "3c4c55"
+let g:tinted_gui00 = "3c4c55"
 let s:gui01        = "556873"
-let g:base16_gui01 = "556873"
+let g:tinted_gui01 = "556873"
 let s:gui02        = "6a7d89"
-let g:base16_gui02 = "6a7d89"
+let g:tinted_gui02 = "6a7d89"
 let s:gui03        = "899ba6"
-let g:base16_gui03 = "899ba6"
+let g:tinted_gui03 = "899ba6"
 let s:gui04        = "899ba6"
-let g:base16_gui04 = "899ba6"
+let g:tinted_gui04 = "899ba6"
 let s:gui05        = "c5d4dd"
-let g:base16_gui05 = "c5d4dd"
+let g:tinted_gui05 = "c5d4dd"
 let s:gui06        = "899ba6"
-let g:base16_gui06 = "899ba6"
+let g:tinted_gui06 = "899ba6"
 let s:gui07        = "556873"
-let g:base16_gui07 = "556873"
+let g:tinted_gui07 = "556873"
 let s:gui08        = "83afe5"
-let g:base16_gui08 = "83afe5"
+let g:tinted_gui08 = "83afe5"
 let s:gui09        = "7fc1ca"
-let g:base16_gui09 = "7fc1ca"
+let g:tinted_gui09 = "7fc1ca"
 let s:gui0A        = "a8ce93"
-let g:base16_gui0A = "a8ce93"
+let g:tinted_gui0A = "a8ce93"
 let s:gui0B        = "7fc1ca"
-let g:base16_gui0B = "7fc1ca"
+let g:tinted_gui0B = "7fc1ca"
 let s:gui0C        = "f2c38f"
-let g:base16_gui0C = "f2c38f"
+let g:tinted_gui0C = "f2c38f"
 let s:gui0D        = "83afe5"
-let g:base16_gui0D = "83afe5"
+let g:tinted_gui0D = "83afe5"
 let s:gui0E        = "9a93e1"
-let g:base16_gui0E = "9a93e1"
+let g:tinted_gui0E = "9a93e1"
 let s:gui0F        = "f2c38f"
+let g:tinted_gui0F = "f2c38f"
+
+" Legacy
+let g:base16_gui00 = "3c4c55"
+let g:base16_gui01 = "556873"
+let g:base16_gui02 = "6a7d89"
+let g:base16_gui03 = "899ba6"
+let g:base16_gui04 = "899ba6"
+let g:base16_gui05 = "c5d4dd"
+let g:base16_gui06 = "899ba6"
+let g:base16_gui07 = "556873"
+let g:base16_gui08 = "83afe5"
+let g:base16_gui09 = "7fc1ca"
+let g:base16_gui0A = "a8ce93"
+let g:base16_gui0B = "7fc1ca"
+let g:base16_gui0C = "f2c38f"
+let g:base16_gui0D = "83afe5"
+let g:base16_gui0E = "9a93e1"
 let g:base16_gui0F = "f2c38f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#556873",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Ocean
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-ocean.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/ocean.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/ocean.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2b303b"
-let g:base16_gui00 = "2b303b"
+let g:tinted_gui00 = "2b303b"
 let s:gui01        = "343d46"
-let g:base16_gui01 = "343d46"
+let g:tinted_gui01 = "343d46"
 let s:gui02        = "4f5b66"
-let g:base16_gui02 = "4f5b66"
+let g:tinted_gui02 = "4f5b66"
 let s:gui03        = "65737e"
-let g:base16_gui03 = "65737e"
+let g:tinted_gui03 = "65737e"
 let s:gui04        = "a7adba"
-let g:base16_gui04 = "a7adba"
+let g:tinted_gui04 = "a7adba"
 let s:gui05        = "c0c5ce"
-let g:base16_gui05 = "c0c5ce"
+let g:tinted_gui05 = "c0c5ce"
 let s:gui06        = "dfe1e8"
-let g:base16_gui06 = "dfe1e8"
+let g:tinted_gui06 = "dfe1e8"
 let s:gui07        = "eff1f5"
-let g:base16_gui07 = "eff1f5"
+let g:tinted_gui07 = "eff1f5"
 let s:gui08        = "bf616a"
-let g:base16_gui08 = "bf616a"
+let g:tinted_gui08 = "bf616a"
 let s:gui09        = "d08770"
-let g:base16_gui09 = "d08770"
+let g:tinted_gui09 = "d08770"
 let s:gui0A        = "ebcb8b"
-let g:base16_gui0A = "ebcb8b"
+let g:tinted_gui0A = "ebcb8b"
 let s:gui0B        = "a3be8c"
-let g:base16_gui0B = "a3be8c"
+let g:tinted_gui0B = "a3be8c"
 let s:gui0C        = "96b5b4"
-let g:base16_gui0C = "96b5b4"
+let g:tinted_gui0C = "96b5b4"
 let s:gui0D        = "8fa1b3"
-let g:base16_gui0D = "8fa1b3"
+let g:tinted_gui0D = "8fa1b3"
 let s:gui0E        = "b48ead"
-let g:base16_gui0E = "b48ead"
+let g:tinted_gui0E = "b48ead"
 let s:gui0F        = "ab7967"
+let g:tinted_gui0F = "ab7967"
+
+" Legacy
+let g:base16_gui00 = "2b303b"
+let g:base16_gui01 = "343d46"
+let g:base16_gui02 = "4f5b66"
+let g:base16_gui03 = "65737e"
+let g:base16_gui04 = "a7adba"
+let g:base16_gui05 = "c0c5ce"
+let g:base16_gui06 = "dfe1e8"
+let g:base16_gui07 = "eff1f5"
+let g:base16_gui08 = "bf616a"
+let g:base16_gui09 = "d08770"
+let g:base16_gui0A = "ebcb8b"
+let g:base16_gui0B = "a3be8c"
+let g:base16_gui0C = "96b5b4"
+let g:base16_gui0D = "8fa1b3"
+let g:base16_gui0E = "b48ead"
 let g:base16_gui0F = "ab7967"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#eff1f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: OceanicNext
 " Scheme author: https://github.com/voronianski/oceanic-next-color-scheme
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-oceanicnext.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/oceanicnext.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/oceanicnext.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1b2b34"
-let g:base16_gui00 = "1b2b34"
+let g:tinted_gui00 = "1b2b34"
 let s:gui01        = "343d46"
-let g:base16_gui01 = "343d46"
+let g:tinted_gui01 = "343d46"
 let s:gui02        = "4f5b66"
-let g:base16_gui02 = "4f5b66"
+let g:tinted_gui02 = "4f5b66"
 let s:gui03        = "65737e"
-let g:base16_gui03 = "65737e"
+let g:tinted_gui03 = "65737e"
 let s:gui04        = "a7adba"
-let g:base16_gui04 = "a7adba"
+let g:tinted_gui04 = "a7adba"
 let s:gui05        = "c0c5ce"
-let g:base16_gui05 = "c0c5ce"
+let g:tinted_gui05 = "c0c5ce"
 let s:gui06        = "cdd3de"
-let g:base16_gui06 = "cdd3de"
+let g:tinted_gui06 = "cdd3de"
 let s:gui07        = "d8dee9"
-let g:base16_gui07 = "d8dee9"
+let g:tinted_gui07 = "d8dee9"
 let s:gui08        = "ec5f67"
-let g:base16_gui08 = "ec5f67"
+let g:tinted_gui08 = "ec5f67"
 let s:gui09        = "f99157"
-let g:base16_gui09 = "f99157"
+let g:tinted_gui09 = "f99157"
 let s:gui0A        = "fac863"
-let g:base16_gui0A = "fac863"
+let g:tinted_gui0A = "fac863"
 let s:gui0B        = "99c794"
-let g:base16_gui0B = "99c794"
+let g:tinted_gui0B = "99c794"
 let s:gui0C        = "5fb3b3"
-let g:base16_gui0C = "5fb3b3"
+let g:tinted_gui0C = "5fb3b3"
 let s:gui0D        = "6699cc"
-let g:base16_gui0D = "6699cc"
+let g:tinted_gui0D = "6699cc"
 let s:gui0E        = "c594c5"
-let g:base16_gui0E = "c594c5"
+let g:tinted_gui0E = "c594c5"
 let s:gui0F        = "ab7967"
+let g:tinted_gui0F = "ab7967"
+
+" Legacy
+let g:base16_gui00 = "1b2b34"
+let g:base16_gui01 = "343d46"
+let g:base16_gui02 = "4f5b66"
+let g:base16_gui03 = "65737e"
+let g:base16_gui04 = "a7adba"
+let g:base16_gui05 = "c0c5ce"
+let g:base16_gui06 = "cdd3de"
+let g:base16_gui07 = "d8dee9"
+let g:base16_gui08 = "ec5f67"
+let g:base16_gui09 = "f99157"
+let g:base16_gui0A = "fac863"
+let g:base16_gui0B = "99c794"
+let g:base16_gui0C = "5fb3b3"
+let g:base16_gui0D = "6699cc"
+let g:base16_gui0E = "c594c5"
 let g:base16_gui0F = "ab7967"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d8dee9",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: One Light
 " Scheme author: Daniel Pfeifer (http://github.com/purpleKarrot)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-one-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/one-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/one-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fafafa"
-let g:base16_gui00 = "fafafa"
+let g:tinted_gui00 = "fafafa"
 let s:gui01        = "f0f0f1"
-let g:base16_gui01 = "f0f0f1"
+let g:tinted_gui01 = "f0f0f1"
 let s:gui02        = "e5e5e6"
-let g:base16_gui02 = "e5e5e6"
+let g:tinted_gui02 = "e5e5e6"
 let s:gui03        = "a0a1a7"
-let g:base16_gui03 = "a0a1a7"
+let g:tinted_gui03 = "a0a1a7"
 let s:gui04        = "696c77"
-let g:base16_gui04 = "696c77"
+let g:tinted_gui04 = "696c77"
 let s:gui05        = "383a42"
-let g:base16_gui05 = "383a42"
+let g:tinted_gui05 = "383a42"
 let s:gui06        = "202227"
-let g:base16_gui06 = "202227"
+let g:tinted_gui06 = "202227"
 let s:gui07        = "090a0b"
-let g:base16_gui07 = "090a0b"
+let g:tinted_gui07 = "090a0b"
 let s:gui08        = "ca1243"
-let g:base16_gui08 = "ca1243"
+let g:tinted_gui08 = "ca1243"
 let s:gui09        = "d75f00"
-let g:base16_gui09 = "d75f00"
+let g:tinted_gui09 = "d75f00"
 let s:gui0A        = "c18401"
-let g:base16_gui0A = "c18401"
+let g:tinted_gui0A = "c18401"
 let s:gui0B        = "50a14f"
-let g:base16_gui0B = "50a14f"
+let g:tinted_gui0B = "50a14f"
 let s:gui0C        = "0184bc"
-let g:base16_gui0C = "0184bc"
+let g:tinted_gui0C = "0184bc"
 let s:gui0D        = "4078f2"
-let g:base16_gui0D = "4078f2"
+let g:tinted_gui0D = "4078f2"
 let s:gui0E        = "a626a4"
-let g:base16_gui0E = "a626a4"
+let g:tinted_gui0E = "a626a4"
 let s:gui0F        = "986801"
+let g:tinted_gui0F = "986801"
+
+" Legacy
+let g:base16_gui00 = "fafafa"
+let g:base16_gui01 = "f0f0f1"
+let g:base16_gui02 = "e5e5e6"
+let g:base16_gui03 = "a0a1a7"
+let g:base16_gui04 = "696c77"
+let g:base16_gui05 = "383a42"
+let g:base16_gui06 = "202227"
+let g:base16_gui07 = "090a0b"
+let g:base16_gui08 = "ca1243"
+let g:base16_gui09 = "d75f00"
+let g:base16_gui0A = "c18401"
+let g:base16_gui0B = "50a14f"
+let g:base16_gui0C = "0184bc"
+let g:base16_gui0D = "4078f2"
+let g:base16_gui0E = "a626a4"
 let g:base16_gui0F = "986801"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#090a0b",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-onedark-dark.vim
+++ b/colors/base16-onedark-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: OneDark Dark
 " Scheme author: olimorris (https://github.com/olimorris)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-onedark-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/onedark-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/onedark-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "1c1f24"
-let g:base16_gui01 = "1c1f24"
+let g:tinted_gui01 = "1c1f24"
 let s:gui02        = "2c313a"
-let g:base16_gui02 = "2c313a"
+let g:tinted_gui02 = "2c313a"
 let s:gui03        = "434852"
-let g:base16_gui03 = "434852"
+let g:tinted_gui03 = "434852"
 let s:gui04        = "565c64"
-let g:base16_gui04 = "565c64"
+let g:tinted_gui04 = "565c64"
 let s:gui05        = "abb2bf"
-let g:base16_gui05 = "abb2bf"
+let g:tinted_gui05 = "abb2bf"
 let s:gui06        = "b6bdca"
-let g:base16_gui06 = "b6bdca"
+let g:tinted_gui06 = "b6bdca"
 let s:gui07        = "c8ccd4"
-let g:base16_gui07 = "c8ccd4"
+let g:tinted_gui07 = "c8ccd4"
 let s:gui08        = "ef596f"
-let g:base16_gui08 = "ef596f"
+let g:tinted_gui08 = "ef596f"
 let s:gui09        = "d19a66"
-let g:base16_gui09 = "d19a66"
+let g:tinted_gui09 = "d19a66"
 let s:gui0A        = "e5c07b"
-let g:base16_gui0A = "e5c07b"
+let g:tinted_gui0A = "e5c07b"
 let s:gui0B        = "89ca78"
-let g:base16_gui0B = "89ca78"
+let g:tinted_gui0B = "89ca78"
 let s:gui0C        = "2bbac5"
-let g:base16_gui0C = "2bbac5"
+let g:tinted_gui0C = "2bbac5"
 let s:gui0D        = "61afef"
-let g:base16_gui0D = "61afef"
+let g:tinted_gui0D = "61afef"
 let s:gui0E        = "d55fde"
-let g:base16_gui0E = "d55fde"
+let g:tinted_gui0E = "d55fde"
 let s:gui0F        = "be5046"
+let g:tinted_gui0F = "be5046"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "1c1f24"
+let g:base16_gui02 = "2c313a"
+let g:base16_gui03 = "434852"
+let g:base16_gui04 = "565c64"
+let g:base16_gui05 = "abb2bf"
+let g:base16_gui06 = "b6bdca"
+let g:base16_gui07 = "c8ccd4"
+let g:base16_gui08 = "ef596f"
+let g:base16_gui09 = "d19a66"
+let g:base16_gui0A = "e5c07b"
+let g:base16_gui0B = "89ca78"
+let g:base16_gui0C = "2bbac5"
+let g:base16_gui0D = "61afef"
+let g:base16_gui0E = "d55fde"
 let g:base16_gui0F = "be5046"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c8ccd4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: OneDark
 " Scheme author: Lalit Magant (http://github.com/tilal6991)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-onedark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/onedark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/onedark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282c34"
-let g:base16_gui00 = "282c34"
+let g:tinted_gui00 = "282c34"
 let s:gui01        = "353b45"
-let g:base16_gui01 = "353b45"
+let g:tinted_gui01 = "353b45"
 let s:gui02        = "3e4451"
-let g:base16_gui02 = "3e4451"
+let g:tinted_gui02 = "3e4451"
 let s:gui03        = "545862"
-let g:base16_gui03 = "545862"
+let g:tinted_gui03 = "545862"
 let s:gui04        = "565c64"
-let g:base16_gui04 = "565c64"
+let g:tinted_gui04 = "565c64"
 let s:gui05        = "abb2bf"
-let g:base16_gui05 = "abb2bf"
+let g:tinted_gui05 = "abb2bf"
 let s:gui06        = "b6bdca"
-let g:base16_gui06 = "b6bdca"
+let g:tinted_gui06 = "b6bdca"
 let s:gui07        = "c8ccd4"
-let g:base16_gui07 = "c8ccd4"
+let g:tinted_gui07 = "c8ccd4"
 let s:gui08        = "e06c75"
-let g:base16_gui08 = "e06c75"
+let g:tinted_gui08 = "e06c75"
 let s:gui09        = "d19a66"
-let g:base16_gui09 = "d19a66"
+let g:tinted_gui09 = "d19a66"
 let s:gui0A        = "e5c07b"
-let g:base16_gui0A = "e5c07b"
+let g:tinted_gui0A = "e5c07b"
 let s:gui0B        = "98c379"
-let g:base16_gui0B = "98c379"
+let g:tinted_gui0B = "98c379"
 let s:gui0C        = "56b6c2"
-let g:base16_gui0C = "56b6c2"
+let g:tinted_gui0C = "56b6c2"
 let s:gui0D        = "61afef"
-let g:base16_gui0D = "61afef"
+let g:tinted_gui0D = "61afef"
 let s:gui0E        = "c678dd"
-let g:base16_gui0E = "c678dd"
+let g:tinted_gui0E = "c678dd"
 let s:gui0F        = "be5046"
+let g:tinted_gui0F = "be5046"
+
+" Legacy
+let g:base16_gui00 = "282c34"
+let g:base16_gui01 = "353b45"
+let g:base16_gui02 = "3e4451"
+let g:base16_gui03 = "545862"
+let g:base16_gui04 = "565c64"
+let g:base16_gui05 = "abb2bf"
+let g:base16_gui06 = "b6bdca"
+let g:base16_gui07 = "c8ccd4"
+let g:base16_gui08 = "e06c75"
+let g:base16_gui09 = "d19a66"
+let g:base16_gui0A = "e5c07b"
+let g:base16_gui0B = "98c379"
+let g:base16_gui0C = "56b6c2"
+let g:base16_gui0D = "61afef"
+let g:base16_gui0E = "c678dd"
 let g:base16_gui0F = "be5046"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c8ccd4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Outrun Dark
 " Scheme author: Hugo Delahousse (http://github.com/hugodelahousse/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-outrun-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/outrun-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/outrun-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "00002a"
-let g:base16_gui00 = "00002a"
+let g:tinted_gui00 = "00002a"
 let s:gui01        = "20204a"
-let g:base16_gui01 = "20204a"
+let g:tinted_gui01 = "20204a"
 let s:gui02        = "30305a"
-let g:base16_gui02 = "30305a"
+let g:tinted_gui02 = "30305a"
 let s:gui03        = "50507a"
-let g:base16_gui03 = "50507a"
+let g:tinted_gui03 = "50507a"
 let s:gui04        = "b0b0da"
-let g:base16_gui04 = "b0b0da"
+let g:tinted_gui04 = "b0b0da"
 let s:gui05        = "d0d0fa"
-let g:base16_gui05 = "d0d0fa"
+let g:tinted_gui05 = "d0d0fa"
 let s:gui06        = "e0e0ff"
-let g:base16_gui06 = "e0e0ff"
+let g:tinted_gui06 = "e0e0ff"
 let s:gui07        = "f5f5ff"
-let g:base16_gui07 = "f5f5ff"
+let g:tinted_gui07 = "f5f5ff"
 let s:gui08        = "ff4242"
-let g:base16_gui08 = "ff4242"
+let g:tinted_gui08 = "ff4242"
 let s:gui09        = "fc8d28"
-let g:base16_gui09 = "fc8d28"
+let g:tinted_gui09 = "fc8d28"
 let s:gui0A        = "f3e877"
-let g:base16_gui0A = "f3e877"
+let g:tinted_gui0A = "f3e877"
 let s:gui0B        = "59f176"
-let g:base16_gui0B = "59f176"
+let g:tinted_gui0B = "59f176"
 let s:gui0C        = "0ef0f0"
-let g:base16_gui0C = "0ef0f0"
+let g:tinted_gui0C = "0ef0f0"
 let s:gui0D        = "66b0ff"
-let g:base16_gui0D = "66b0ff"
+let g:tinted_gui0D = "66b0ff"
 let s:gui0E        = "f10596"
-let g:base16_gui0E = "f10596"
+let g:tinted_gui0E = "f10596"
 let s:gui0F        = "f003ef"
+let g:tinted_gui0F = "f003ef"
+
+" Legacy
+let g:base16_gui00 = "00002a"
+let g:base16_gui01 = "20204a"
+let g:base16_gui02 = "30305a"
+let g:base16_gui03 = "50507a"
+let g:base16_gui04 = "b0b0da"
+let g:base16_gui05 = "d0d0fa"
+let g:base16_gui06 = "e0e0ff"
+let g:base16_gui07 = "f5f5ff"
+let g:base16_gui08 = "ff4242"
+let g:base16_gui09 = "fc8d28"
+let g:base16_gui0A = "f3e877"
+let g:base16_gui0B = "59f176"
+let g:base16_gui0C = "0ef0f0"
+let g:base16_gui0D = "66b0ff"
+let g:base16_gui0E = "f10596"
 let g:base16_gui0F = "f003ef"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f5ff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-oxocarbon-dark.vim
+++ b/colors/base16-oxocarbon-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Oxocarbon Dark
 " Scheme author: shaunsingh/IBM
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-oxocarbon-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/oxocarbon-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/oxocarbon-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "161616"
-let g:base16_gui00 = "161616"
+let g:tinted_gui00 = "161616"
 let s:gui01        = "262626"
-let g:base16_gui01 = "262626"
+let g:tinted_gui01 = "262626"
 let s:gui02        = "393939"
-let g:base16_gui02 = "393939"
+let g:tinted_gui02 = "393939"
 let s:gui03        = "525252"
-let g:base16_gui03 = "525252"
+let g:tinted_gui03 = "525252"
 let s:gui04        = "dde1e6"
-let g:base16_gui04 = "dde1e6"
+let g:tinted_gui04 = "dde1e6"
 let s:gui05        = "f2f4f8"
-let g:base16_gui05 = "f2f4f8"
+let g:tinted_gui05 = "f2f4f8"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "08bdba"
-let g:base16_gui07 = "08bdba"
+let g:tinted_gui07 = "08bdba"
 let s:gui08        = "3ddbd9"
-let g:base16_gui08 = "3ddbd9"
+let g:tinted_gui08 = "3ddbd9"
 let s:gui09        = "78a9ff"
-let g:base16_gui09 = "78a9ff"
+let g:tinted_gui09 = "78a9ff"
 let s:gui0A        = "ee5396"
-let g:base16_gui0A = "ee5396"
+let g:tinted_gui0A = "ee5396"
 let s:gui0B        = "33b1ff"
-let g:base16_gui0B = "33b1ff"
+let g:tinted_gui0B = "33b1ff"
 let s:gui0C        = "ff7eb6"
-let g:base16_gui0C = "ff7eb6"
+let g:tinted_gui0C = "ff7eb6"
 let s:gui0D        = "42be65"
-let g:base16_gui0D = "42be65"
+let g:tinted_gui0D = "42be65"
 let s:gui0E        = "be95ff"
-let g:base16_gui0E = "be95ff"
+let g:tinted_gui0E = "be95ff"
 let s:gui0F        = "82cfff"
+let g:tinted_gui0F = "82cfff"
+
+" Legacy
+let g:base16_gui00 = "161616"
+let g:base16_gui01 = "262626"
+let g:base16_gui02 = "393939"
+let g:base16_gui03 = "525252"
+let g:base16_gui04 = "dde1e6"
+let g:base16_gui05 = "f2f4f8"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "08bdba"
+let g:base16_gui08 = "3ddbd9"
+let g:base16_gui09 = "78a9ff"
+let g:base16_gui0A = "ee5396"
+let g:base16_gui0B = "33b1ff"
+let g:base16_gui0C = "ff7eb6"
+let g:base16_gui0D = "42be65"
+let g:base16_gui0E = "be95ff"
 let g:base16_gui0F = "82cfff"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#08bdba",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-oxocarbon-light.vim
+++ b/colors/base16-oxocarbon-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Oxocarbon Light
 " Scheme author: shaunsingh/IBM
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-oxocarbon-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/oxocarbon-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/oxocarbon-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f2f4f8"
-let g:base16_gui00 = "f2f4f8"
+let g:tinted_gui00 = "f2f4f8"
 let s:gui01        = "dde1e6"
-let g:base16_gui01 = "dde1e6"
+let g:tinted_gui01 = "dde1e6"
 let s:gui02        = "525252"
-let g:base16_gui02 = "525252"
+let g:tinted_gui02 = "525252"
 let s:gui03        = "161616"
-let g:base16_gui03 = "161616"
+let g:tinted_gui03 = "161616"
 let s:gui04        = "262626"
-let g:base16_gui04 = "262626"
+let g:tinted_gui04 = "262626"
 let s:gui05        = "393939"
-let g:base16_gui05 = "393939"
+let g:tinted_gui05 = "393939"
 let s:gui06        = "525252"
-let g:base16_gui06 = "525252"
+let g:tinted_gui06 = "525252"
 let s:gui07        = "08bdba"
-let g:base16_gui07 = "08bdba"
+let g:tinted_gui07 = "08bdba"
 let s:gui08        = "ff7eb6"
-let g:base16_gui08 = "ff7eb6"
+let g:tinted_gui08 = "ff7eb6"
 let s:gui09        = "ee5396"
-let g:base16_gui09 = "ee5396"
+let g:tinted_gui09 = "ee5396"
 let s:gui0A        = "ff6f00"
-let g:base16_gui0A = "ff6f00"
+let g:tinted_gui0A = "ff6f00"
 let s:gui0B        = "0f62fe"
-let g:base16_gui0B = "0f62fe"
+let g:tinted_gui0B = "0f62fe"
 let s:gui0C        = "673ab7"
-let g:base16_gui0C = "673ab7"
+let g:tinted_gui0C = "673ab7"
 let s:gui0D        = "42be65"
-let g:base16_gui0D = "42be65"
+let g:tinted_gui0D = "42be65"
 let s:gui0E        = "be95ff"
-let g:base16_gui0E = "be95ff"
+let g:tinted_gui0E = "be95ff"
 let s:gui0F        = "37474f"
+let g:tinted_gui0F = "37474f"
+
+" Legacy
+let g:base16_gui00 = "f2f4f8"
+let g:base16_gui01 = "dde1e6"
+let g:base16_gui02 = "525252"
+let g:base16_gui03 = "161616"
+let g:base16_gui04 = "262626"
+let g:base16_gui05 = "393939"
+let g:base16_gui06 = "525252"
+let g:base16_gui07 = "08bdba"
+let g:base16_gui08 = "ff7eb6"
+let g:base16_gui09 = "ee5396"
+let g:base16_gui0A = "ff6f00"
+let g:base16_gui0B = "0f62fe"
+let g:base16_gui0C = "673ab7"
+let g:base16_gui0D = "42be65"
+let g:base16_gui0E = "be95ff"
 let g:base16_gui0F = "37474f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#08bdba",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-pandora.vim
+++ b/colors/base16-pandora.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: pandora
 " Scheme author: Cassandra Fox
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-pandora.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/pandora.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/pandora.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "131213"
-let g:base16_gui00 = "131213"
+let g:tinted_gui00 = "131213"
 let s:gui01        = "2f1823"
-let g:base16_gui01 = "2f1823"
+let g:tinted_gui01 = "2f1823"
 let s:gui02        = "472234"
-let g:base16_gui02 = "472234"
+let g:tinted_gui02 = "472234"
 let s:gui03        = "ffbee3"
-let g:base16_gui03 = "ffbee3"
+let g:tinted_gui03 = "ffbee3"
 let s:gui04        = "9b2a46"
-let g:base16_gui04 = "9b2a46"
+let g:tinted_gui04 = "9b2a46"
 let s:gui05        = "f15c99"
-let g:base16_gui05 = "f15c99"
+let g:tinted_gui05 = "f15c99"
 let s:gui06        = "81506a"
-let g:base16_gui06 = "81506a"
+let g:tinted_gui06 = "81506a"
 let s:gui07        = "632227"
-let g:base16_gui07 = "632227"
+let g:tinted_gui07 = "632227"
 let s:gui08        = "b00b69"
-let g:base16_gui08 = "b00b69"
+let g:tinted_gui08 = "b00b69"
 let s:gui09        = "ff9153"
-let g:base16_gui09 = "ff9153"
+let g:tinted_gui09 = "ff9153"
 let s:gui0A        = "ffcc00"
-let g:base16_gui0A = "ffcc00"
+let g:tinted_gui0A = "ffcc00"
 let s:gui0B        = "9ddf69"
-let g:base16_gui0B = "9ddf69"
+let g:tinted_gui0B = "9ddf69"
 let s:gui0C        = "714ca6"
-let g:base16_gui0C = "714ca6"
+let g:tinted_gui0C = "714ca6"
 let s:gui0D        = "008080"
-let g:base16_gui0D = "008080"
+let g:tinted_gui0D = "008080"
 let s:gui0E        = "a24030"
-let g:base16_gui0E = "a24030"
+let g:tinted_gui0E = "a24030"
 let s:gui0F        = "a24030"
+let g:tinted_gui0F = "a24030"
+
+" Legacy
+let g:base16_gui00 = "131213"
+let g:base16_gui01 = "2f1823"
+let g:base16_gui02 = "472234"
+let g:base16_gui03 = "ffbee3"
+let g:base16_gui04 = "9b2a46"
+let g:base16_gui05 = "f15c99"
+let g:base16_gui06 = "81506a"
+let g:base16_gui07 = "632227"
+let g:base16_gui08 = "b00b69"
+let g:base16_gui09 = "ff9153"
+let g:base16_gui0A = "ffcc00"
+let g:base16_gui0B = "9ddf69"
+let g:base16_gui0C = "714ca6"
+let g:base16_gui0D = "008080"
+let g:base16_gui0E = "a24030"
 let g:base16_gui0F = "a24030"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#632227",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: PaperColor Dark
 " Scheme author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-papercolor-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/papercolor-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/papercolor-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c1c1c"
-let g:base16_gui00 = "1c1c1c"
+let g:tinted_gui00 = "1c1c1c"
 let s:gui01        = "af005f"
-let g:base16_gui01 = "af005f"
+let g:tinted_gui01 = "af005f"
 let s:gui02        = "5faf00"
-let g:base16_gui02 = "5faf00"
+let g:tinted_gui02 = "5faf00"
 let s:gui03        = "d7af5f"
-let g:base16_gui03 = "d7af5f"
+let g:tinted_gui03 = "d7af5f"
 let s:gui04        = "5fafd7"
-let g:base16_gui04 = "5fafd7"
+let g:tinted_gui04 = "5fafd7"
 let s:gui05        = "808080"
-let g:base16_gui05 = "808080"
+let g:tinted_gui05 = "808080"
 let s:gui06        = "d7875f"
-let g:base16_gui06 = "d7875f"
+let g:tinted_gui06 = "d7875f"
 let s:gui07        = "d0d0d0"
-let g:base16_gui07 = "d0d0d0"
+let g:tinted_gui07 = "d0d0d0"
 let s:gui08        = "585858"
-let g:base16_gui08 = "585858"
+let g:tinted_gui08 = "585858"
 let s:gui09        = "5faf5f"
-let g:base16_gui09 = "5faf5f"
+let g:tinted_gui09 = "5faf5f"
 let s:gui0A        = "afd700"
-let g:base16_gui0A = "afd700"
+let g:tinted_gui0A = "afd700"
 let s:gui0B        = "af87d7"
-let g:base16_gui0B = "af87d7"
+let g:tinted_gui0B = "af87d7"
 let s:gui0C        = "ffaf00"
-let g:base16_gui0C = "ffaf00"
+let g:tinted_gui0C = "ffaf00"
 let s:gui0D        = "ff5faf"
-let g:base16_gui0D = "ff5faf"
+let g:tinted_gui0D = "ff5faf"
 let s:gui0E        = "00afaf"
-let g:base16_gui0E = "00afaf"
+let g:tinted_gui0E = "00afaf"
 let s:gui0F        = "5f8787"
+let g:tinted_gui0F = "5f8787"
+
+" Legacy
+let g:base16_gui00 = "1c1c1c"
+let g:base16_gui01 = "af005f"
+let g:base16_gui02 = "5faf00"
+let g:base16_gui03 = "d7af5f"
+let g:base16_gui04 = "5fafd7"
+let g:base16_gui05 = "808080"
+let g:base16_gui06 = "d7875f"
+let g:base16_gui07 = "d0d0d0"
+let g:base16_gui08 = "585858"
+let g:base16_gui09 = "5faf5f"
+let g:base16_gui0A = "afd700"
+let g:base16_gui0B = "af87d7"
+let g:base16_gui0C = "ffaf00"
+let g:base16_gui0D = "ff5faf"
+let g:base16_gui0E = "00afaf"
 let g:base16_gui0F = "5f8787"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d0d0d0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: PaperColor Light
 " Scheme author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-papercolor-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/papercolor-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/papercolor-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "eeeeee"
-let g:base16_gui00 = "eeeeee"
+let g:tinted_gui00 = "eeeeee"
 let s:gui01        = "af0000"
-let g:base16_gui01 = "af0000"
+let g:tinted_gui01 = "af0000"
 let s:gui02        = "008700"
-let g:base16_gui02 = "008700"
+let g:tinted_gui02 = "008700"
 let s:gui03        = "5f8700"
-let g:base16_gui03 = "5f8700"
+let g:tinted_gui03 = "5f8700"
 let s:gui04        = "0087af"
-let g:base16_gui04 = "0087af"
+let g:tinted_gui04 = "0087af"
 let s:gui05        = "444444"
-let g:base16_gui05 = "444444"
+let g:tinted_gui05 = "444444"
 let s:gui06        = "005f87"
-let g:base16_gui06 = "005f87"
+let g:tinted_gui06 = "005f87"
 let s:gui07        = "878787"
-let g:base16_gui07 = "878787"
+let g:tinted_gui07 = "878787"
 let s:gui08        = "bcbcbc"
-let g:base16_gui08 = "bcbcbc"
+let g:tinted_gui08 = "bcbcbc"
 let s:gui09        = "d70000"
-let g:base16_gui09 = "d70000"
+let g:tinted_gui09 = "d70000"
 let s:gui0A        = "d70087"
-let g:base16_gui0A = "d70087"
+let g:tinted_gui0A = "d70087"
 let s:gui0B        = "8700af"
-let g:base16_gui0B = "8700af"
+let g:tinted_gui0B = "8700af"
 let s:gui0C        = "d75f00"
-let g:base16_gui0C = "d75f00"
+let g:tinted_gui0C = "d75f00"
 let s:gui0D        = "d75f00"
-let g:base16_gui0D = "d75f00"
+let g:tinted_gui0D = "d75f00"
 let s:gui0E        = "005faf"
-let g:base16_gui0E = "005faf"
+let g:tinted_gui0E = "005faf"
 let s:gui0F        = "005f87"
+let g:tinted_gui0F = "005f87"
+
+" Legacy
+let g:base16_gui00 = "eeeeee"
+let g:base16_gui01 = "af0000"
+let g:base16_gui02 = "008700"
+let g:base16_gui03 = "5f8700"
+let g:base16_gui04 = "0087af"
+let g:base16_gui05 = "444444"
+let g:base16_gui06 = "005f87"
+let g:base16_gui07 = "878787"
+let g:base16_gui08 = "bcbcbc"
+let g:base16_gui09 = "d70000"
+let g:base16_gui0A = "d70087"
+let g:base16_gui0B = "8700af"
+let g:base16_gui0C = "d75f00"
+let g:base16_gui0D = "d75f00"
+let g:base16_gui0E = "005faf"
 let g:base16_gui0F = "005f87"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#878787",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Paraiso
 " Scheme author: Jan T. Sott
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-paraiso.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/paraiso.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/paraiso.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2f1e2e"
-let g:base16_gui00 = "2f1e2e"
+let g:tinted_gui00 = "2f1e2e"
 let s:gui01        = "41323f"
-let g:base16_gui01 = "41323f"
+let g:tinted_gui01 = "41323f"
 let s:gui02        = "4f424c"
-let g:base16_gui02 = "4f424c"
+let g:tinted_gui02 = "4f424c"
 let s:gui03        = "776e71"
-let g:base16_gui03 = "776e71"
+let g:tinted_gui03 = "776e71"
 let s:gui04        = "8d8687"
-let g:base16_gui04 = "8d8687"
+let g:tinted_gui04 = "8d8687"
 let s:gui05        = "a39e9b"
-let g:base16_gui05 = "a39e9b"
+let g:tinted_gui05 = "a39e9b"
 let s:gui06        = "b9b6b0"
-let g:base16_gui06 = "b9b6b0"
+let g:tinted_gui06 = "b9b6b0"
 let s:gui07        = "e7e9db"
-let g:base16_gui07 = "e7e9db"
+let g:tinted_gui07 = "e7e9db"
 let s:gui08        = "ef6155"
-let g:base16_gui08 = "ef6155"
+let g:tinted_gui08 = "ef6155"
 let s:gui09        = "f99b15"
-let g:base16_gui09 = "f99b15"
+let g:tinted_gui09 = "f99b15"
 let s:gui0A        = "fec418"
-let g:base16_gui0A = "fec418"
+let g:tinted_gui0A = "fec418"
 let s:gui0B        = "48b685"
-let g:base16_gui0B = "48b685"
+let g:tinted_gui0B = "48b685"
 let s:gui0C        = "5bc4bf"
-let g:base16_gui0C = "5bc4bf"
+let g:tinted_gui0C = "5bc4bf"
 let s:gui0D        = "06b6ef"
-let g:base16_gui0D = "06b6ef"
+let g:tinted_gui0D = "06b6ef"
 let s:gui0E        = "815ba4"
-let g:base16_gui0E = "815ba4"
+let g:tinted_gui0E = "815ba4"
 let s:gui0F        = "e96ba8"
+let g:tinted_gui0F = "e96ba8"
+
+" Legacy
+let g:base16_gui00 = "2f1e2e"
+let g:base16_gui01 = "41323f"
+let g:base16_gui02 = "4f424c"
+let g:base16_gui03 = "776e71"
+let g:base16_gui04 = "8d8687"
+let g:base16_gui05 = "a39e9b"
+let g:base16_gui06 = "b9b6b0"
+let g:base16_gui07 = "e7e9db"
+let g:base16_gui08 = "ef6155"
+let g:base16_gui09 = "f99b15"
+let g:base16_gui0A = "fec418"
+let g:base16_gui0B = "48b685"
+let g:base16_gui0C = "5bc4bf"
+let g:base16_gui0D = "06b6ef"
+let g:base16_gui0E = "815ba4"
 let g:base16_gui0F = "e96ba8"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e7e9db",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Pasque
 " Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-pasque.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/pasque.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/pasque.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "271c3a"
-let g:base16_gui00 = "271c3a"
+let g:tinted_gui00 = "271c3a"
 let s:gui01        = "100323"
-let g:base16_gui01 = "100323"
+let g:tinted_gui01 = "100323"
 let s:gui02        = "3e2d5c"
-let g:base16_gui02 = "3e2d5c"
+let g:tinted_gui02 = "3e2d5c"
 let s:gui03        = "5d5766"
-let g:base16_gui03 = "5d5766"
+let g:tinted_gui03 = "5d5766"
 let s:gui04        = "bebcbf"
-let g:base16_gui04 = "bebcbf"
+let g:tinted_gui04 = "bebcbf"
 let s:gui05        = "dedcdf"
-let g:base16_gui05 = "dedcdf"
+let g:tinted_gui05 = "dedcdf"
 let s:gui06        = "edeaef"
-let g:base16_gui06 = "edeaef"
+let g:tinted_gui06 = "edeaef"
 let s:gui07        = "bbaadd"
-let g:base16_gui07 = "bbaadd"
+let g:tinted_gui07 = "bbaadd"
 let s:gui08        = "a92258"
-let g:base16_gui08 = "a92258"
+let g:tinted_gui08 = "a92258"
 let s:gui09        = "918889"
-let g:base16_gui09 = "918889"
+let g:tinted_gui09 = "918889"
 let s:gui0A        = "804ead"
-let g:base16_gui0A = "804ead"
+let g:tinted_gui0A = "804ead"
 let s:gui0B        = "c6914b"
-let g:base16_gui0B = "c6914b"
+let g:tinted_gui0B = "c6914b"
 let s:gui0C        = "7263aa"
-let g:base16_gui0C = "7263aa"
+let g:tinted_gui0C = "7263aa"
 let s:gui0D        = "8e7dc6"
-let g:base16_gui0D = "8e7dc6"
+let g:tinted_gui0D = "8e7dc6"
 let s:gui0E        = "953b9d"
-let g:base16_gui0E = "953b9d"
+let g:tinted_gui0E = "953b9d"
 let s:gui0F        = "59325c"
+let g:tinted_gui0F = "59325c"
+
+" Legacy
+let g:base16_gui00 = "271c3a"
+let g:base16_gui01 = "100323"
+let g:base16_gui02 = "3e2d5c"
+let g:base16_gui03 = "5d5766"
+let g:base16_gui04 = "bebcbf"
+let g:base16_gui05 = "dedcdf"
+let g:base16_gui06 = "edeaef"
+let g:base16_gui07 = "bbaadd"
+let g:base16_gui08 = "a92258"
+let g:base16_gui09 = "918889"
+let g:base16_gui0A = "804ead"
+let g:base16_gui0B = "c6914b"
+let g:base16_gui0C = "7263aa"
+let g:base16_gui0D = "8e7dc6"
+let g:base16_gui0E = "953b9d"
 let g:base16_gui0F = "59325c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#bbaadd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: PhD
 " Scheme author: Hennig Hasemann (http://leetless.de/vim.html)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-phd.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/phd.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/phd.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "061229"
-let g:base16_gui00 = "061229"
+let g:tinted_gui00 = "061229"
 let s:gui01        = "2a3448"
-let g:base16_gui01 = "2a3448"
+let g:tinted_gui01 = "2a3448"
 let s:gui02        = "4d5666"
-let g:base16_gui02 = "4d5666"
+let g:tinted_gui02 = "4d5666"
 let s:gui03        = "717885"
-let g:base16_gui03 = "717885"
+let g:tinted_gui03 = "717885"
 let s:gui04        = "9a99a3"
-let g:base16_gui04 = "9a99a3"
+let g:tinted_gui04 = "9a99a3"
 let s:gui05        = "b8bbc2"
-let g:base16_gui05 = "b8bbc2"
+let g:tinted_gui05 = "b8bbc2"
 let s:gui06        = "dbdde0"
-let g:base16_gui06 = "dbdde0"
+let g:tinted_gui06 = "dbdde0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "d07346"
-let g:base16_gui08 = "d07346"
+let g:tinted_gui08 = "d07346"
 let s:gui09        = "f0a000"
-let g:base16_gui09 = "f0a000"
+let g:tinted_gui09 = "f0a000"
 let s:gui0A        = "fbd461"
-let g:base16_gui0A = "fbd461"
+let g:tinted_gui0A = "fbd461"
 let s:gui0B        = "99bf52"
-let g:base16_gui0B = "99bf52"
+let g:tinted_gui0B = "99bf52"
 let s:gui0C        = "72b9bf"
-let g:base16_gui0C = "72b9bf"
+let g:tinted_gui0C = "72b9bf"
 let s:gui0D        = "5299bf"
-let g:base16_gui0D = "5299bf"
+let g:tinted_gui0D = "5299bf"
 let s:gui0E        = "9989cc"
-let g:base16_gui0E = "9989cc"
+let g:tinted_gui0E = "9989cc"
 let s:gui0F        = "b08060"
+let g:tinted_gui0F = "b08060"
+
+" Legacy
+let g:base16_gui00 = "061229"
+let g:base16_gui01 = "2a3448"
+let g:base16_gui02 = "4d5666"
+let g:base16_gui03 = "717885"
+let g:base16_gui04 = "9a99a3"
+let g:base16_gui05 = "b8bbc2"
+let g:base16_gui06 = "dbdde0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "d07346"
+let g:base16_gui09 = "f0a000"
+let g:base16_gui0A = "fbd461"
+let g:base16_gui0B = "99bf52"
+let g:base16_gui0C = "72b9bf"
+let g:base16_gui0D = "5299bf"
+let g:base16_gui0E = "9989cc"
 let g:base16_gui0F = "b08060"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Pico
 " Scheme author: PICO-8 (http://www.lexaloffle.com/pico-8.php)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-pico.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/pico.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/pico.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "1d2b53"
-let g:base16_gui01 = "1d2b53"
+let g:tinted_gui01 = "1d2b53"
 let s:gui02        = "7e2553"
-let g:base16_gui02 = "7e2553"
+let g:tinted_gui02 = "7e2553"
 let s:gui03        = "008751"
-let g:base16_gui03 = "008751"
+let g:tinted_gui03 = "008751"
 let s:gui04        = "ab5236"
-let g:base16_gui04 = "ab5236"
+let g:tinted_gui04 = "ab5236"
 let s:gui05        = "5f574f"
-let g:base16_gui05 = "5f574f"
+let g:tinted_gui05 = "5f574f"
 let s:gui06        = "c2c3c7"
-let g:base16_gui06 = "c2c3c7"
+let g:tinted_gui06 = "c2c3c7"
 let s:gui07        = "fff1e8"
-let g:base16_gui07 = "fff1e8"
+let g:tinted_gui07 = "fff1e8"
 let s:gui08        = "ff004d"
-let g:base16_gui08 = "ff004d"
+let g:tinted_gui08 = "ff004d"
 let s:gui09        = "ffa300"
-let g:base16_gui09 = "ffa300"
+let g:tinted_gui09 = "ffa300"
 let s:gui0A        = "fff024"
-let g:base16_gui0A = "fff024"
+let g:tinted_gui0A = "fff024"
 let s:gui0B        = "00e756"
-let g:base16_gui0B = "00e756"
+let g:tinted_gui0B = "00e756"
 let s:gui0C        = "29adff"
-let g:base16_gui0C = "29adff"
+let g:tinted_gui0C = "29adff"
 let s:gui0D        = "83769c"
-let g:base16_gui0D = "83769c"
+let g:tinted_gui0D = "83769c"
 let s:gui0E        = "ff77a8"
-let g:base16_gui0E = "ff77a8"
+let g:tinted_gui0E = "ff77a8"
 let s:gui0F        = "ffccaa"
+let g:tinted_gui0F = "ffccaa"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "1d2b53"
+let g:base16_gui02 = "7e2553"
+let g:base16_gui03 = "008751"
+let g:base16_gui04 = "ab5236"
+let g:base16_gui05 = "5f574f"
+let g:base16_gui06 = "c2c3c7"
+let g:base16_gui07 = "fff1e8"
+let g:base16_gui08 = "ff004d"
+let g:base16_gui09 = "ffa300"
+let g:base16_gui0A = "fff024"
+let g:base16_gui0B = "00e756"
+let g:base16_gui0C = "29adff"
+let g:base16_gui0D = "83769c"
+let g:base16_gui0E = "ff77a8"
 let g:base16_gui0F = "ffccaa"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fff1e8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-pinky.vim
+++ b/colors/base16-pinky.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: pinky
 " Scheme author: Benjamin (https://github.com/b3nj5m1n)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-pinky.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/pinky.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/pinky.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171517"
-let g:base16_gui00 = "171517"
+let g:tinted_gui00 = "171517"
 let s:gui01        = "1b181b"
-let g:base16_gui01 = "1b181b"
+let g:tinted_gui01 = "1b181b"
 let s:gui02        = "1d1b1d"
-let g:base16_gui02 = "1d1b1d"
+let g:tinted_gui02 = "1d1b1d"
 let s:gui03        = "383338"
-let g:base16_gui03 = "383338"
+let g:tinted_gui03 = "383338"
 let s:gui04        = "e7dbdb"
-let g:base16_gui04 = "e7dbdb"
+let g:tinted_gui04 = "e7dbdb"
 let s:gui05        = "f5f5f5"
-let g:base16_gui05 = "f5f5f5"
+let g:tinted_gui05 = "f5f5f5"
 let s:gui06        = "ffffff"
-let g:base16_gui06 = "ffffff"
+let g:tinted_gui06 = "ffffff"
 let s:gui07        = "f7f3f7"
-let g:base16_gui07 = "f7f3f7"
+let g:tinted_gui07 = "f7f3f7"
 let s:gui08        = "ffa600"
-let g:base16_gui08 = "ffa600"
+let g:tinted_gui08 = "ffa600"
 let s:gui09        = "00ff66"
-let g:base16_gui09 = "00ff66"
+let g:tinted_gui09 = "00ff66"
 let s:gui0A        = "20df6c"
-let g:base16_gui0A = "20df6c"
+let g:tinted_gui0A = "20df6c"
 let s:gui0B        = "ff0066"
-let g:base16_gui0B = "ff0066"
+let g:tinted_gui0B = "ff0066"
 let s:gui0C        = "6600ff"
-let g:base16_gui0C = "6600ff"
+let g:tinted_gui0C = "6600ff"
 let s:gui0D        = "00ffff"
-let g:base16_gui0D = "00ffff"
+let g:tinted_gui0D = "00ffff"
 let s:gui0E        = "007fff"
-let g:base16_gui0E = "007fff"
+let g:tinted_gui0E = "007fff"
 let s:gui0F        = "df206c"
+let g:tinted_gui0F = "df206c"
+
+" Legacy
+let g:base16_gui00 = "171517"
+let g:base16_gui01 = "1b181b"
+let g:base16_gui02 = "1d1b1d"
+let g:base16_gui03 = "383338"
+let g:base16_gui04 = "e7dbdb"
+let g:base16_gui05 = "f5f5f5"
+let g:base16_gui06 = "ffffff"
+let g:base16_gui07 = "f7f3f7"
+let g:base16_gui08 = "ffa600"
+let g:base16_gui09 = "00ff66"
+let g:base16_gui0A = "20df6c"
+let g:base16_gui0B = "ff0066"
+let g:base16_gui0C = "6600ff"
+let g:base16_gui0D = "00ffff"
+let g:base16_gui0E = "007fff"
 let g:base16_gui0F = "df206c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f7f3f7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Pop
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-pop.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/pop.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/pop.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "202020"
-let g:base16_gui01 = "202020"
+let g:tinted_gui01 = "202020"
 let s:gui02        = "303030"
-let g:base16_gui02 = "303030"
+let g:tinted_gui02 = "303030"
 let s:gui03        = "505050"
-let g:base16_gui03 = "505050"
+let g:tinted_gui03 = "505050"
 let s:gui04        = "b0b0b0"
-let g:base16_gui04 = "b0b0b0"
+let g:tinted_gui04 = "b0b0b0"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "eb008a"
-let g:base16_gui08 = "eb008a"
+let g:tinted_gui08 = "eb008a"
 let s:gui09        = "f29333"
-let g:base16_gui09 = "f29333"
+let g:tinted_gui09 = "f29333"
 let s:gui0A        = "f8ca12"
-let g:base16_gui0A = "f8ca12"
+let g:tinted_gui0A = "f8ca12"
 let s:gui0B        = "37b349"
-let g:base16_gui0B = "37b349"
+let g:tinted_gui0B = "37b349"
 let s:gui0C        = "00aabb"
-let g:base16_gui0C = "00aabb"
+let g:tinted_gui0C = "00aabb"
 let s:gui0D        = "0e5a94"
-let g:base16_gui0D = "0e5a94"
+let g:tinted_gui0D = "0e5a94"
 let s:gui0E        = "b31e8d"
-let g:base16_gui0E = "b31e8d"
+let g:tinted_gui0E = "b31e8d"
 let s:gui0F        = "7a2d00"
+let g:tinted_gui0F = "7a2d00"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "202020"
+let g:base16_gui02 = "303030"
+let g:base16_gui03 = "505050"
+let g:base16_gui04 = "b0b0b0"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "eb008a"
+let g:base16_gui09 = "f29333"
+let g:base16_gui0A = "f8ca12"
+let g:base16_gui0B = "37b349"
+let g:base16_gui0C = "00aabb"
+let g:base16_gui0D = "0e5a94"
+let g:base16_gui0E = "b31e8d"
 let g:base16_gui0F = "7a2d00"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Porple
 " Scheme author: Niek den Breeje (https://github.com/AuditeMarlow)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-porple.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/porple.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/porple.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "292c36"
-let g:base16_gui00 = "292c36"
+let g:tinted_gui00 = "292c36"
 let s:gui01        = "333344"
-let g:base16_gui01 = "333344"
+let g:tinted_gui01 = "333344"
 let s:gui02        = "474160"
-let g:base16_gui02 = "474160"
+let g:tinted_gui02 = "474160"
 let s:gui03        = "65568a"
-let g:base16_gui03 = "65568a"
+let g:tinted_gui03 = "65568a"
 let s:gui04        = "b8b8b8"
-let g:base16_gui04 = "b8b8b8"
+let g:tinted_gui04 = "b8b8b8"
 let s:gui05        = "d8d8d8"
-let g:base16_gui05 = "d8d8d8"
+let g:tinted_gui05 = "d8d8d8"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "f8f8f8"
-let g:base16_gui07 = "f8f8f8"
+let g:tinted_gui07 = "f8f8f8"
 let s:gui08        = "f84547"
-let g:base16_gui08 = "f84547"
+let g:tinted_gui08 = "f84547"
 let s:gui09        = "d28e5d"
-let g:base16_gui09 = "d28e5d"
+let g:tinted_gui09 = "d28e5d"
 let s:gui0A        = "efa16b"
-let g:base16_gui0A = "efa16b"
+let g:tinted_gui0A = "efa16b"
 let s:gui0B        = "95c76f"
-let g:base16_gui0B = "95c76f"
+let g:tinted_gui0B = "95c76f"
 let s:gui0C        = "64878f"
-let g:base16_gui0C = "64878f"
+let g:tinted_gui0C = "64878f"
 let s:gui0D        = "8485ce"
-let g:base16_gui0D = "8485ce"
+let g:tinted_gui0D = "8485ce"
 let s:gui0E        = "b74989"
-let g:base16_gui0E = "b74989"
+let g:tinted_gui0E = "b74989"
 let s:gui0F        = "986841"
+let g:tinted_gui0F = "986841"
+
+" Legacy
+let g:base16_gui00 = "292c36"
+let g:base16_gui01 = "333344"
+let g:base16_gui02 = "474160"
+let g:base16_gui03 = "65568a"
+let g:base16_gui04 = "b8b8b8"
+let g:base16_gui05 = "d8d8d8"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "f8f8f8"
+let g:base16_gui08 = "f84547"
+let g:base16_gui09 = "d28e5d"
+let g:base16_gui0A = "efa16b"
+let g:base16_gui0B = "95c76f"
+let g:base16_gui0C = "64878f"
+let g:base16_gui0D = "8485ce"
+let g:base16_gui0E = "b74989"
 let g:base16_gui0F = "986841"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8f8f8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-precious-dark-eleven.vim
+++ b/colors/base16-precious-dark-eleven.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Precious Dark Eleven
 " Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-precious-dark-eleven.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/precious-dark-eleven.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/precious-dark-eleven.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c1e20"
-let g:base16_gui00 = "1c1e20"
+let g:tinted_gui00 = "1c1e20"
 let s:gui01        = "292b2d"
-let g:base16_gui01 = "292b2d"
+let g:tinted_gui01 = "292b2d"
 let s:gui02        = "37393a"
-let g:base16_gui02 = "37393a"
+let g:tinted_gui02 = "37393a"
 let s:gui03        = "858585"
-let g:base16_gui03 = "858585"
+let g:tinted_gui03 = "858585"
 let s:gui04        = "a8a8a7"
-let g:base16_gui04 = "a8a8a7"
+let g:tinted_gui04 = "a8a8a7"
 let s:gui05        = "b8b7b6"
-let g:base16_gui05 = "b8b7b6"
+let g:tinted_gui05 = "b8b7b6"
 let s:gui06        = "b8b7b6"
-let g:base16_gui06 = "b8b7b6"
+let g:tinted_gui06 = "b8b7b6"
 let s:gui07        = "b8b7b6"
-let g:base16_gui07 = "b8b7b6"
+let g:tinted_gui07 = "b8b7b6"
 let s:gui08        = "ff8782"
-let g:base16_gui08 = "ff8782"
+let g:tinted_gui08 = "ff8782"
 let s:gui09        = "ea9755"
-let g:base16_gui09 = "ea9755"
+let g:tinted_gui09 = "ea9755"
 let s:gui0A        = "d0a543"
-let g:base16_gui0A = "d0a543"
+let g:tinted_gui0A = "d0a543"
 let s:gui0B        = "95b658"
-let g:base16_gui0B = "95b658"
+let g:tinted_gui0B = "95b658"
 let s:gui0C        = "42bda7"
-let g:base16_gui0C = "42bda7"
+let g:tinted_gui0C = "42bda7"
 let s:gui0D        = "68b0ee"
-let g:base16_gui0D = "68b0ee"
+let g:tinted_gui0D = "68b0ee"
 let s:gui0E        = "b799fe"
-let g:base16_gui0E = "b799fe"
+let g:tinted_gui0E = "b799fe"
 let s:gui0F        = "f382d8"
+let g:tinted_gui0F = "f382d8"
+
+" Legacy
+let g:base16_gui00 = "1c1e20"
+let g:base16_gui01 = "292b2d"
+let g:base16_gui02 = "37393a"
+let g:base16_gui03 = "858585"
+let g:base16_gui04 = "a8a8a7"
+let g:base16_gui05 = "b8b7b6"
+let g:base16_gui06 = "b8b7b6"
+let g:base16_gui07 = "b8b7b6"
+let g:base16_gui08 = "ff8782"
+let g:base16_gui09 = "ea9755"
+let g:base16_gui0A = "d0a543"
+let g:base16_gui0B = "95b658"
+let g:base16_gui0C = "42bda7"
+let g:base16_gui0D = "68b0ee"
+let g:base16_gui0E = "b799fe"
 let g:base16_gui0F = "f382d8"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#b8b7b6",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-precious-dark-fifteen.vim
+++ b/colors/base16-precious-dark-fifteen.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Precious Dark Fifteen
 " Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-precious-dark-fifteen.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/precious-dark-fifteen.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/precious-dark-fifteen.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "23262b"
-let g:base16_gui00 = "23262b"
+let g:tinted_gui00 = "23262b"
 let s:gui01        = "303337"
-let g:base16_gui01 = "303337"
+let g:tinted_gui01 = "303337"
 let s:gui02        = "3e4044"
-let g:base16_gui02 = "3e4044"
+let g:tinted_gui02 = "3e4044"
 let s:gui03        = "898989"
-let g:base16_gui03 = "898989"
+let g:tinted_gui03 = "898989"
 let s:gui04        = "abaaa8"
-let g:base16_gui04 = "abaaa8"
+let g:tinted_gui04 = "abaaa8"
 let s:gui05        = "bab9b6"
-let g:base16_gui05 = "bab9b6"
+let g:tinted_gui05 = "bab9b6"
 let s:gui06        = "bab9b6"
-let g:base16_gui06 = "bab9b6"
+let g:tinted_gui06 = "bab9b6"
 let s:gui07        = "bab9b6"
-let g:base16_gui07 = "bab9b6"
+let g:tinted_gui07 = "bab9b6"
 let s:gui08        = "ff8782"
-let g:base16_gui08 = "ff8782"
+let g:tinted_gui08 = "ff8782"
 let s:gui09        = "e99857"
-let g:base16_gui09 = "e99857"
+let g:tinted_gui09 = "e99857"
 let s:gui0A        = "cfa546"
-let g:base16_gui0A = "cfa546"
+let g:tinted_gui0A = "cfa546"
 let s:gui0B        = "95b659"
-let g:base16_gui0B = "95b659"
+let g:tinted_gui0B = "95b659"
 let s:gui0C        = "42bda7"
-let g:base16_gui0C = "42bda7"
+let g:tinted_gui0C = "42bda7"
 let s:gui0D        = "66b0ef"
-let g:base16_gui0D = "66b0ef"
+let g:tinted_gui0D = "66b0ef"
 let s:gui0E        = "b799ff"
-let g:base16_gui0E = "b799ff"
+let g:tinted_gui0E = "b799ff"
 let s:gui0F        = "f382d8"
+let g:tinted_gui0F = "f382d8"
+
+" Legacy
+let g:base16_gui00 = "23262b"
+let g:base16_gui01 = "303337"
+let g:base16_gui02 = "3e4044"
+let g:base16_gui03 = "898989"
+let g:base16_gui04 = "abaaa8"
+let g:base16_gui05 = "bab9b6"
+let g:base16_gui06 = "bab9b6"
+let g:base16_gui07 = "bab9b6"
+let g:base16_gui08 = "ff8782"
+let g:base16_gui09 = "e99857"
+let g:base16_gui0A = "cfa546"
+let g:base16_gui0B = "95b659"
+let g:base16_gui0C = "42bda7"
+let g:base16_gui0D = "66b0ef"
+let g:base16_gui0E = "b799ff"
 let g:base16_gui0F = "f382d8"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#bab9b6",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-precious-light-warm.vim
+++ b/colors/base16-precious-light-warm.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Precious Light Warm
 " Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-precious-light-warm.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/precious-light-warm.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/precious-light-warm.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fff5e5"
-let g:base16_gui00 = "fff5e5"
+let g:tinted_gui00 = "fff5e5"
 let s:gui01        = "ece4d6"
-let g:base16_gui01 = "ece4d6"
+let g:tinted_gui01 = "ece4d6"
 let s:gui02        = "d9d3c8"
-let g:base16_gui02 = "d9d3c8"
+let g:tinted_gui02 = "d9d3c8"
 let s:gui03        = "7f8080"
-let g:base16_gui03 = "7f8080"
+let g:tinted_gui03 = "7f8080"
 let s:gui04        = "5d6065"
-let g:base16_gui04 = "5d6065"
+let g:tinted_gui04 = "5d6065"
 let s:gui05        = "4e5359"
-let g:base16_gui05 = "4e5359"
+let g:tinted_gui05 = "4e5359"
 let s:gui06        = "4e5359"
-let g:base16_gui06 = "4e5359"
+let g:tinted_gui06 = "4e5359"
 let s:gui07        = "4e5359"
-let g:base16_gui07 = "4e5359"
+let g:tinted_gui07 = "4e5359"
 let s:gui08        = "b14745"
-let g:base16_gui08 = "b14745"
+let g:tinted_gui08 = "b14745"
 let s:gui09        = "a25600"
-let g:base16_gui09 = "a25600"
+let g:tinted_gui09 = "a25600"
 let s:gui0A        = "876500"
-let g:base16_gui0A = "876500"
+let g:tinted_gui0A = "876500"
 let s:gui0B        = "557300"
-let g:base16_gui0B = "557300"
+let g:tinted_gui0B = "557300"
 let s:gui0C        = "0e7767"
-let g:base16_gui0C = "0e7767"
+let g:tinted_gui0C = "0e7767"
 let s:gui0D        = "246da5"
-let g:base16_gui0D = "246da5"
+let g:tinted_gui0D = "246da5"
 let s:gui0E        = "7a50c6"
-let g:base16_gui0E = "7a50c6"
+let g:tinted_gui0E = "7a50c6"
 let s:gui0F        = "a83f92"
+let g:tinted_gui0F = "a83f92"
+
+" Legacy
+let g:base16_gui00 = "fff5e5"
+let g:base16_gui01 = "ece4d6"
+let g:base16_gui02 = "d9d3c8"
+let g:base16_gui03 = "7f8080"
+let g:base16_gui04 = "5d6065"
+let g:base16_gui05 = "4e5359"
+let g:base16_gui06 = "4e5359"
+let g:base16_gui07 = "4e5359"
+let g:base16_gui08 = "b14745"
+let g:base16_gui09 = "a25600"
+let g:base16_gui0A = "876500"
+let g:base16_gui0B = "557300"
+let g:base16_gui0C = "0e7767"
+let g:base16_gui0D = "246da5"
+let g:base16_gui0E = "7a50c6"
 let g:base16_gui0F = "a83f92"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#4e5359",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-precious-light-white.vim
+++ b/colors/base16-precious-light-white.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Precious Light White
 " Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-precious-light-white.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/precious-light-white.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/precious-light-white.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "ededed"
-let g:base16_gui01 = "ededed"
+let g:tinted_gui01 = "ededed"
 let s:gui02        = "dbdbdb"
-let g:base16_gui02 = "dbdbdb"
+let g:tinted_gui02 = "dbdbdb"
 let s:gui03        = "848484"
-let g:base16_gui03 = "848484"
+let g:tinted_gui03 = "848484"
 let s:gui04        = "636363"
-let g:base16_gui04 = "636363"
+let g:tinted_gui04 = "636363"
 let s:gui05        = "555555"
-let g:base16_gui05 = "555555"
+let g:tinted_gui05 = "555555"
 let s:gui06        = "555555"
-let g:base16_gui06 = "555555"
+let g:tinted_gui06 = "555555"
 let s:gui07        = "555555"
-let g:base16_gui07 = "555555"
+let g:tinted_gui07 = "555555"
 let s:gui08        = "af4947"
-let g:base16_gui08 = "af4947"
+let g:tinted_gui08 = "af4947"
 let s:gui09        = "a0570d"
-let g:base16_gui09 = "a0570d"
+let g:tinted_gui09 = "a0570d"
 let s:gui0A        = "876500"
-let g:base16_gui0A = "876500"
+let g:tinted_gui0A = "876500"
 let s:gui0B        = "557301"
-let g:base16_gui0B = "557301"
+let g:tinted_gui0B = "557301"
 let s:gui0C        = "087767"
-let g:base16_gui0C = "087767"
+let g:tinted_gui0C = "087767"
 let s:gui0D        = "186daa"
-let g:base16_gui0D = "186daa"
+let g:tinted_gui0D = "186daa"
 let s:gui0E        = "7b4ecb"
-let g:base16_gui0E = "7b4ecb"
+let g:tinted_gui0E = "7b4ecb"
 let s:gui0F        = "a93e93"
+let g:tinted_gui0F = "a93e93"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "ededed"
+let g:base16_gui02 = "dbdbdb"
+let g:base16_gui03 = "848484"
+let g:base16_gui04 = "636363"
+let g:base16_gui05 = "555555"
+let g:base16_gui06 = "555555"
+let g:base16_gui07 = "555555"
+let g:base16_gui08 = "af4947"
+let g:base16_gui09 = "a0570d"
+let g:base16_gui0A = "876500"
+let g:base16_gui0B = "557301"
+let g:base16_gui0C = "087767"
+let g:base16_gui0D = "186daa"
+let g:base16_gui0E = "7b4ecb"
 let g:base16_gui0F = "a93e93"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#555555",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-primer-dark-dimmed.vim
+++ b/colors/base16-primer-dark-dimmed.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Primer Dark Dimmed
 " Scheme author: Jimmy Lin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-primer-dark-dimmed.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/primer-dark-dimmed.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/primer-dark-dimmed.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c2128"
-let g:base16_gui00 = "1c2128"
+let g:tinted_gui00 = "1c2128"
 let s:gui01        = "373e47"
-let g:base16_gui01 = "373e47"
+let g:tinted_gui01 = "373e47"
 let s:gui02        = "444c56"
-let g:base16_gui02 = "444c56"
+let g:tinted_gui02 = "444c56"
 let s:gui03        = "545d68"
-let g:base16_gui03 = "545d68"
+let g:tinted_gui03 = "545d68"
 let s:gui04        = "768390"
-let g:base16_gui04 = "768390"
+let g:tinted_gui04 = "768390"
 let s:gui05        = "909dab"
-let g:base16_gui05 = "909dab"
+let g:tinted_gui05 = "909dab"
 let s:gui06        = "adbac7"
-let g:base16_gui06 = "adbac7"
+let g:tinted_gui06 = "adbac7"
 let s:gui07        = "cdd9e5"
-let g:base16_gui07 = "cdd9e5"
+let g:tinted_gui07 = "cdd9e5"
 let s:gui08        = "f47067"
-let g:base16_gui08 = "f47067"
+let g:tinted_gui08 = "f47067"
 let s:gui09        = "e0823d"
-let g:base16_gui09 = "e0823d"
+let g:tinted_gui09 = "e0823d"
 let s:gui0A        = "c69026"
-let g:base16_gui0A = "c69026"
+let g:tinted_gui0A = "c69026"
 let s:gui0B        = "57ab5a"
-let g:base16_gui0B = "57ab5a"
+let g:tinted_gui0B = "57ab5a"
 let s:gui0C        = "96d0ff"
-let g:base16_gui0C = "96d0ff"
+let g:tinted_gui0C = "96d0ff"
 let s:gui0D        = "539bf5"
-let g:base16_gui0D = "539bf5"
+let g:tinted_gui0D = "539bf5"
 let s:gui0E        = "e275ad"
-let g:base16_gui0E = "e275ad"
+let g:tinted_gui0E = "e275ad"
 let s:gui0F        = "ae5622"
+let g:tinted_gui0F = "ae5622"
+
+" Legacy
+let g:base16_gui00 = "1c2128"
+let g:base16_gui01 = "373e47"
+let g:base16_gui02 = "444c56"
+let g:base16_gui03 = "545d68"
+let g:base16_gui04 = "768390"
+let g:base16_gui05 = "909dab"
+let g:base16_gui06 = "adbac7"
+let g:base16_gui07 = "cdd9e5"
+let g:base16_gui08 = "f47067"
+let g:base16_gui09 = "e0823d"
+let g:base16_gui0A = "c69026"
+let g:base16_gui0B = "57ab5a"
+let g:base16_gui0C = "96d0ff"
+let g:base16_gui0D = "539bf5"
+let g:base16_gui0E = "e275ad"
 let g:base16_gui0F = "ae5622"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#cdd9e5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-primer-dark.vim
+++ b/colors/base16-primer-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Primer Dark
 " Scheme author: Jimmy Lin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-primer-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/primer-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/primer-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "010409"
-let g:base16_gui00 = "010409"
+let g:tinted_gui00 = "010409"
 let s:gui01        = "21262d"
-let g:base16_gui01 = "21262d"
+let g:tinted_gui01 = "21262d"
 let s:gui02        = "30363d"
-let g:base16_gui02 = "30363d"
+let g:tinted_gui02 = "30363d"
 let s:gui03        = "484f58"
-let g:base16_gui03 = "484f58"
+let g:tinted_gui03 = "484f58"
 let s:gui04        = "8b949e"
-let g:base16_gui04 = "8b949e"
+let g:tinted_gui04 = "8b949e"
 let s:gui05        = "b1bac4"
-let g:base16_gui05 = "b1bac4"
+let g:tinted_gui05 = "b1bac4"
 let s:gui06        = "c9d1d9"
-let g:base16_gui06 = "c9d1d9"
+let g:tinted_gui06 = "c9d1d9"
 let s:gui07        = "f0f6fc"
-let g:base16_gui07 = "f0f6fc"
+let g:tinted_gui07 = "f0f6fc"
 let s:gui08        = "ff7b72"
-let g:base16_gui08 = "ff7b72"
+let g:tinted_gui08 = "ff7b72"
 let s:gui09        = "f0883e"
-let g:base16_gui09 = "f0883e"
+let g:tinted_gui09 = "f0883e"
 let s:gui0A        = "d29922"
-let g:base16_gui0A = "d29922"
+let g:tinted_gui0A = "d29922"
 let s:gui0B        = "3fb950"
-let g:base16_gui0B = "3fb950"
+let g:tinted_gui0B = "3fb950"
 let s:gui0C        = "a5d6ff"
-let g:base16_gui0C = "a5d6ff"
+let g:tinted_gui0C = "a5d6ff"
 let s:gui0D        = "58a6ff"
-let g:base16_gui0D = "58a6ff"
+let g:tinted_gui0D = "58a6ff"
 let s:gui0E        = "f778ba"
-let g:base16_gui0E = "f778ba"
+let g:tinted_gui0E = "f778ba"
 let s:gui0F        = "bd561d"
+let g:tinted_gui0F = "bd561d"
+
+" Legacy
+let g:base16_gui00 = "010409"
+let g:base16_gui01 = "21262d"
+let g:base16_gui02 = "30363d"
+let g:base16_gui03 = "484f58"
+let g:base16_gui04 = "8b949e"
+let g:base16_gui05 = "b1bac4"
+let g:base16_gui06 = "c9d1d9"
+let g:base16_gui07 = "f0f6fc"
+let g:base16_gui08 = "ff7b72"
+let g:base16_gui09 = "f0883e"
+let g:base16_gui0A = "d29922"
+let g:base16_gui0B = "3fb950"
+let g:base16_gui0C = "a5d6ff"
+let g:base16_gui0D = "58a6ff"
+let g:base16_gui0E = "f778ba"
 let g:base16_gui0F = "bd561d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f0f6fc",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-primer-light.vim
+++ b/colors/base16-primer-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Primer Light
 " Scheme author: Jimmy Lin
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-primer-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/primer-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/primer-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fafbfc"
-let g:base16_gui00 = "fafbfc"
+let g:tinted_gui00 = "fafbfc"
 let s:gui01        = "e1e4e8"
-let g:base16_gui01 = "e1e4e8"
+let g:tinted_gui01 = "e1e4e8"
 let s:gui02        = "d1d5da"
-let g:base16_gui02 = "d1d5da"
+let g:tinted_gui02 = "d1d5da"
 let s:gui03        = "959da5"
-let g:base16_gui03 = "959da5"
+let g:tinted_gui03 = "959da5"
 let s:gui04        = "444d56"
-let g:base16_gui04 = "444d56"
+let g:tinted_gui04 = "444d56"
 let s:gui05        = "2f363d"
-let g:base16_gui05 = "2f363d"
+let g:tinted_gui05 = "2f363d"
 let s:gui06        = "24292e"
-let g:base16_gui06 = "24292e"
+let g:tinted_gui06 = "24292e"
 let s:gui07        = "1b1f23"
-let g:base16_gui07 = "1b1f23"
+let g:tinted_gui07 = "1b1f23"
 let s:gui08        = "d73a49"
-let g:base16_gui08 = "d73a49"
+let g:tinted_gui08 = "d73a49"
 let s:gui09        = "f66a0a"
-let g:base16_gui09 = "f66a0a"
+let g:tinted_gui09 = "f66a0a"
 let s:gui0A        = "ffd33d"
-let g:base16_gui0A = "ffd33d"
+let g:tinted_gui0A = "ffd33d"
 let s:gui0B        = "28a745"
-let g:base16_gui0B = "28a745"
+let g:tinted_gui0B = "28a745"
 let s:gui0C        = "79b8ff"
-let g:base16_gui0C = "79b8ff"
+let g:tinted_gui0C = "79b8ff"
 let s:gui0D        = "0366d6"
-let g:base16_gui0D = "0366d6"
+let g:tinted_gui0D = "0366d6"
 let s:gui0E        = "ea4aaa"
-let g:base16_gui0E = "ea4aaa"
+let g:tinted_gui0E = "ea4aaa"
 let s:gui0F        = "a04100"
+let g:tinted_gui0F = "a04100"
+
+" Legacy
+let g:base16_gui00 = "fafbfc"
+let g:base16_gui01 = "e1e4e8"
+let g:base16_gui02 = "d1d5da"
+let g:base16_gui03 = "959da5"
+let g:base16_gui04 = "444d56"
+let g:base16_gui05 = "2f363d"
+let g:base16_gui06 = "24292e"
+let g:base16_gui07 = "1b1f23"
+let g:base16_gui08 = "d73a49"
+let g:base16_gui09 = "f66a0a"
+let g:base16_gui0A = "ffd33d"
+let g:base16_gui0B = "28a745"
+let g:base16_gui0C = "79b8ff"
+let g:base16_gui0D = "0366d6"
+let g:base16_gui0E = "ea4aaa"
 let g:base16_gui0F = "a04100"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1b1f23",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-purpledream.vim
+++ b/colors/base16-purpledream.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Purpledream
 " Scheme author: malet
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-purpledream.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/purpledream.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/purpledream.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "100510"
-let g:base16_gui00 = "100510"
+let g:tinted_gui00 = "100510"
 let s:gui01        = "302030"
-let g:base16_gui01 = "302030"
+let g:tinted_gui01 = "302030"
 let s:gui02        = "403040"
-let g:base16_gui02 = "403040"
+let g:tinted_gui02 = "403040"
 let s:gui03        = "605060"
-let g:base16_gui03 = "605060"
+let g:tinted_gui03 = "605060"
 let s:gui04        = "bbb0bb"
-let g:base16_gui04 = "bbb0bb"
+let g:tinted_gui04 = "bbb0bb"
 let s:gui05        = "ddd0dd"
-let g:base16_gui05 = "ddd0dd"
+let g:tinted_gui05 = "ddd0dd"
 let s:gui06        = "eee0ee"
-let g:base16_gui06 = "eee0ee"
+let g:tinted_gui06 = "eee0ee"
 let s:gui07        = "fff0ff"
-let g:base16_gui07 = "fff0ff"
+let g:tinted_gui07 = "fff0ff"
 let s:gui08        = "ff1d0d"
-let g:base16_gui08 = "ff1d0d"
+let g:tinted_gui08 = "ff1d0d"
 let s:gui09        = "ccae14"
-let g:base16_gui09 = "ccae14"
+let g:tinted_gui09 = "ccae14"
 let s:gui0A        = "f000a0"
-let g:base16_gui0A = "f000a0"
+let g:tinted_gui0A = "f000a0"
 let s:gui0B        = "14cc64"
-let g:base16_gui0B = "14cc64"
+let g:tinted_gui0B = "14cc64"
 let s:gui0C        = "0075b0"
-let g:base16_gui0C = "0075b0"
+let g:tinted_gui0C = "0075b0"
 let s:gui0D        = "00a0f0"
-let g:base16_gui0D = "00a0f0"
+let g:tinted_gui0D = "00a0f0"
 let s:gui0E        = "b000d0"
-let g:base16_gui0E = "b000d0"
+let g:tinted_gui0E = "b000d0"
 let s:gui0F        = "6a2a3c"
+let g:tinted_gui0F = "6a2a3c"
+
+" Legacy
+let g:base16_gui00 = "100510"
+let g:base16_gui01 = "302030"
+let g:base16_gui02 = "403040"
+let g:base16_gui03 = "605060"
+let g:base16_gui04 = "bbb0bb"
+let g:base16_gui05 = "ddd0dd"
+let g:base16_gui06 = "eee0ee"
+let g:base16_gui07 = "fff0ff"
+let g:base16_gui08 = "ff1d0d"
+let g:base16_gui09 = "ccae14"
+let g:base16_gui0A = "f000a0"
+let g:base16_gui0B = "14cc64"
+let g:base16_gui0C = "0075b0"
+let g:base16_gui0D = "00a0f0"
+let g:base16_gui0E = "b000d0"
 let g:base16_gui0F = "6a2a3c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fff0ff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-qualia.vim
+++ b/colors/base16-qualia.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Qualia
 " Scheme author: isaacwhanson
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-qualia.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/qualia.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/qualia.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "101010"
-let g:base16_gui00 = "101010"
+let g:tinted_gui00 = "101010"
 let s:gui01        = "454545"
-let g:base16_gui01 = "454545"
+let g:tinted_gui01 = "454545"
 let s:gui02        = "454545"
-let g:base16_gui02 = "454545"
+let g:tinted_gui02 = "454545"
 let s:gui03        = "454545"
-let g:base16_gui03 = "454545"
+let g:tinted_gui03 = "454545"
 let s:gui04        = "808080"
-let g:base16_gui04 = "808080"
+let g:tinted_gui04 = "808080"
 let s:gui05        = "c0c0c0"
-let g:base16_gui05 = "c0c0c0"
+let g:tinted_gui05 = "c0c0c0"
 let s:gui06        = "c0c0c0"
-let g:base16_gui06 = "c0c0c0"
+let g:tinted_gui06 = "c0c0c0"
 let s:gui07        = "454545"
-let g:base16_gui07 = "454545"
+let g:tinted_gui07 = "454545"
 let s:gui08        = "efa6a2"
-let g:base16_gui08 = "efa6a2"
+let g:tinted_gui08 = "efa6a2"
 let s:gui09        = "a3b8ef"
-let g:base16_gui09 = "a3b8ef"
+let g:tinted_gui09 = "a3b8ef"
 let s:gui0A        = "e6a3dc"
-let g:base16_gui0A = "e6a3dc"
+let g:tinted_gui0A = "e6a3dc"
 let s:gui0B        = "80c990"
-let g:base16_gui0B = "80c990"
+let g:tinted_gui0B = "80c990"
 let s:gui0C        = "c8c874"
-let g:base16_gui0C = "c8c874"
+let g:tinted_gui0C = "c8c874"
 let s:gui0D        = "50cacd"
-let g:base16_gui0D = "50cacd"
+let g:tinted_gui0D = "50cacd"
 let s:gui0E        = "e0af85"
-let g:base16_gui0E = "e0af85"
+let g:tinted_gui0E = "e0af85"
 let s:gui0F        = "808080"
+let g:tinted_gui0F = "808080"
+
+" Legacy
+let g:base16_gui00 = "101010"
+let g:base16_gui01 = "454545"
+let g:base16_gui02 = "454545"
+let g:base16_gui03 = "454545"
+let g:base16_gui04 = "808080"
+let g:base16_gui05 = "c0c0c0"
+let g:base16_gui06 = "c0c0c0"
+let g:base16_gui07 = "454545"
+let g:base16_gui08 = "efa6a2"
+let g:base16_gui09 = "a3b8ef"
+let g:base16_gui0A = "e6a3dc"
+let g:base16_gui0B = "80c990"
+let g:base16_gui0C = "c8c874"
+let g:base16_gui0D = "50cacd"
+let g:base16_gui0E = "e0af85"
 let g:base16_gui0F = "808080"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#454545",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Railscasts
 " Scheme author: Ryan Bates (http://railscasts.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-railscasts.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/railscasts.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/railscasts.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2b2b2b"
-let g:base16_gui00 = "2b2b2b"
+let g:tinted_gui00 = "2b2b2b"
 let s:gui01        = "272935"
-let g:base16_gui01 = "272935"
+let g:tinted_gui01 = "272935"
 let s:gui02        = "3a4055"
-let g:base16_gui02 = "3a4055"
+let g:tinted_gui02 = "3a4055"
 let s:gui03        = "5a647e"
-let g:base16_gui03 = "5a647e"
+let g:tinted_gui03 = "5a647e"
 let s:gui04        = "d4cfc9"
-let g:base16_gui04 = "d4cfc9"
+let g:tinted_gui04 = "d4cfc9"
 let s:gui05        = "e6e1dc"
-let g:base16_gui05 = "e6e1dc"
+let g:tinted_gui05 = "e6e1dc"
 let s:gui06        = "f4f1ed"
-let g:base16_gui06 = "f4f1ed"
+let g:tinted_gui06 = "f4f1ed"
 let s:gui07        = "f9f7f3"
-let g:base16_gui07 = "f9f7f3"
+let g:tinted_gui07 = "f9f7f3"
 let s:gui08        = "da4939"
-let g:base16_gui08 = "da4939"
+let g:tinted_gui08 = "da4939"
 let s:gui09        = "cc7833"
-let g:base16_gui09 = "cc7833"
+let g:tinted_gui09 = "cc7833"
 let s:gui0A        = "ffc66d"
-let g:base16_gui0A = "ffc66d"
+let g:tinted_gui0A = "ffc66d"
 let s:gui0B        = "a5c261"
-let g:base16_gui0B = "a5c261"
+let g:tinted_gui0B = "a5c261"
 let s:gui0C        = "519f50"
-let g:base16_gui0C = "519f50"
+let g:tinted_gui0C = "519f50"
 let s:gui0D        = "6d9cbe"
-let g:base16_gui0D = "6d9cbe"
+let g:tinted_gui0D = "6d9cbe"
 let s:gui0E        = "b6b3eb"
-let g:base16_gui0E = "b6b3eb"
+let g:tinted_gui0E = "b6b3eb"
 let s:gui0F        = "bc9458"
+let g:tinted_gui0F = "bc9458"
+
+" Legacy
+let g:base16_gui00 = "2b2b2b"
+let g:base16_gui01 = "272935"
+let g:base16_gui02 = "3a4055"
+let g:base16_gui03 = "5a647e"
+let g:base16_gui04 = "d4cfc9"
+let g:base16_gui05 = "e6e1dc"
+let g:base16_gui06 = "f4f1ed"
+let g:base16_gui07 = "f9f7f3"
+let g:base16_gui08 = "da4939"
+let g:base16_gui09 = "cc7833"
+let g:base16_gui0A = "ffc66d"
+let g:base16_gui0B = "a5c261"
+let g:base16_gui0C = "519f50"
+let g:base16_gui0D = "6d9cbe"
+let g:base16_gui0E = "b6b3eb"
 let g:base16_gui0F = "bc9458"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f9f7f3",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Rebecca
 " Scheme author: Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-rebecca.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/rebecca.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/rebecca.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "292a44"
-let g:base16_gui00 = "292a44"
+let g:tinted_gui00 = "292a44"
 let s:gui01        = "663399"
-let g:base16_gui01 = "663399"
+let g:tinted_gui01 = "663399"
 let s:gui02        = "383a62"
-let g:base16_gui02 = "383a62"
+let g:tinted_gui02 = "383a62"
 let s:gui03        = "666699"
-let g:base16_gui03 = "666699"
+let g:tinted_gui03 = "666699"
 let s:gui04        = "a0a0c5"
-let g:base16_gui04 = "a0a0c5"
+let g:tinted_gui04 = "a0a0c5"
 let s:gui05        = "f1eff8"
-let g:base16_gui05 = "f1eff8"
+let g:tinted_gui05 = "f1eff8"
 let s:gui06        = "ccccff"
-let g:base16_gui06 = "ccccff"
+let g:tinted_gui06 = "ccccff"
 let s:gui07        = "53495d"
-let g:base16_gui07 = "53495d"
+let g:tinted_gui07 = "53495d"
 let s:gui08        = "a0a0c5"
-let g:base16_gui08 = "a0a0c5"
+let g:tinted_gui08 = "a0a0c5"
 let s:gui09        = "efe4a1"
-let g:base16_gui09 = "efe4a1"
+let g:tinted_gui09 = "efe4a1"
 let s:gui0A        = "ae81ff"
-let g:base16_gui0A = "ae81ff"
+let g:tinted_gui0A = "ae81ff"
 let s:gui0B        = "6dfedf"
-let g:base16_gui0B = "6dfedf"
+let g:tinted_gui0B = "6dfedf"
 let s:gui0C        = "8eaee0"
-let g:base16_gui0C = "8eaee0"
+let g:tinted_gui0C = "8eaee0"
 let s:gui0D        = "2de0a7"
-let g:base16_gui0D = "2de0a7"
+let g:tinted_gui0D = "2de0a7"
 let s:gui0E        = "7aa5ff"
-let g:base16_gui0E = "7aa5ff"
+let g:tinted_gui0E = "7aa5ff"
 let s:gui0F        = "ff79c6"
+let g:tinted_gui0F = "ff79c6"
+
+" Legacy
+let g:base16_gui00 = "292a44"
+let g:base16_gui01 = "663399"
+let g:base16_gui02 = "383a62"
+let g:base16_gui03 = "666699"
+let g:base16_gui04 = "a0a0c5"
+let g:base16_gui05 = "f1eff8"
+let g:base16_gui06 = "ccccff"
+let g:base16_gui07 = "53495d"
+let g:base16_gui08 = "a0a0c5"
+let g:base16_gui09 = "efe4a1"
+let g:base16_gui0A = "ae81ff"
+let g:base16_gui0B = "6dfedf"
+let g:base16_gui0C = "8eaee0"
+let g:base16_gui0D = "2de0a7"
+let g:base16_gui0E = "7aa5ff"
 let g:base16_gui0F = "ff79c6"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#53495d",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-rose-pine-dawn.vim
+++ b/colors/base16-rose-pine-dawn.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Rosé Pine Dawn
 " Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-rose-pine-dawn.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/rose-pine-dawn.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/rose-pine-dawn.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "faf4ed"
-let g:base16_gui00 = "faf4ed"
+let g:tinted_gui00 = "faf4ed"
 let s:gui01        = "fffaf3"
-let g:base16_gui01 = "fffaf3"
+let g:tinted_gui01 = "fffaf3"
 let s:gui02        = "f2e9de"
-let g:base16_gui02 = "f2e9de"
+let g:tinted_gui02 = "f2e9de"
 let s:gui03        = "9893a5"
-let g:base16_gui03 = "9893a5"
+let g:tinted_gui03 = "9893a5"
 let s:gui04        = "797593"
-let g:base16_gui04 = "797593"
+let g:tinted_gui04 = "797593"
 let s:gui05        = "575279"
-let g:base16_gui05 = "575279"
+let g:tinted_gui05 = "575279"
 let s:gui06        = "575279"
-let g:base16_gui06 = "575279"
+let g:tinted_gui06 = "575279"
 let s:gui07        = "cecacd"
-let g:base16_gui07 = "cecacd"
+let g:tinted_gui07 = "cecacd"
 let s:gui08        = "b4637a"
-let g:base16_gui08 = "b4637a"
+let g:tinted_gui08 = "b4637a"
 let s:gui09        = "ea9d34"
-let g:base16_gui09 = "ea9d34"
+let g:tinted_gui09 = "ea9d34"
 let s:gui0A        = "d7827e"
-let g:base16_gui0A = "d7827e"
+let g:tinted_gui0A = "d7827e"
 let s:gui0B        = "286983"
-let g:base16_gui0B = "286983"
+let g:tinted_gui0B = "286983"
 let s:gui0C        = "56949f"
-let g:base16_gui0C = "56949f"
+let g:tinted_gui0C = "56949f"
 let s:gui0D        = "907aa9"
-let g:base16_gui0D = "907aa9"
+let g:tinted_gui0D = "907aa9"
 let s:gui0E        = "ea9d34"
-let g:base16_gui0E = "ea9d34"
+let g:tinted_gui0E = "ea9d34"
 let s:gui0F        = "cecacd"
+let g:tinted_gui0F = "cecacd"
+
+" Legacy
+let g:base16_gui00 = "faf4ed"
+let g:base16_gui01 = "fffaf3"
+let g:base16_gui02 = "f2e9de"
+let g:base16_gui03 = "9893a5"
+let g:base16_gui04 = "797593"
+let g:base16_gui05 = "575279"
+let g:base16_gui06 = "575279"
+let g:base16_gui07 = "cecacd"
+let g:base16_gui08 = "b4637a"
+let g:base16_gui09 = "ea9d34"
+let g:base16_gui0A = "d7827e"
+let g:base16_gui0B = "286983"
+let g:base16_gui0C = "56949f"
+let g:base16_gui0D = "907aa9"
+let g:base16_gui0E = "ea9d34"
 let g:base16_gui0F = "cecacd"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#cecacd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-rose-pine-moon.vim
+++ b/colors/base16-rose-pine-moon.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Rosé Pine Moon
 " Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-rose-pine-moon.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/rose-pine-moon.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/rose-pine-moon.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "232136"
-let g:base16_gui00 = "232136"
+let g:tinted_gui00 = "232136"
 let s:gui01        = "2a273f"
-let g:base16_gui01 = "2a273f"
+let g:tinted_gui01 = "2a273f"
 let s:gui02        = "393552"
-let g:base16_gui02 = "393552"
+let g:tinted_gui02 = "393552"
 let s:gui03        = "6e6a86"
-let g:base16_gui03 = "6e6a86"
+let g:tinted_gui03 = "6e6a86"
 let s:gui04        = "908caa"
-let g:base16_gui04 = "908caa"
+let g:tinted_gui04 = "908caa"
 let s:gui05        = "e0def4"
-let g:base16_gui05 = "e0def4"
+let g:tinted_gui05 = "e0def4"
 let s:gui06        = "e0def4"
-let g:base16_gui06 = "e0def4"
+let g:tinted_gui06 = "e0def4"
 let s:gui07        = "56526e"
-let g:base16_gui07 = "56526e"
+let g:tinted_gui07 = "56526e"
 let s:gui08        = "eb6f92"
-let g:base16_gui08 = "eb6f92"
+let g:tinted_gui08 = "eb6f92"
 let s:gui09        = "f6c177"
-let g:base16_gui09 = "f6c177"
+let g:tinted_gui09 = "f6c177"
 let s:gui0A        = "ea9a97"
-let g:base16_gui0A = "ea9a97"
+let g:tinted_gui0A = "ea9a97"
 let s:gui0B        = "3e8fb0"
-let g:base16_gui0B = "3e8fb0"
+let g:tinted_gui0B = "3e8fb0"
 let s:gui0C        = "9ccfd8"
-let g:base16_gui0C = "9ccfd8"
+let g:tinted_gui0C = "9ccfd8"
 let s:gui0D        = "c4a7e7"
-let g:base16_gui0D = "c4a7e7"
+let g:tinted_gui0D = "c4a7e7"
 let s:gui0E        = "f6c177"
-let g:base16_gui0E = "f6c177"
+let g:tinted_gui0E = "f6c177"
 let s:gui0F        = "56526e"
+let g:tinted_gui0F = "56526e"
+
+" Legacy
+let g:base16_gui00 = "232136"
+let g:base16_gui01 = "2a273f"
+let g:base16_gui02 = "393552"
+let g:base16_gui03 = "6e6a86"
+let g:base16_gui04 = "908caa"
+let g:base16_gui05 = "e0def4"
+let g:base16_gui06 = "e0def4"
+let g:base16_gui07 = "56526e"
+let g:base16_gui08 = "eb6f92"
+let g:base16_gui09 = "f6c177"
+let g:base16_gui0A = "ea9a97"
+let g:base16_gui0B = "3e8fb0"
+let g:base16_gui0C = "9ccfd8"
+let g:base16_gui0D = "c4a7e7"
+let g:base16_gui0E = "f6c177"
 let g:base16_gui0F = "56526e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#56526e",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-rose-pine.vim
+++ b/colors/base16-rose-pine.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Rosé Pine
 " Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-rose-pine.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/rose-pine.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/rose-pine.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "191724"
-let g:base16_gui00 = "191724"
+let g:tinted_gui00 = "191724"
 let s:gui01        = "1f1d2e"
-let g:base16_gui01 = "1f1d2e"
+let g:tinted_gui01 = "1f1d2e"
 let s:gui02        = "26233a"
-let g:base16_gui02 = "26233a"
+let g:tinted_gui02 = "26233a"
 let s:gui03        = "6e6a86"
-let g:base16_gui03 = "6e6a86"
+let g:tinted_gui03 = "6e6a86"
 let s:gui04        = "908caa"
-let g:base16_gui04 = "908caa"
+let g:tinted_gui04 = "908caa"
 let s:gui05        = "e0def4"
-let g:base16_gui05 = "e0def4"
+let g:tinted_gui05 = "e0def4"
 let s:gui06        = "e0def4"
-let g:base16_gui06 = "e0def4"
+let g:tinted_gui06 = "e0def4"
 let s:gui07        = "524f67"
-let g:base16_gui07 = "524f67"
+let g:tinted_gui07 = "524f67"
 let s:gui08        = "eb6f92"
-let g:base16_gui08 = "eb6f92"
+let g:tinted_gui08 = "eb6f92"
 let s:gui09        = "f6c177"
-let g:base16_gui09 = "f6c177"
+let g:tinted_gui09 = "f6c177"
 let s:gui0A        = "ebbcba"
-let g:base16_gui0A = "ebbcba"
+let g:tinted_gui0A = "ebbcba"
 let s:gui0B        = "31748f"
-let g:base16_gui0B = "31748f"
+let g:tinted_gui0B = "31748f"
 let s:gui0C        = "9ccfd8"
-let g:base16_gui0C = "9ccfd8"
+let g:tinted_gui0C = "9ccfd8"
 let s:gui0D        = "c4a7e7"
-let g:base16_gui0D = "c4a7e7"
+let g:tinted_gui0D = "c4a7e7"
 let s:gui0E        = "f6c177"
-let g:base16_gui0E = "f6c177"
+let g:tinted_gui0E = "f6c177"
 let s:gui0F        = "524f67"
+let g:tinted_gui0F = "524f67"
+
+" Legacy
+let g:base16_gui00 = "191724"
+let g:base16_gui01 = "1f1d2e"
+let g:base16_gui02 = "26233a"
+let g:base16_gui03 = "6e6a86"
+let g:base16_gui04 = "908caa"
+let g:base16_gui05 = "e0def4"
+let g:base16_gui06 = "e0def4"
+let g:base16_gui07 = "524f67"
+let g:base16_gui08 = "eb6f92"
+let g:base16_gui09 = "f6c177"
+let g:base16_gui0A = "ebbcba"
+let g:base16_gui0B = "31748f"
+let g:base16_gui0C = "9ccfd8"
+let g:base16_gui0D = "c4a7e7"
+let g:base16_gui0E = "f6c177"
 let g:base16_gui0F = "524f67"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#524f67",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-saga.vim
+++ b/colors/base16-saga.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: SAGA
 " Scheme author: https://github.com/SAGAtheme/SAGA
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-saga.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/saga.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/saga.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "05080a"
-let g:base16_gui00 = "05080a"
+let g:tinted_gui00 = "05080a"
 let s:gui01        = "0a1014"
-let g:base16_gui01 = "0a1014"
+let g:tinted_gui01 = "0a1014"
 let s:gui02        = "0f181e"
-let g:base16_gui02 = "0f181e"
+let g:tinted_gui02 = "0f181e"
 let s:gui03        = "141f27"
-let g:base16_gui03 = "141f27"
+let g:tinted_gui03 = "141f27"
 let s:gui04        = "192630"
-let g:base16_gui04 = "192630"
+let g:tinted_gui04 = "192630"
 let s:gui05        = "dce2f7"
-let g:base16_gui05 = "dce2f7"
+let g:tinted_gui05 = "dce2f7"
 let s:gui06        = "f8eae7"
-let g:base16_gui06 = "f8eae7"
+let g:tinted_gui06 = "f8eae7"
 let s:gui07        = "ccd3fe"
-let g:base16_gui07 = "ccd3fe"
+let g:tinted_gui07 = "ccd3fe"
 let s:gui08        = "ffd4e9"
-let g:base16_gui08 = "ffd4e9"
+let g:tinted_gui08 = "ffd4e9"
 let s:gui09        = "fbcbae"
-let g:base16_gui09 = "fbcbae"
+let g:tinted_gui09 = "fbcbae"
 let s:gui0A        = "fbebc8"
-let g:base16_gui0A = "fbebc8"
+let g:tinted_gui0A = "fbebc8"
 let s:gui0B        = "f7ddff"
-let g:base16_gui0B = "f7ddff"
+let g:tinted_gui0B = "f7ddff"
 let s:gui0C        = "c5edc1"
-let g:base16_gui0C = "c5edc1"
+let g:tinted_gui0C = "c5edc1"
 let s:gui0D        = "c9fff7"
-let g:base16_gui0D = "c9fff7"
+let g:tinted_gui0D = "c9fff7"
 let s:gui0E        = "dcc3f9"
-let g:base16_gui0E = "dcc3f9"
+let g:tinted_gui0E = "dcc3f9"
 let s:gui0F        = "f6dddd"
+let g:tinted_gui0F = "f6dddd"
+
+" Legacy
+let g:base16_gui00 = "05080a"
+let g:base16_gui01 = "0a1014"
+let g:base16_gui02 = "0f181e"
+let g:base16_gui03 = "141f27"
+let g:base16_gui04 = "192630"
+let g:base16_gui05 = "dce2f7"
+let g:base16_gui06 = "f8eae7"
+let g:base16_gui07 = "ccd3fe"
+let g:base16_gui08 = "ffd4e9"
+let g:base16_gui09 = "fbcbae"
+let g:base16_gui0A = "fbebc8"
+let g:base16_gui0B = "f7ddff"
+let g:base16_gui0C = "c5edc1"
+let g:base16_gui0D = "c9fff7"
+let g:base16_gui0E = "dcc3f9"
 let g:base16_gui0F = "f6dddd"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ccd3fe",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Sagelight
 " Scheme author: Carter Veldhuizen
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-sagelight.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/sagelight.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/sagelight.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f8f8f8"
-let g:base16_gui00 = "f8f8f8"
+let g:tinted_gui00 = "f8f8f8"
 let s:gui01        = "e8e8e8"
-let g:base16_gui01 = "e8e8e8"
+let g:tinted_gui01 = "e8e8e8"
 let s:gui02        = "d8d8d8"
-let g:base16_gui02 = "d8d8d8"
+let g:tinted_gui02 = "d8d8d8"
 let s:gui03        = "b8b8b8"
-let g:base16_gui03 = "b8b8b8"
+let g:tinted_gui03 = "b8b8b8"
 let s:gui04        = "585858"
-let g:base16_gui04 = "585858"
+let g:tinted_gui04 = "585858"
 let s:gui05        = "383838"
-let g:base16_gui05 = "383838"
+let g:tinted_gui05 = "383838"
 let s:gui06        = "282828"
-let g:base16_gui06 = "282828"
+let g:tinted_gui06 = "282828"
 let s:gui07        = "181818"
-let g:base16_gui07 = "181818"
+let g:tinted_gui07 = "181818"
 let s:gui08        = "fa8480"
-let g:base16_gui08 = "fa8480"
+let g:tinted_gui08 = "fa8480"
 let s:gui09        = "ffaa61"
-let g:base16_gui09 = "ffaa61"
+let g:tinted_gui09 = "ffaa61"
 let s:gui0A        = "ffdc61"
-let g:base16_gui0A = "ffdc61"
+let g:tinted_gui0A = "ffdc61"
 let s:gui0B        = "a0d2c8"
-let g:base16_gui0B = "a0d2c8"
+let g:tinted_gui0B = "a0d2c8"
 let s:gui0C        = "a2d6f5"
-let g:base16_gui0C = "a2d6f5"
+let g:tinted_gui0C = "a2d6f5"
 let s:gui0D        = "a0a7d2"
-let g:base16_gui0D = "a0a7d2"
+let g:tinted_gui0D = "a0a7d2"
 let s:gui0E        = "c8a0d2"
-let g:base16_gui0E = "c8a0d2"
+let g:tinted_gui0E = "c8a0d2"
 let s:gui0F        = "d2b2a0"
+let g:tinted_gui0F = "d2b2a0"
+
+" Legacy
+let g:base16_gui00 = "f8f8f8"
+let g:base16_gui01 = "e8e8e8"
+let g:base16_gui02 = "d8d8d8"
+let g:base16_gui03 = "b8b8b8"
+let g:base16_gui04 = "585858"
+let g:base16_gui05 = "383838"
+let g:base16_gui06 = "282828"
+let g:base16_gui07 = "181818"
+let g:base16_gui08 = "fa8480"
+let g:base16_gui09 = "ffaa61"
+let g:base16_gui0A = "ffdc61"
+let g:base16_gui0B = "a0d2c8"
+let g:base16_gui0C = "a2d6f5"
+let g:base16_gui0D = "a0a7d2"
+let g:base16_gui0E = "c8a0d2"
 let g:base16_gui0F = "d2b2a0"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#181818",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-sakura.vim
+++ b/colors/base16-sakura.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Sakura
 " Scheme author: Misterio77 (http://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-sakura.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/sakura.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/sakura.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "feedf3"
-let g:base16_gui00 = "feedf3"
+let g:tinted_gui00 = "feedf3"
 let s:gui01        = "f8e2e7"
-let g:base16_gui01 = "f8e2e7"
+let g:tinted_gui01 = "f8e2e7"
 let s:gui02        = "e0ccd1"
-let g:base16_gui02 = "e0ccd1"
+let g:tinted_gui02 = "e0ccd1"
 let s:gui03        = "755f64"
-let g:base16_gui03 = "755f64"
+let g:tinted_gui03 = "755f64"
 let s:gui04        = "665055"
-let g:base16_gui04 = "665055"
+let g:tinted_gui04 = "665055"
 let s:gui05        = "564448"
-let g:base16_gui05 = "564448"
+let g:tinted_gui05 = "564448"
 let s:gui06        = "42383a"
-let g:base16_gui06 = "42383a"
+let g:tinted_gui06 = "42383a"
 let s:gui07        = "33292b"
-let g:base16_gui07 = "33292b"
+let g:tinted_gui07 = "33292b"
 let s:gui08        = "df2d52"
-let g:base16_gui08 = "df2d52"
+let g:tinted_gui08 = "df2d52"
 let s:gui09        = "f6661e"
-let g:base16_gui09 = "f6661e"
+let g:tinted_gui09 = "f6661e"
 let s:gui0A        = "c29461"
-let g:base16_gui0A = "c29461"
+let g:tinted_gui0A = "c29461"
 let s:gui0B        = "2e916d"
-let g:base16_gui0B = "2e916d"
+let g:tinted_gui0B = "2e916d"
 let s:gui0C        = "1d8991"
-let g:base16_gui0C = "1d8991"
+let g:tinted_gui0C = "1d8991"
 let s:gui0D        = "006e93"
-let g:base16_gui0D = "006e93"
+let g:tinted_gui0D = "006e93"
 let s:gui0E        = "5e2180"
-let g:base16_gui0E = "5e2180"
+let g:tinted_gui0E = "5e2180"
 let s:gui0F        = "ba0d35"
+let g:tinted_gui0F = "ba0d35"
+
+" Legacy
+let g:base16_gui00 = "feedf3"
+let g:base16_gui01 = "f8e2e7"
+let g:base16_gui02 = "e0ccd1"
+let g:base16_gui03 = "755f64"
+let g:base16_gui04 = "665055"
+let g:base16_gui05 = "564448"
+let g:base16_gui06 = "42383a"
+let g:base16_gui07 = "33292b"
+let g:base16_gui08 = "df2d52"
+let g:base16_gui09 = "f6661e"
+let g:base16_gui0A = "c29461"
+let g:base16_gui0B = "2e916d"
+let g:base16_gui0C = "1d8991"
+let g:base16_gui0D = "006e93"
+let g:base16_gui0E = "5e2180"
 let g:base16_gui0F = "ba0d35"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#33292b",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Sandcastle
 " Scheme author: George Essig (https://github.com/gessig)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-sandcastle.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/sandcastle.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/sandcastle.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282c34"
-let g:base16_gui00 = "282c34"
+let g:tinted_gui00 = "282c34"
 let s:gui01        = "2c323b"
-let g:base16_gui01 = "2c323b"
+let g:tinted_gui01 = "2c323b"
 let s:gui02        = "3e4451"
-let g:base16_gui02 = "3e4451"
+let g:tinted_gui02 = "3e4451"
 let s:gui03        = "665c54"
-let g:base16_gui03 = "665c54"
+let g:tinted_gui03 = "665c54"
 let s:gui04        = "928374"
-let g:base16_gui04 = "928374"
+let g:tinted_gui04 = "928374"
 let s:gui05        = "a89984"
-let g:base16_gui05 = "a89984"
+let g:tinted_gui05 = "a89984"
 let s:gui06        = "d5c4a1"
-let g:base16_gui06 = "d5c4a1"
+let g:tinted_gui06 = "d5c4a1"
 let s:gui07        = "fdf4c1"
-let g:base16_gui07 = "fdf4c1"
+let g:tinted_gui07 = "fdf4c1"
 let s:gui08        = "83a598"
-let g:base16_gui08 = "83a598"
+let g:tinted_gui08 = "83a598"
 let s:gui09        = "a07e3b"
-let g:base16_gui09 = "a07e3b"
+let g:tinted_gui09 = "a07e3b"
 let s:gui0A        = "a07e3b"
-let g:base16_gui0A = "a07e3b"
+let g:tinted_gui0A = "a07e3b"
 let s:gui0B        = "528b8b"
-let g:base16_gui0B = "528b8b"
+let g:tinted_gui0B = "528b8b"
 let s:gui0C        = "83a598"
-let g:base16_gui0C = "83a598"
+let g:tinted_gui0C = "83a598"
 let s:gui0D        = "83a598"
-let g:base16_gui0D = "83a598"
+let g:tinted_gui0D = "83a598"
 let s:gui0E        = "d75f5f"
-let g:base16_gui0E = "d75f5f"
+let g:tinted_gui0E = "d75f5f"
 let s:gui0F        = "a87322"
+let g:tinted_gui0F = "a87322"
+
+" Legacy
+let g:base16_gui00 = "282c34"
+let g:base16_gui01 = "2c323b"
+let g:base16_gui02 = "3e4451"
+let g:base16_gui03 = "665c54"
+let g:base16_gui04 = "928374"
+let g:base16_gui05 = "a89984"
+let g:base16_gui06 = "d5c4a1"
+let g:base16_gui07 = "fdf4c1"
+let g:base16_gui08 = "83a598"
+let g:base16_gui09 = "a07e3b"
+let g:base16_gui0A = "a07e3b"
+let g:base16_gui0B = "528b8b"
+let g:base16_gui0C = "83a598"
+let g:base16_gui0D = "83a598"
+let g:base16_gui0E = "d75f5f"
 let g:base16_gui0F = "a87322"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fdf4c1",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-selenized-black.vim
+++ b/colors/base16-selenized-black.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: selenized-black
 " Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-selenized-black.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/selenized-black.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/selenized-black.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "181818"
-let g:base16_gui00 = "181818"
+let g:tinted_gui00 = "181818"
 let s:gui01        = "252525"
-let g:base16_gui01 = "252525"
+let g:tinted_gui01 = "252525"
 let s:gui02        = "3b3b3b"
-let g:base16_gui02 = "3b3b3b"
+let g:tinted_gui02 = "3b3b3b"
 let s:gui03        = "777777"
-let g:base16_gui03 = "777777"
+let g:tinted_gui03 = "777777"
 let s:gui04        = "777777"
-let g:base16_gui04 = "777777"
+let g:tinted_gui04 = "777777"
 let s:gui05        = "b9b9b9"
-let g:base16_gui05 = "b9b9b9"
+let g:tinted_gui05 = "b9b9b9"
 let s:gui06        = "dedede"
-let g:base16_gui06 = "dedede"
+let g:tinted_gui06 = "dedede"
 let s:gui07        = "dedede"
-let g:base16_gui07 = "dedede"
+let g:tinted_gui07 = "dedede"
 let s:gui08        = "ed4a46"
-let g:base16_gui08 = "ed4a46"
+let g:tinted_gui08 = "ed4a46"
 let s:gui09        = "e67f43"
-let g:base16_gui09 = "e67f43"
+let g:tinted_gui09 = "e67f43"
 let s:gui0A        = "dbb32d"
-let g:base16_gui0A = "dbb32d"
+let g:tinted_gui0A = "dbb32d"
 let s:gui0B        = "70b433"
-let g:base16_gui0B = "70b433"
+let g:tinted_gui0B = "70b433"
 let s:gui0C        = "3fc5b7"
-let g:base16_gui0C = "3fc5b7"
+let g:tinted_gui0C = "3fc5b7"
 let s:gui0D        = "368aeb"
-let g:base16_gui0D = "368aeb"
+let g:tinted_gui0D = "368aeb"
 let s:gui0E        = "a580e2"
-let g:base16_gui0E = "a580e2"
+let g:tinted_gui0E = "a580e2"
 let s:gui0F        = "eb6eb7"
+let g:tinted_gui0F = "eb6eb7"
+
+" Legacy
+let g:base16_gui00 = "181818"
+let g:base16_gui01 = "252525"
+let g:base16_gui02 = "3b3b3b"
+let g:base16_gui03 = "777777"
+let g:base16_gui04 = "777777"
+let g:base16_gui05 = "b9b9b9"
+let g:base16_gui06 = "dedede"
+let g:base16_gui07 = "dedede"
+let g:base16_gui08 = "ed4a46"
+let g:base16_gui09 = "e67f43"
+let g:base16_gui0A = "dbb32d"
+let g:base16_gui0B = "70b433"
+let g:base16_gui0C = "3fc5b7"
+let g:base16_gui0D = "368aeb"
+let g:base16_gui0E = "a580e2"
 let g:base16_gui0F = "eb6eb7"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#dedede",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-selenized-dark.vim
+++ b/colors/base16-selenized-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: selenized-dark
 " Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-selenized-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/selenized-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/selenized-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "103c48"
-let g:base16_gui00 = "103c48"
+let g:tinted_gui00 = "103c48"
 let s:gui01        = "184956"
-let g:base16_gui01 = "184956"
+let g:tinted_gui01 = "184956"
 let s:gui02        = "2d5b69"
-let g:base16_gui02 = "2d5b69"
+let g:tinted_gui02 = "2d5b69"
 let s:gui03        = "72898f"
-let g:base16_gui03 = "72898f"
+let g:tinted_gui03 = "72898f"
 let s:gui04        = "72898f"
-let g:base16_gui04 = "72898f"
+let g:tinted_gui04 = "72898f"
 let s:gui05        = "adbcbc"
-let g:base16_gui05 = "adbcbc"
+let g:tinted_gui05 = "adbcbc"
 let s:gui06        = "cad8d9"
-let g:base16_gui06 = "cad8d9"
+let g:tinted_gui06 = "cad8d9"
 let s:gui07        = "cad8d9"
-let g:base16_gui07 = "cad8d9"
+let g:tinted_gui07 = "cad8d9"
 let s:gui08        = "fa5750"
-let g:base16_gui08 = "fa5750"
+let g:tinted_gui08 = "fa5750"
 let s:gui09        = "ed8649"
-let g:base16_gui09 = "ed8649"
+let g:tinted_gui09 = "ed8649"
 let s:gui0A        = "dbb32d"
-let g:base16_gui0A = "dbb32d"
+let g:tinted_gui0A = "dbb32d"
 let s:gui0B        = "75b938"
-let g:base16_gui0B = "75b938"
+let g:tinted_gui0B = "75b938"
 let s:gui0C        = "41c7b9"
-let g:base16_gui0C = "41c7b9"
+let g:tinted_gui0C = "41c7b9"
 let s:gui0D        = "4695f7"
-let g:base16_gui0D = "4695f7"
+let g:tinted_gui0D = "4695f7"
 let s:gui0E        = "af88eb"
-let g:base16_gui0E = "af88eb"
+let g:tinted_gui0E = "af88eb"
 let s:gui0F        = "f275be"
+let g:tinted_gui0F = "f275be"
+
+" Legacy
+let g:base16_gui00 = "103c48"
+let g:base16_gui01 = "184956"
+let g:base16_gui02 = "2d5b69"
+let g:base16_gui03 = "72898f"
+let g:base16_gui04 = "72898f"
+let g:base16_gui05 = "adbcbc"
+let g:base16_gui06 = "cad8d9"
+let g:base16_gui07 = "cad8d9"
+let g:base16_gui08 = "fa5750"
+let g:base16_gui09 = "ed8649"
+let g:base16_gui0A = "dbb32d"
+let g:base16_gui0B = "75b938"
+let g:base16_gui0C = "41c7b9"
+let g:base16_gui0D = "4695f7"
+let g:base16_gui0E = "af88eb"
 let g:base16_gui0F = "f275be"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#cad8d9",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-selenized-light.vim
+++ b/colors/base16-selenized-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: selenized-light
 " Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-selenized-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/selenized-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/selenized-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fbf3db"
-let g:base16_gui00 = "fbf3db"
+let g:tinted_gui00 = "fbf3db"
 let s:gui01        = "ece3cc"
-let g:base16_gui01 = "ece3cc"
+let g:tinted_gui01 = "ece3cc"
 let s:gui02        = "d5cdb6"
-let g:base16_gui02 = "d5cdb6"
+let g:tinted_gui02 = "d5cdb6"
 let s:gui03        = "909995"
-let g:base16_gui03 = "909995"
+let g:tinted_gui03 = "909995"
 let s:gui04        = "909995"
-let g:base16_gui04 = "909995"
+let g:tinted_gui04 = "909995"
 let s:gui05        = "53676d"
-let g:base16_gui05 = "53676d"
+let g:tinted_gui05 = "53676d"
 let s:gui06        = "3a4d53"
-let g:base16_gui06 = "3a4d53"
+let g:tinted_gui06 = "3a4d53"
 let s:gui07        = "3a4d53"
-let g:base16_gui07 = "3a4d53"
+let g:tinted_gui07 = "3a4d53"
 let s:gui08        = "cc1729"
-let g:base16_gui08 = "cc1729"
+let g:tinted_gui08 = "cc1729"
 let s:gui09        = "bc5819"
-let g:base16_gui09 = "bc5819"
+let g:tinted_gui09 = "bc5819"
 let s:gui0A        = "a78300"
-let g:base16_gui0A = "a78300"
+let g:tinted_gui0A = "a78300"
 let s:gui0B        = "428b00"
-let g:base16_gui0B = "428b00"
+let g:tinted_gui0B = "428b00"
 let s:gui0C        = "00978a"
-let g:base16_gui0C = "00978a"
+let g:tinted_gui0C = "00978a"
 let s:gui0D        = "006dce"
-let g:base16_gui0D = "006dce"
+let g:tinted_gui0D = "006dce"
 let s:gui0E        = "825dc0"
-let g:base16_gui0E = "825dc0"
+let g:tinted_gui0E = "825dc0"
 let s:gui0F        = "c44392"
+let g:tinted_gui0F = "c44392"
+
+" Legacy
+let g:base16_gui00 = "fbf3db"
+let g:base16_gui01 = "ece3cc"
+let g:base16_gui02 = "d5cdb6"
+let g:base16_gui03 = "909995"
+let g:base16_gui04 = "909995"
+let g:base16_gui05 = "53676d"
+let g:base16_gui06 = "3a4d53"
+let g:base16_gui07 = "3a4d53"
+let g:base16_gui08 = "cc1729"
+let g:base16_gui09 = "bc5819"
+let g:base16_gui0A = "a78300"
+let g:base16_gui0B = "428b00"
+let g:base16_gui0C = "00978a"
+let g:base16_gui0D = "006dce"
+let g:base16_gui0E = "825dc0"
 let g:base16_gui0F = "c44392"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#3a4d53",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-selenized-white.vim
+++ b/colors/base16-selenized-white.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: selenized-white
 " Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-selenized-white.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/selenized-white.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/selenized-white.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "ebebeb"
-let g:base16_gui01 = "ebebeb"
+let g:tinted_gui01 = "ebebeb"
 let s:gui02        = "cdcdcd"
-let g:base16_gui02 = "cdcdcd"
+let g:tinted_gui02 = "cdcdcd"
 let s:gui03        = "878787"
-let g:base16_gui03 = "878787"
+let g:tinted_gui03 = "878787"
 let s:gui04        = "878787"
-let g:base16_gui04 = "878787"
+let g:tinted_gui04 = "878787"
 let s:gui05        = "474747"
-let g:base16_gui05 = "474747"
+let g:tinted_gui05 = "474747"
 let s:gui06        = "282828"
-let g:base16_gui06 = "282828"
+let g:tinted_gui06 = "282828"
 let s:gui07        = "282828"
-let g:base16_gui07 = "282828"
+let g:tinted_gui07 = "282828"
 let s:gui08        = "bf0000"
-let g:base16_gui08 = "bf0000"
+let g:tinted_gui08 = "bf0000"
 let s:gui09        = "ba3700"
-let g:base16_gui09 = "ba3700"
+let g:tinted_gui09 = "ba3700"
 let s:gui0A        = "af8500"
-let g:base16_gui0A = "af8500"
+let g:tinted_gui0A = "af8500"
 let s:gui0B        = "008400"
-let g:base16_gui0B = "008400"
+let g:tinted_gui0B = "008400"
 let s:gui0C        = "009a8a"
-let g:base16_gui0C = "009a8a"
+let g:tinted_gui0C = "009a8a"
 let s:gui0D        = "0054cf"
-let g:base16_gui0D = "0054cf"
+let g:tinted_gui0D = "0054cf"
 let s:gui0E        = "6b40c3"
-let g:base16_gui0E = "6b40c3"
+let g:tinted_gui0E = "6b40c3"
 let s:gui0F        = "dd0f9d"
+let g:tinted_gui0F = "dd0f9d"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "ebebeb"
+let g:base16_gui02 = "cdcdcd"
+let g:base16_gui03 = "878787"
+let g:base16_gui04 = "878787"
+let g:base16_gui05 = "474747"
+let g:base16_gui06 = "282828"
+let g:base16_gui07 = "282828"
+let g:base16_gui08 = "bf0000"
+let g:base16_gui09 = "ba3700"
+let g:base16_gui0A = "af8500"
+let g:base16_gui0B = "008400"
+let g:base16_gui0C = "009a8a"
+let g:base16_gui0D = "0054cf"
+let g:base16_gui0E = "6b40c3"
 let g:base16_gui0F = "dd0f9d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#282828",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Seti UI
 " Scheme author: 
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-seti.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/seti.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/seti.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "151718"
-let g:base16_gui00 = "151718"
+let g:tinted_gui00 = "151718"
 let s:gui01        = "282a2b"
-let g:base16_gui01 = "282a2b"
+let g:tinted_gui01 = "282a2b"
 let s:gui02        = "3b758c"
-let g:base16_gui02 = "3b758c"
+let g:tinted_gui02 = "3b758c"
 let s:gui03        = "41535b"
-let g:base16_gui03 = "41535b"
+let g:tinted_gui03 = "41535b"
 let s:gui04        = "43a5d5"
-let g:base16_gui04 = "43a5d5"
+let g:tinted_gui04 = "43a5d5"
 let s:gui05        = "d6d6d6"
-let g:base16_gui05 = "d6d6d6"
+let g:tinted_gui05 = "d6d6d6"
 let s:gui06        = "eeeeee"
-let g:base16_gui06 = "eeeeee"
+let g:tinted_gui06 = "eeeeee"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "cd3f45"
-let g:base16_gui08 = "cd3f45"
+let g:tinted_gui08 = "cd3f45"
 let s:gui09        = "db7b55"
-let g:base16_gui09 = "db7b55"
+let g:tinted_gui09 = "db7b55"
 let s:gui0A        = "e6cd69"
-let g:base16_gui0A = "e6cd69"
+let g:tinted_gui0A = "e6cd69"
 let s:gui0B        = "9fca56"
-let g:base16_gui0B = "9fca56"
+let g:tinted_gui0B = "9fca56"
 let s:gui0C        = "55dbbe"
-let g:base16_gui0C = "55dbbe"
+let g:tinted_gui0C = "55dbbe"
 let s:gui0D        = "55b5db"
-let g:base16_gui0D = "55b5db"
+let g:tinted_gui0D = "55b5db"
 let s:gui0E        = "a074c4"
-let g:base16_gui0E = "a074c4"
+let g:tinted_gui0E = "a074c4"
 let s:gui0F        = "8a553f"
+let g:tinted_gui0F = "8a553f"
+
+" Legacy
+let g:base16_gui00 = "151718"
+let g:base16_gui01 = "282a2b"
+let g:base16_gui02 = "3b758c"
+let g:base16_gui03 = "41535b"
+let g:base16_gui04 = "43a5d5"
+let g:base16_gui05 = "d6d6d6"
+let g:base16_gui06 = "eeeeee"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "cd3f45"
+let g:base16_gui09 = "db7b55"
+let g:base16_gui0A = "e6cd69"
+let g:base16_gui0B = "9fca56"
+let g:base16_gui0C = "55dbbe"
+let g:base16_gui0D = "55b5db"
+let g:base16_gui0E = "a074c4"
 let g:base16_gui0F = "8a553f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-shades-of-purple.vim
+++ b/colors/base16-shades-of-purple.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Shades of Purple
 " Scheme author: Iolar Demartini Junior (http://github.com/demartini), based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-shades-of-purple.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/shades-of-purple.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/shades-of-purple.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1e1e3f"
-let g:base16_gui00 = "1e1e3f"
+let g:tinted_gui00 = "1e1e3f"
 let s:gui01        = "43d426"
-let g:base16_gui01 = "43d426"
+let g:tinted_gui01 = "43d426"
 let s:gui02        = "f1d000"
-let g:base16_gui02 = "f1d000"
+let g:tinted_gui02 = "f1d000"
 let s:gui03        = "808080"
-let g:base16_gui03 = "808080"
+let g:tinted_gui03 = "808080"
 let s:gui04        = "6871ff"
-let g:base16_gui04 = "6871ff"
+let g:tinted_gui04 = "6871ff"
 let s:gui05        = "c7c7c7"
-let g:base16_gui05 = "c7c7c7"
+let g:tinted_gui05 = "c7c7c7"
 let s:gui06        = "ff77ff"
-let g:base16_gui06 = "ff77ff"
+let g:tinted_gui06 = "ff77ff"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "d90429"
-let g:base16_gui08 = "d90429"
+let g:tinted_gui08 = "d90429"
 let s:gui09        = "f92a1c"
-let g:base16_gui09 = "f92a1c"
+let g:tinted_gui09 = "f92a1c"
 let s:gui0A        = "ffe700"
-let g:base16_gui0A = "ffe700"
+let g:tinted_gui0A = "ffe700"
 let s:gui0B        = "3ad900"
-let g:base16_gui0B = "3ad900"
+let g:tinted_gui0B = "3ad900"
 let s:gui0C        = "00c5c7"
-let g:base16_gui0C = "00c5c7"
+let g:tinted_gui0C = "00c5c7"
 let s:gui0D        = "6943ff"
-let g:base16_gui0D = "6943ff"
+let g:tinted_gui0D = "6943ff"
 let s:gui0E        = "ff2c70"
-let g:base16_gui0E = "ff2c70"
+let g:tinted_gui0E = "ff2c70"
 let s:gui0F        = "79e8fb"
+let g:tinted_gui0F = "79e8fb"
+
+" Legacy
+let g:base16_gui00 = "1e1e3f"
+let g:base16_gui01 = "43d426"
+let g:base16_gui02 = "f1d000"
+let g:base16_gui03 = "808080"
+let g:base16_gui04 = "6871ff"
+let g:base16_gui05 = "c7c7c7"
+let g:base16_gui06 = "ff77ff"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "d90429"
+let g:base16_gui09 = "f92a1c"
+let g:base16_gui0A = "ffe700"
+let g:base16_gui0B = "3ad900"
+let g:base16_gui0C = "00c5c7"
+let g:base16_gui0D = "6943ff"
+let g:base16_gui0E = "ff2c70"
 let g:base16_gui0F = "79e8fb"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-shadesmear-dark.vim
+++ b/colors/base16-shadesmear-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: ShadeSmear Dark
 " Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-shadesmear-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/shadesmear-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/shadesmear-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "232323"
-let g:base16_gui00 = "232323"
+let g:tinted_gui00 = "232323"
 let s:gui01        = "1c1c1c"
-let g:base16_gui01 = "1c1c1c"
+let g:tinted_gui01 = "1c1c1c"
 let s:gui02        = "4e4e4e"
-let g:base16_gui02 = "4e4e4e"
+let g:tinted_gui02 = "4e4e4e"
 let s:gui03        = "c0c0c0"
-let g:base16_gui03 = "c0c0c0"
+let g:tinted_gui03 = "c0c0c0"
 let s:gui04        = "e4e4e4"
-let g:base16_gui04 = "e4e4e4"
+let g:tinted_gui04 = "e4e4e4"
 let s:gui05        = "dbdbdb"
-let g:base16_gui05 = "dbdbdb"
+let g:tinted_gui05 = "dbdbdb"
 let s:gui06        = "e4e4e4"
-let g:base16_gui06 = "e4e4e4"
+let g:tinted_gui06 = "e4e4e4"
 let s:gui07        = "1c1c1c"
-let g:base16_gui07 = "1c1c1c"
+let g:tinted_gui07 = "1c1c1c"
 let s:gui08        = "cc5450"
-let g:base16_gui08 = "cc5450"
+let g:tinted_gui08 = "cc5450"
 let s:gui09        = "a64270"
-let g:base16_gui09 = "a64270"
+let g:tinted_gui09 = "a64270"
 let s:gui0A        = "307878"
-let g:base16_gui0A = "307878"
+let g:tinted_gui0A = "307878"
 let s:gui0B        = "71983b"
-let g:base16_gui0B = "71983b"
+let g:tinted_gui0B = "71983b"
 let s:gui0C        = "c57d42"
-let g:base16_gui0C = "c57d42"
+let g:tinted_gui0C = "c57d42"
 let s:gui0D        = "376388"
-let g:base16_gui0D = "376388"
+let g:tinted_gui0D = "376388"
 let s:gui0E        = "d7ab54"
-let g:base16_gui0E = "d7ab54"
+let g:tinted_gui0E = "d7ab54"
 let s:gui0F        = "6d6d6d"
+let g:tinted_gui0F = "6d6d6d"
+
+" Legacy
+let g:base16_gui00 = "232323"
+let g:base16_gui01 = "1c1c1c"
+let g:base16_gui02 = "4e4e4e"
+let g:base16_gui03 = "c0c0c0"
+let g:base16_gui04 = "e4e4e4"
+let g:base16_gui05 = "dbdbdb"
+let g:base16_gui06 = "e4e4e4"
+let g:base16_gui07 = "1c1c1c"
+let g:base16_gui08 = "cc5450"
+let g:base16_gui09 = "a64270"
+let g:base16_gui0A = "307878"
+let g:base16_gui0B = "71983b"
+let g:base16_gui0C = "c57d42"
+let g:base16_gui0D = "376388"
+let g:base16_gui0E = "d7ab54"
 let g:base16_gui0F = "6d6d6d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1c1c1c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-shadesmear-light.vim
+++ b/colors/base16-shadesmear-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: ShadeSmear Light
 " Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-shadesmear-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/shadesmear-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/shadesmear-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "dbdbdb"
-let g:base16_gui00 = "dbdbdb"
+let g:tinted_gui00 = "dbdbdb"
 let s:gui01        = "e4e4e4"
-let g:base16_gui01 = "e4e4e4"
+let g:tinted_gui01 = "e4e4e4"
 let s:gui02        = "c0c0c0"
-let g:base16_gui02 = "c0c0c0"
+let g:tinted_gui02 = "c0c0c0"
 let s:gui03        = "4e4e4e"
-let g:base16_gui03 = "4e4e4e"
+let g:tinted_gui03 = "4e4e4e"
 let s:gui04        = "1c1c1c"
-let g:base16_gui04 = "1c1c1c"
+let g:tinted_gui04 = "1c1c1c"
 let s:gui05        = "232323"
-let g:base16_gui05 = "232323"
+let g:tinted_gui05 = "232323"
 let s:gui06        = "1c1c1c"
-let g:base16_gui06 = "1c1c1c"
+let g:tinted_gui06 = "1c1c1c"
 let s:gui07        = "e4e4e4"
-let g:base16_gui07 = "e4e4e4"
+let g:tinted_gui07 = "e4e4e4"
 let s:gui08        = "cc5450"
-let g:base16_gui08 = "cc5450"
+let g:tinted_gui08 = "cc5450"
 let s:gui09        = "a64270"
-let g:base16_gui09 = "a64270"
+let g:tinted_gui09 = "a64270"
 let s:gui0A        = "307878"
-let g:base16_gui0A = "307878"
+let g:tinted_gui0A = "307878"
 let s:gui0B        = "71983b"
-let g:base16_gui0B = "71983b"
+let g:tinted_gui0B = "71983b"
 let s:gui0C        = "c57d42"
-let g:base16_gui0C = "c57d42"
+let g:tinted_gui0C = "c57d42"
 let s:gui0D        = "376388"
-let g:base16_gui0D = "376388"
+let g:tinted_gui0D = "376388"
 let s:gui0E        = "d7ab54"
-let g:base16_gui0E = "d7ab54"
+let g:tinted_gui0E = "d7ab54"
 let s:gui0F        = "6d6d6d"
+let g:tinted_gui0F = "6d6d6d"
+
+" Legacy
+let g:base16_gui00 = "dbdbdb"
+let g:base16_gui01 = "e4e4e4"
+let g:base16_gui02 = "c0c0c0"
+let g:base16_gui03 = "4e4e4e"
+let g:base16_gui04 = "1c1c1c"
+let g:base16_gui05 = "232323"
+let g:base16_gui06 = "1c1c1c"
+let g:base16_gui07 = "e4e4e4"
+let g:base16_gui08 = "cc5450"
+let g:base16_gui09 = "a64270"
+let g:base16_gui0A = "307878"
+let g:base16_gui0B = "71983b"
+let g:base16_gui0C = "c57d42"
+let g:base16_gui0D = "376388"
+let g:base16_gui0E = "d7ab54"
 let g:base16_gui0F = "6d6d6d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e4e4e4",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Shapeshifter
 " Scheme author: Tyler Benziger (http://tybenz.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-shapeshifter.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/shapeshifter.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/shapeshifter.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f9f9f9"
-let g:base16_gui00 = "f9f9f9"
+let g:tinted_gui00 = "f9f9f9"
 let s:gui01        = "e0e0e0"
-let g:base16_gui01 = "e0e0e0"
+let g:tinted_gui01 = "e0e0e0"
 let s:gui02        = "ababab"
-let g:base16_gui02 = "ababab"
+let g:tinted_gui02 = "ababab"
 let s:gui03        = "555555"
-let g:base16_gui03 = "555555"
+let g:tinted_gui03 = "555555"
 let s:gui04        = "343434"
-let g:base16_gui04 = "343434"
+let g:tinted_gui04 = "343434"
 let s:gui05        = "102015"
-let g:base16_gui05 = "102015"
+let g:tinted_gui05 = "102015"
 let s:gui06        = "040404"
-let g:base16_gui06 = "040404"
+let g:tinted_gui06 = "040404"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "e92f2f"
-let g:base16_gui08 = "e92f2f"
+let g:tinted_gui08 = "e92f2f"
 let s:gui09        = "e09448"
-let g:base16_gui09 = "e09448"
+let g:tinted_gui09 = "e09448"
 let s:gui0A        = "dddd13"
-let g:base16_gui0A = "dddd13"
+let g:tinted_gui0A = "dddd13"
 let s:gui0B        = "0ed839"
-let g:base16_gui0B = "0ed839"
+let g:tinted_gui0B = "0ed839"
 let s:gui0C        = "23edda"
-let g:base16_gui0C = "23edda"
+let g:tinted_gui0C = "23edda"
 let s:gui0D        = "3b48e3"
-let g:base16_gui0D = "3b48e3"
+let g:tinted_gui0D = "3b48e3"
 let s:gui0E        = "f996e2"
-let g:base16_gui0E = "f996e2"
+let g:tinted_gui0E = "f996e2"
 let s:gui0F        = "69542d"
+let g:tinted_gui0F = "69542d"
+
+" Legacy
+let g:base16_gui00 = "f9f9f9"
+let g:base16_gui01 = "e0e0e0"
+let g:base16_gui02 = "ababab"
+let g:base16_gui03 = "555555"
+let g:base16_gui04 = "343434"
+let g:base16_gui05 = "102015"
+let g:base16_gui06 = "040404"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "e92f2f"
+let g:base16_gui09 = "e09448"
+let g:base16_gui0A = "dddd13"
+let g:base16_gui0B = "0ed839"
+let g:base16_gui0C = "23edda"
+let g:base16_gui0D = "3b48e3"
+let g:base16_gui0E = "f996e2"
 let g:base16_gui0F = "69542d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Silk Dark
 " Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-silk-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/silk-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/silk-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0e3c46"
-let g:base16_gui00 = "0e3c46"
+let g:tinted_gui00 = "0e3c46"
 let s:gui01        = "1d494e"
-let g:base16_gui01 = "1d494e"
+let g:tinted_gui01 = "1d494e"
 let s:gui02        = "2a5054"
-let g:base16_gui02 = "2a5054"
+let g:tinted_gui02 = "2a5054"
 let s:gui03        = "587073"
-let g:base16_gui03 = "587073"
+let g:tinted_gui03 = "587073"
 let s:gui04        = "9dc8cd"
-let g:base16_gui04 = "9dc8cd"
+let g:tinted_gui04 = "9dc8cd"
 let s:gui05        = "c7dbdd"
-let g:base16_gui05 = "c7dbdd"
+let g:tinted_gui05 = "c7dbdd"
 let s:gui06        = "cbf2f7"
-let g:base16_gui06 = "cbf2f7"
+let g:tinted_gui06 = "cbf2f7"
 let s:gui07        = "d2faff"
-let g:base16_gui07 = "d2faff"
+let g:tinted_gui07 = "d2faff"
 let s:gui08        = "fb6953"
-let g:base16_gui08 = "fb6953"
+let g:tinted_gui08 = "fb6953"
 let s:gui09        = "fcab74"
-let g:base16_gui09 = "fcab74"
+let g:tinted_gui09 = "fcab74"
 let s:gui0A        = "fce380"
-let g:base16_gui0A = "fce380"
+let g:tinted_gui0A = "fce380"
 let s:gui0B        = "73d8ad"
-let g:base16_gui0B = "73d8ad"
+let g:tinted_gui0B = "73d8ad"
 let s:gui0C        = "3fb2b9"
-let g:base16_gui0C = "3fb2b9"
+let g:tinted_gui0C = "3fb2b9"
 let s:gui0D        = "46bddd"
-let g:base16_gui0D = "46bddd"
+let g:tinted_gui0D = "46bddd"
 let s:gui0E        = "756b8a"
-let g:base16_gui0E = "756b8a"
+let g:tinted_gui0E = "756b8a"
 let s:gui0F        = "9b647b"
+let g:tinted_gui0F = "9b647b"
+
+" Legacy
+let g:base16_gui00 = "0e3c46"
+let g:base16_gui01 = "1d494e"
+let g:base16_gui02 = "2a5054"
+let g:base16_gui03 = "587073"
+let g:base16_gui04 = "9dc8cd"
+let g:base16_gui05 = "c7dbdd"
+let g:base16_gui06 = "cbf2f7"
+let g:base16_gui07 = "d2faff"
+let g:base16_gui08 = "fb6953"
+let g:base16_gui09 = "fcab74"
+let g:base16_gui0A = "fce380"
+let g:base16_gui0B = "73d8ad"
+let g:base16_gui0C = "3fb2b9"
+let g:base16_gui0D = "46bddd"
+let g:base16_gui0E = "756b8a"
 let g:base16_gui0F = "9b647b"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d2faff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Silk Light
 " Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-silk-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/silk-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/silk-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "e9f1ef"
-let g:base16_gui00 = "e9f1ef"
+let g:tinted_gui00 = "e9f1ef"
 let s:gui01        = "ccd4d3"
-let g:base16_gui01 = "ccd4d3"
+let g:tinted_gui01 = "ccd4d3"
 let s:gui02        = "90b7b6"
-let g:base16_gui02 = "90b7b6"
+let g:tinted_gui02 = "90b7b6"
 let s:gui03        = "5c787b"
-let g:base16_gui03 = "5c787b"
+let g:tinted_gui03 = "5c787b"
 let s:gui04        = "4b5b5f"
-let g:base16_gui04 = "4b5b5f"
+let g:tinted_gui04 = "4b5b5f"
 let s:gui05        = "385156"
-let g:base16_gui05 = "385156"
+let g:tinted_gui05 = "385156"
 let s:gui06        = "0e3c46"
-let g:base16_gui06 = "0e3c46"
+let g:tinted_gui06 = "0e3c46"
 let s:gui07        = "d2faff"
-let g:base16_gui07 = "d2faff"
+let g:tinted_gui07 = "d2faff"
 let s:gui08        = "cf432e"
-let g:base16_gui08 = "cf432e"
+let g:tinted_gui08 = "cf432e"
 let s:gui09        = "d27f46"
-let g:base16_gui09 = "d27f46"
+let g:tinted_gui09 = "d27f46"
 let s:gui0A        = "cfad25"
-let g:base16_gui0A = "cfad25"
+let g:tinted_gui0A = "cfad25"
 let s:gui0B        = "6ca38c"
-let g:base16_gui0B = "6ca38c"
+let g:tinted_gui0B = "6ca38c"
 let s:gui0C        = "329ca2"
-let g:base16_gui0C = "329ca2"
+let g:tinted_gui0C = "329ca2"
 let s:gui0D        = "39aac9"
-let g:base16_gui0D = "39aac9"
+let g:tinted_gui0D = "39aac9"
 let s:gui0E        = "6e6582"
-let g:base16_gui0E = "6e6582"
+let g:tinted_gui0E = "6e6582"
 let s:gui0F        = "865369"
+let g:tinted_gui0F = "865369"
+
+" Legacy
+let g:base16_gui00 = "e9f1ef"
+let g:base16_gui01 = "ccd4d3"
+let g:base16_gui02 = "90b7b6"
+let g:base16_gui03 = "5c787b"
+let g:base16_gui04 = "4b5b5f"
+let g:base16_gui05 = "385156"
+let g:base16_gui06 = "0e3c46"
+let g:base16_gui07 = "d2faff"
+let g:base16_gui08 = "cf432e"
+let g:base16_gui09 = "d27f46"
+let g:base16_gui0A = "cfad25"
+let g:base16_gui0B = "6ca38c"
+let g:base16_gui0C = "329ca2"
+let g:base16_gui0D = "39aac9"
+let g:base16_gui0E = "6e6582"
 let g:base16_gui0F = "865369"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d2faff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Snazzy
 " Scheme author: Chawye Hsu (https://github.com/chawyehsu), based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-snazzy.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/snazzy.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/snazzy.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282a36"
-let g:base16_gui00 = "282a36"
+let g:tinted_gui00 = "282a36"
 let s:gui01        = "34353e"
-let g:base16_gui01 = "34353e"
+let g:tinted_gui01 = "34353e"
 let s:gui02        = "43454f"
-let g:base16_gui02 = "43454f"
+let g:tinted_gui02 = "43454f"
 let s:gui03        = "78787e"
-let g:base16_gui03 = "78787e"
+let g:tinted_gui03 = "78787e"
 let s:gui04        = "a5a5a9"
-let g:base16_gui04 = "a5a5a9"
+let g:tinted_gui04 = "a5a5a9"
 let s:gui05        = "e2e4e5"
-let g:base16_gui05 = "e2e4e5"
+let g:tinted_gui05 = "e2e4e5"
 let s:gui06        = "eff0eb"
-let g:base16_gui06 = "eff0eb"
+let g:tinted_gui06 = "eff0eb"
 let s:gui07        = "f1f1f0"
-let g:base16_gui07 = "f1f1f0"
+let g:tinted_gui07 = "f1f1f0"
 let s:gui08        = "ff5c57"
-let g:base16_gui08 = "ff5c57"
+let g:tinted_gui08 = "ff5c57"
 let s:gui09        = "ff9f43"
-let g:base16_gui09 = "ff9f43"
+let g:tinted_gui09 = "ff9f43"
 let s:gui0A        = "f3f99d"
-let g:base16_gui0A = "f3f99d"
+let g:tinted_gui0A = "f3f99d"
 let s:gui0B        = "5af78e"
-let g:base16_gui0B = "5af78e"
+let g:tinted_gui0B = "5af78e"
 let s:gui0C        = "9aedfe"
-let g:base16_gui0C = "9aedfe"
+let g:tinted_gui0C = "9aedfe"
 let s:gui0D        = "57c7ff"
-let g:base16_gui0D = "57c7ff"
+let g:tinted_gui0D = "57c7ff"
 let s:gui0E        = "ff6ac1"
-let g:base16_gui0E = "ff6ac1"
+let g:tinted_gui0E = "ff6ac1"
 let s:gui0F        = "b2643c"
+let g:tinted_gui0F = "b2643c"
+
+" Legacy
+let g:base16_gui00 = "282a36"
+let g:base16_gui01 = "34353e"
+let g:base16_gui02 = "43454f"
+let g:base16_gui03 = "78787e"
+let g:base16_gui04 = "a5a5a9"
+let g:base16_gui05 = "e2e4e5"
+let g:base16_gui06 = "eff0eb"
+let g:base16_gui07 = "f1f1f0"
+let g:base16_gui08 = "ff5c57"
+let g:base16_gui09 = "ff9f43"
+let g:base16_gui0A = "f3f99d"
+let g:base16_gui0B = "5af78e"
+let g:base16_gui0C = "9aedfe"
+let g:base16_gui0D = "57c7ff"
+let g:base16_gui0E = "ff6ac1"
 let g:base16_gui0F = "b2643c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f1f1f0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Solar Flare Light
 " Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-solarflare-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/solarflare-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/solarflare-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f5f7fa"
-let g:base16_gui00 = "f5f7fa"
+let g:tinted_gui00 = "f5f7fa"
 let s:gui01        = "e8e9ed"
-let g:base16_gui01 = "e8e9ed"
+let g:tinted_gui01 = "e8e9ed"
 let s:gui02        = "a6afb8"
-let g:base16_gui02 = "a6afb8"
+let g:tinted_gui02 = "a6afb8"
 let s:gui03        = "85939e"
-let g:base16_gui03 = "85939e"
+let g:tinted_gui03 = "85939e"
 let s:gui04        = "667581"
-let g:base16_gui04 = "667581"
+let g:tinted_gui04 = "667581"
 let s:gui05        = "586875"
-let g:base16_gui05 = "586875"
+let g:tinted_gui05 = "586875"
 let s:gui06        = "222e38"
-let g:base16_gui06 = "222e38"
+let g:tinted_gui06 = "222e38"
 let s:gui07        = "18262f"
-let g:base16_gui07 = "18262f"
+let g:tinted_gui07 = "18262f"
 let s:gui08        = "ef5253"
-let g:base16_gui08 = "ef5253"
+let g:tinted_gui08 = "ef5253"
 let s:gui09        = "e66b2b"
-let g:base16_gui09 = "e66b2b"
+let g:tinted_gui09 = "e66b2b"
 let s:gui0A        = "e4b51c"
-let g:base16_gui0A = "e4b51c"
+let g:tinted_gui0A = "e4b51c"
 let s:gui0B        = "7cc844"
-let g:base16_gui0B = "7cc844"
+let g:tinted_gui0B = "7cc844"
 let s:gui0C        = "52cbb0"
-let g:base16_gui0C = "52cbb0"
+let g:tinted_gui0C = "52cbb0"
 let s:gui0D        = "33b5e1"
-let g:base16_gui0D = "33b5e1"
+let g:tinted_gui0D = "33b5e1"
 let s:gui0E        = "a363d5"
-let g:base16_gui0E = "a363d5"
+let g:tinted_gui0E = "a363d5"
 let s:gui0F        = "d73c9a"
+let g:tinted_gui0F = "d73c9a"
+
+" Legacy
+let g:base16_gui00 = "f5f7fa"
+let g:base16_gui01 = "e8e9ed"
+let g:base16_gui02 = "a6afb8"
+let g:base16_gui03 = "85939e"
+let g:base16_gui04 = "667581"
+let g:base16_gui05 = "586875"
+let g:base16_gui06 = "222e38"
+let g:base16_gui07 = "18262f"
+let g:base16_gui08 = "ef5253"
+let g:base16_gui09 = "e66b2b"
+let g:base16_gui0A = "e4b51c"
+let g:base16_gui0B = "7cc844"
+let g:base16_gui0C = "52cbb0"
+let g:base16_gui0D = "33b5e1"
+let g:base16_gui0E = "a363d5"
 let g:base16_gui0F = "d73c9a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#18262f",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Solar Flare
 " Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-solarflare.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/solarflare.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/solarflare.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "18262f"
-let g:base16_gui00 = "18262f"
+let g:tinted_gui00 = "18262f"
 let s:gui01        = "222e38"
-let g:base16_gui01 = "222e38"
+let g:tinted_gui01 = "222e38"
 let s:gui02        = "586875"
-let g:base16_gui02 = "586875"
+let g:tinted_gui02 = "586875"
 let s:gui03        = "667581"
-let g:base16_gui03 = "667581"
+let g:tinted_gui03 = "667581"
 let s:gui04        = "85939e"
-let g:base16_gui04 = "85939e"
+let g:tinted_gui04 = "85939e"
 let s:gui05        = "a6afb8"
-let g:base16_gui05 = "a6afb8"
+let g:tinted_gui05 = "a6afb8"
 let s:gui06        = "e8e9ed"
-let g:base16_gui06 = "e8e9ed"
+let g:tinted_gui06 = "e8e9ed"
 let s:gui07        = "f5f7fa"
-let g:base16_gui07 = "f5f7fa"
+let g:tinted_gui07 = "f5f7fa"
 let s:gui08        = "ef5253"
-let g:base16_gui08 = "ef5253"
+let g:tinted_gui08 = "ef5253"
 let s:gui09        = "e66b2b"
-let g:base16_gui09 = "e66b2b"
+let g:tinted_gui09 = "e66b2b"
 let s:gui0A        = "e4b51c"
-let g:base16_gui0A = "e4b51c"
+let g:tinted_gui0A = "e4b51c"
 let s:gui0B        = "7cc844"
-let g:base16_gui0B = "7cc844"
+let g:tinted_gui0B = "7cc844"
 let s:gui0C        = "52cbb0"
-let g:base16_gui0C = "52cbb0"
+let g:tinted_gui0C = "52cbb0"
 let s:gui0D        = "33b5e1"
-let g:base16_gui0D = "33b5e1"
+let g:tinted_gui0D = "33b5e1"
 let s:gui0E        = "a363d5"
-let g:base16_gui0E = "a363d5"
+let g:tinted_gui0E = "a363d5"
 let s:gui0F        = "d73c9a"
+let g:tinted_gui0F = "d73c9a"
+
+" Legacy
+let g:base16_gui00 = "18262f"
+let g:base16_gui01 = "222e38"
+let g:base16_gui02 = "586875"
+let g:base16_gui03 = "667581"
+let g:base16_gui04 = "85939e"
+let g:base16_gui05 = "a6afb8"
+let g:base16_gui06 = "e8e9ed"
+let g:base16_gui07 = "f5f7fa"
+let g:base16_gui08 = "ef5253"
+let g:base16_gui09 = "e66b2b"
+let g:base16_gui0A = "e4b51c"
+let g:base16_gui0B = "7cc844"
+let g:base16_gui0C = "52cbb0"
+let g:base16_gui0D = "33b5e1"
+let g:base16_gui0E = "a363d5"
 let g:base16_gui0F = "d73c9a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f7fa",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Solarized Dark
 " Scheme author: Ethan Schoonover (modified by aramisgithub)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-solarized-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/solarized-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/solarized-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "002b36"
-let g:base16_gui00 = "002b36"
+let g:tinted_gui00 = "002b36"
 let s:gui01        = "073642"
-let g:base16_gui01 = "073642"
+let g:tinted_gui01 = "073642"
 let s:gui02        = "586e75"
-let g:base16_gui02 = "586e75"
+let g:tinted_gui02 = "586e75"
 let s:gui03        = "657b83"
-let g:base16_gui03 = "657b83"
+let g:tinted_gui03 = "657b83"
 let s:gui04        = "839496"
-let g:base16_gui04 = "839496"
+let g:tinted_gui04 = "839496"
 let s:gui05        = "93a1a1"
-let g:base16_gui05 = "93a1a1"
+let g:tinted_gui05 = "93a1a1"
 let s:gui06        = "eee8d5"
-let g:base16_gui06 = "eee8d5"
+let g:tinted_gui06 = "eee8d5"
 let s:gui07        = "fdf6e3"
-let g:base16_gui07 = "fdf6e3"
+let g:tinted_gui07 = "fdf6e3"
 let s:gui08        = "dc322f"
-let g:base16_gui08 = "dc322f"
+let g:tinted_gui08 = "dc322f"
 let s:gui09        = "cb4b16"
-let g:base16_gui09 = "cb4b16"
+let g:tinted_gui09 = "cb4b16"
 let s:gui0A        = "b58900"
-let g:base16_gui0A = "b58900"
+let g:tinted_gui0A = "b58900"
 let s:gui0B        = "859900"
-let g:base16_gui0B = "859900"
+let g:tinted_gui0B = "859900"
 let s:gui0C        = "2aa198"
-let g:base16_gui0C = "2aa198"
+let g:tinted_gui0C = "2aa198"
 let s:gui0D        = "268bd2"
-let g:base16_gui0D = "268bd2"
+let g:tinted_gui0D = "268bd2"
 let s:gui0E        = "6c71c4"
-let g:base16_gui0E = "6c71c4"
+let g:tinted_gui0E = "6c71c4"
 let s:gui0F        = "d33682"
+let g:tinted_gui0F = "d33682"
+
+" Legacy
+let g:base16_gui00 = "002b36"
+let g:base16_gui01 = "073642"
+let g:base16_gui02 = "586e75"
+let g:base16_gui03 = "657b83"
+let g:base16_gui04 = "839496"
+let g:base16_gui05 = "93a1a1"
+let g:base16_gui06 = "eee8d5"
+let g:base16_gui07 = "fdf6e3"
+let g:base16_gui08 = "dc322f"
+let g:base16_gui09 = "cb4b16"
+let g:base16_gui0A = "b58900"
+let g:base16_gui0B = "859900"
+let g:base16_gui0C = "2aa198"
+let g:base16_gui0D = "268bd2"
+let g:base16_gui0E = "6c71c4"
 let g:base16_gui0F = "d33682"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fdf6e3",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Solarized Light
 " Scheme author: Ethan Schoonover (modified by aramisgithub)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-solarized-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/solarized-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/solarized-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fdf6e3"
-let g:base16_gui00 = "fdf6e3"
+let g:tinted_gui00 = "fdf6e3"
 let s:gui01        = "eee8d5"
-let g:base16_gui01 = "eee8d5"
+let g:tinted_gui01 = "eee8d5"
 let s:gui02        = "93a1a1"
-let g:base16_gui02 = "93a1a1"
+let g:tinted_gui02 = "93a1a1"
 let s:gui03        = "839496"
-let g:base16_gui03 = "839496"
+let g:tinted_gui03 = "839496"
 let s:gui04        = "657b83"
-let g:base16_gui04 = "657b83"
+let g:tinted_gui04 = "657b83"
 let s:gui05        = "586e75"
-let g:base16_gui05 = "586e75"
+let g:tinted_gui05 = "586e75"
 let s:gui06        = "073642"
-let g:base16_gui06 = "073642"
+let g:tinted_gui06 = "073642"
 let s:gui07        = "002b36"
-let g:base16_gui07 = "002b36"
+let g:tinted_gui07 = "002b36"
 let s:gui08        = "dc322f"
-let g:base16_gui08 = "dc322f"
+let g:tinted_gui08 = "dc322f"
 let s:gui09        = "cb4b16"
-let g:base16_gui09 = "cb4b16"
+let g:tinted_gui09 = "cb4b16"
 let s:gui0A        = "b58900"
-let g:base16_gui0A = "b58900"
+let g:tinted_gui0A = "b58900"
 let s:gui0B        = "859900"
-let g:base16_gui0B = "859900"
+let g:tinted_gui0B = "859900"
 let s:gui0C        = "2aa198"
-let g:base16_gui0C = "2aa198"
+let g:tinted_gui0C = "2aa198"
 let s:gui0D        = "268bd2"
-let g:base16_gui0D = "268bd2"
+let g:tinted_gui0D = "268bd2"
 let s:gui0E        = "6c71c4"
-let g:base16_gui0E = "6c71c4"
+let g:tinted_gui0E = "6c71c4"
 let s:gui0F        = "d33682"
+let g:tinted_gui0F = "d33682"
+
+" Legacy
+let g:base16_gui00 = "fdf6e3"
+let g:base16_gui01 = "eee8d5"
+let g:base16_gui02 = "93a1a1"
+let g:base16_gui03 = "839496"
+let g:base16_gui04 = "657b83"
+let g:base16_gui05 = "586e75"
+let g:base16_gui06 = "073642"
+let g:base16_gui07 = "002b36"
+let g:base16_gui08 = "dc322f"
+let g:base16_gui09 = "cb4b16"
+let g:base16_gui0A = "b58900"
+let g:base16_gui0B = "859900"
+let g:base16_gui0C = "2aa198"
+let g:base16_gui0D = "268bd2"
+let g:base16_gui0E = "6c71c4"
 let g:base16_gui0F = "d33682"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#002b36",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-spaceduck.vim
+++ b/colors/base16-spaceduck.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Spaceduck
 " Scheme author: Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-spaceduck.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/spaceduck.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/spaceduck.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "16172d"
-let g:base16_gui00 = "16172d"
+let g:tinted_gui00 = "16172d"
 let s:gui01        = "1b1c36"
-let g:base16_gui01 = "1b1c36"
+let g:tinted_gui01 = "1b1c36"
 let s:gui02        = "30365f"
-let g:base16_gui02 = "30365f"
+let g:tinted_gui02 = "30365f"
 let s:gui03        = "686f9a"
-let g:base16_gui03 = "686f9a"
+let g:tinted_gui03 = "686f9a"
 let s:gui04        = "818596"
-let g:base16_gui04 = "818596"
+let g:tinted_gui04 = "818596"
 let s:gui05        = "ecf0c1"
-let g:base16_gui05 = "ecf0c1"
+let g:tinted_gui05 = "ecf0c1"
 let s:gui06        = "c1c3cc"
-let g:base16_gui06 = "c1c3cc"
+let g:tinted_gui06 = "c1c3cc"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "e33400"
-let g:base16_gui08 = "e33400"
+let g:tinted_gui08 = "e33400"
 let s:gui09        = "e39400"
-let g:base16_gui09 = "e39400"
+let g:tinted_gui09 = "e39400"
 let s:gui0A        = "f2ce00"
-let g:base16_gui0A = "f2ce00"
+let g:tinted_gui0A = "f2ce00"
 let s:gui0B        = "5ccc96"
-let g:base16_gui0B = "5ccc96"
+let g:tinted_gui0B = "5ccc96"
 let s:gui0C        = "00a3cc"
-let g:base16_gui0C = "00a3cc"
+let g:tinted_gui0C = "00a3cc"
 let s:gui0D        = "7a5ccc"
-let g:base16_gui0D = "7a5ccc"
+let g:tinted_gui0D = "7a5ccc"
 let s:gui0E        = "b3a1e6"
-let g:base16_gui0E = "b3a1e6"
+let g:tinted_gui0E = "b3a1e6"
 let s:gui0F        = "ce6f8f"
+let g:tinted_gui0F = "ce6f8f"
+
+" Legacy
+let g:base16_gui00 = "16172d"
+let g:base16_gui01 = "1b1c36"
+let g:base16_gui02 = "30365f"
+let g:base16_gui03 = "686f9a"
+let g:base16_gui04 = "818596"
+let g:base16_gui05 = "ecf0c1"
+let g:base16_gui06 = "c1c3cc"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "e33400"
+let g:base16_gui09 = "e39400"
+let g:base16_gui0A = "f2ce00"
+let g:base16_gui0B = "5ccc96"
+let g:base16_gui0C = "00a3cc"
+let g:base16_gui0D = "7a5ccc"
+let g:base16_gui0E = "b3a1e6"
 let g:base16_gui0F = "ce6f8f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Spacemacs
 " Scheme author: Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-spacemacs.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/spacemacs.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/spacemacs.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1f2022"
-let g:base16_gui00 = "1f2022"
+let g:tinted_gui00 = "1f2022"
 let s:gui01        = "282828"
-let g:base16_gui01 = "282828"
+let g:tinted_gui01 = "282828"
 let s:gui02        = "444155"
-let g:base16_gui02 = "444155"
+let g:tinted_gui02 = "444155"
 let s:gui03        = "585858"
-let g:base16_gui03 = "585858"
+let g:tinted_gui03 = "585858"
 let s:gui04        = "b8b8b8"
-let g:base16_gui04 = "b8b8b8"
+let g:tinted_gui04 = "b8b8b8"
 let s:gui05        = "a3a3a3"
-let g:base16_gui05 = "a3a3a3"
+let g:tinted_gui05 = "a3a3a3"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "f8f8f8"
-let g:base16_gui07 = "f8f8f8"
+let g:tinted_gui07 = "f8f8f8"
 let s:gui08        = "f2241f"
-let g:base16_gui08 = "f2241f"
+let g:tinted_gui08 = "f2241f"
 let s:gui09        = "ffa500"
-let g:base16_gui09 = "ffa500"
+let g:tinted_gui09 = "ffa500"
 let s:gui0A        = "b1951d"
-let g:base16_gui0A = "b1951d"
+let g:tinted_gui0A = "b1951d"
 let s:gui0B        = "67b11d"
-let g:base16_gui0B = "67b11d"
+let g:tinted_gui0B = "67b11d"
 let s:gui0C        = "2d9574"
-let g:base16_gui0C = "2d9574"
+let g:tinted_gui0C = "2d9574"
 let s:gui0D        = "4f97d7"
-let g:base16_gui0D = "4f97d7"
+let g:tinted_gui0D = "4f97d7"
 let s:gui0E        = "a31db1"
-let g:base16_gui0E = "a31db1"
+let g:tinted_gui0E = "a31db1"
 let s:gui0F        = "b03060"
+let g:tinted_gui0F = "b03060"
+
+" Legacy
+let g:base16_gui00 = "1f2022"
+let g:base16_gui01 = "282828"
+let g:base16_gui02 = "444155"
+let g:base16_gui03 = "585858"
+let g:base16_gui04 = "b8b8b8"
+let g:base16_gui05 = "a3a3a3"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "f8f8f8"
+let g:base16_gui08 = "f2241f"
+let g:base16_gui09 = "ffa500"
+let g:base16_gui0A = "b1951d"
+let g:base16_gui0B = "67b11d"
+let g:base16_gui0C = "2d9574"
+let g:base16_gui0D = "4f97d7"
+let g:base16_gui0E = "a31db1"
 let g:base16_gui0F = "b03060"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8f8f8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-sparky.vim
+++ b/colors/base16-sparky.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Sparky
 " Scheme author: Leila Sother (https://github.com/mixcoac)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-sparky.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/sparky.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/sparky.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "072b31"
-let g:base16_gui00 = "072b31"
+let g:tinted_gui00 = "072b31"
 let s:gui01        = "00313c"
-let g:base16_gui01 = "00313c"
+let g:tinted_gui01 = "00313c"
 let s:gui02        = "003c46"
-let g:base16_gui02 = "003c46"
+let g:tinted_gui02 = "003c46"
 let s:gui03        = "003b49"
-let g:base16_gui03 = "003b49"
+let g:tinted_gui03 = "003b49"
 let s:gui04        = "00778b"
-let g:base16_gui04 = "00778b"
+let g:tinted_gui04 = "00778b"
 let s:gui05        = "f4f5f0"
-let g:base16_gui05 = "f4f5f0"
+let g:tinted_gui05 = "f4f5f0"
 let s:gui06        = "f5f5f1"
-let g:base16_gui06 = "f5f5f1"
+let g:tinted_gui06 = "f5f5f1"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff585d"
-let g:base16_gui08 = "ff585d"
+let g:tinted_gui08 = "ff585d"
 let s:gui09        = "ff8f1c"
-let g:base16_gui09 = "ff8f1c"
+let g:tinted_gui09 = "ff8f1c"
 let s:gui0A        = "fbdd40"
-let g:base16_gui0A = "fbdd40"
+let g:tinted_gui0A = "fbdd40"
 let s:gui0B        = "78d64b"
-let g:base16_gui0B = "78d64b"
+let g:tinted_gui0B = "78d64b"
 let s:gui0C        = "2dccd3"
-let g:base16_gui0C = "2dccd3"
+let g:tinted_gui0C = "2dccd3"
 let s:gui0D        = "4698cb"
-let g:base16_gui0D = "4698cb"
+let g:tinted_gui0D = "4698cb"
 let s:gui0E        = "d59ed7"
-let g:base16_gui0E = "d59ed7"
+let g:tinted_gui0E = "d59ed7"
 let s:gui0F        = "9b704d"
+let g:tinted_gui0F = "9b704d"
+
+" Legacy
+let g:base16_gui00 = "072b31"
+let g:base16_gui01 = "00313c"
+let g:base16_gui02 = "003c46"
+let g:base16_gui03 = "003b49"
+let g:base16_gui04 = "00778b"
+let g:base16_gui05 = "f4f5f0"
+let g:base16_gui06 = "f5f5f1"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff585d"
+let g:base16_gui09 = "ff8f1c"
+let g:base16_gui0A = "fbdd40"
+let g:base16_gui0B = "78d64b"
+let g:base16_gui0C = "2dccd3"
+let g:base16_gui0D = "4698cb"
+let g:base16_gui0E = "d59ed7"
 let g:base16_gui0F = "9b704d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-standardized-dark.vim
+++ b/colors/base16-standardized-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: standardized-dark
 " Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-standardized-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/standardized-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/standardized-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "222222"
-let g:base16_gui00 = "222222"
+let g:tinted_gui00 = "222222"
 let s:gui01        = "303030"
-let g:base16_gui01 = "303030"
+let g:tinted_gui01 = "303030"
 let s:gui02        = "555555"
-let g:base16_gui02 = "555555"
+let g:tinted_gui02 = "555555"
 let s:gui03        = "898989"
-let g:base16_gui03 = "898989"
+let g:tinted_gui03 = "898989"
 let s:gui04        = "898989"
-let g:base16_gui04 = "898989"
+let g:tinted_gui04 = "898989"
 let s:gui05        = "c0c0c0"
-let g:base16_gui05 = "c0c0c0"
+let g:tinted_gui05 = "c0c0c0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "e15d67"
-let g:base16_gui08 = "e15d67"
+let g:tinted_gui08 = "e15d67"
 let s:gui09        = "fc804e"
-let g:base16_gui09 = "fc804e"
+let g:tinted_gui09 = "fc804e"
 let s:gui0A        = "e1b31a"
-let g:base16_gui0A = "e1b31a"
+let g:tinted_gui0A = "e1b31a"
 let s:gui0B        = "5db129"
-let g:base16_gui0B = "5db129"
+let g:tinted_gui0B = "5db129"
 let s:gui0C        = "21c992"
-let g:base16_gui0C = "21c992"
+let g:tinted_gui0C = "21c992"
 let s:gui0D        = "00a3f2"
-let g:base16_gui0D = "00a3f2"
+let g:tinted_gui0D = "00a3f2"
 let s:gui0E        = "b46ee0"
-let g:base16_gui0E = "b46ee0"
+let g:tinted_gui0E = "b46ee0"
 let s:gui0F        = "b87d28"
+let g:tinted_gui0F = "b87d28"
+
+" Legacy
+let g:base16_gui00 = "222222"
+let g:base16_gui01 = "303030"
+let g:base16_gui02 = "555555"
+let g:base16_gui03 = "898989"
+let g:base16_gui04 = "898989"
+let g:base16_gui05 = "c0c0c0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "e15d67"
+let g:base16_gui09 = "fc804e"
+let g:base16_gui0A = "e1b31a"
+let g:base16_gui0B = "5db129"
+let g:base16_gui0C = "21c992"
+let g:base16_gui0D = "00a3f2"
+let g:base16_gui0E = "b46ee0"
 let g:base16_gui0F = "b87d28"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-standardized-light.vim
+++ b/colors/base16-standardized-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: standardized-light
 " Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-standardized-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/standardized-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/standardized-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "eeeeee"
-let g:base16_gui01 = "eeeeee"
+let g:tinted_gui01 = "eeeeee"
 let s:gui02        = "cccccc"
-let g:base16_gui02 = "cccccc"
+let g:tinted_gui02 = "cccccc"
 let s:gui03        = "767676"
-let g:base16_gui03 = "767676"
+let g:tinted_gui03 = "767676"
 let s:gui04        = "767676"
-let g:base16_gui04 = "767676"
+let g:tinted_gui04 = "767676"
 let s:gui05        = "444444"
-let g:base16_gui05 = "444444"
+let g:tinted_gui05 = "444444"
 let s:gui06        = "333333"
-let g:base16_gui06 = "333333"
+let g:tinted_gui06 = "333333"
 let s:gui07        = "222222"
-let g:base16_gui07 = "222222"
+let g:tinted_gui07 = "222222"
 let s:gui08        = "d03e3e"
-let g:base16_gui08 = "d03e3e"
+let g:tinted_gui08 = "d03e3e"
 let s:gui09        = "d7691d"
-let g:base16_gui09 = "d7691d"
+let g:tinted_gui09 = "d7691d"
 let s:gui0A        = "ad8200"
-let g:base16_gui0A = "ad8200"
+let g:tinted_gui0A = "ad8200"
 let s:gui0B        = "31861f"
-let g:base16_gui0B = "31861f"
+let g:tinted_gui0B = "31861f"
 let s:gui0C        = "00998f"
-let g:base16_gui0C = "00998f"
+let g:tinted_gui0C = "00998f"
 let s:gui0D        = "3173c5"
-let g:base16_gui0D = "3173c5"
+let g:tinted_gui0D = "3173c5"
 let s:gui0E        = "9e57c2"
-let g:base16_gui0E = "9e57c2"
+let g:tinted_gui0E = "9e57c2"
 let s:gui0F        = "895025"
+let g:tinted_gui0F = "895025"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "eeeeee"
+let g:base16_gui02 = "cccccc"
+let g:base16_gui03 = "767676"
+let g:base16_gui04 = "767676"
+let g:base16_gui05 = "444444"
+let g:base16_gui06 = "333333"
+let g:base16_gui07 = "222222"
+let g:base16_gui08 = "d03e3e"
+let g:base16_gui09 = "d7691d"
+let g:base16_gui0A = "ad8200"
+let g:base16_gui0B = "31861f"
+let g:base16_gui0C = "00998f"
+let g:base16_gui0D = "3173c5"
+let g:base16_gui0E = "9e57c2"
 let g:base16_gui0F = "895025"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#222222",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-stella.vim
+++ b/colors/base16-stella.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Stella
 " Scheme author: Shrimpram
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-stella.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/stella.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/stella.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2b213c"
-let g:base16_gui00 = "2b213c"
+let g:tinted_gui00 = "2b213c"
 let s:gui01        = "362b48"
-let g:base16_gui01 = "362b48"
+let g:tinted_gui01 = "362b48"
 let s:gui02        = "4d4160"
-let g:base16_gui02 = "4d4160"
+let g:tinted_gui02 = "4d4160"
 let s:gui03        = "655978"
-let g:base16_gui03 = "655978"
+let g:tinted_gui03 = "655978"
 let s:gui04        = "7f7192"
-let g:base16_gui04 = "7f7192"
+let g:tinted_gui04 = "7f7192"
 let s:gui05        = "998bad"
-let g:base16_gui05 = "998bad"
+let g:tinted_gui05 = "998bad"
 let s:gui06        = "b4a5c8"
-let g:base16_gui06 = "b4a5c8"
+let g:tinted_gui06 = "b4a5c8"
 let s:gui07        = "ebdcff"
-let g:base16_gui07 = "ebdcff"
+let g:tinted_gui07 = "ebdcff"
 let s:gui08        = "c79987"
-let g:base16_gui08 = "c79987"
+let g:tinted_gui08 = "c79987"
 let s:gui09        = "8865c6"
-let g:base16_gui09 = "8865c6"
+let g:tinted_gui09 = "8865c6"
 let s:gui0A        = "c7c691"
-let g:base16_gui0A = "c7c691"
+let g:tinted_gui0A = "c7c691"
 let s:gui0B        = "acc79b"
-let g:base16_gui0B = "acc79b"
+let g:tinted_gui0B = "acc79b"
 let s:gui0C        = "9bc7bf"
-let g:base16_gui0C = "9bc7bf"
+let g:tinted_gui0C = "9bc7bf"
 let s:gui0D        = "a5aad4"
-let g:base16_gui0D = "a5aad4"
+let g:tinted_gui0D = "a5aad4"
 let s:gui0E        = "c594ff"
-let g:base16_gui0E = "c594ff"
+let g:tinted_gui0E = "c594ff"
 let s:gui0F        = "c7ab87"
+let g:tinted_gui0F = "c7ab87"
+
+" Legacy
+let g:base16_gui00 = "2b213c"
+let g:base16_gui01 = "362b48"
+let g:base16_gui02 = "4d4160"
+let g:base16_gui03 = "655978"
+let g:base16_gui04 = "7f7192"
+let g:base16_gui05 = "998bad"
+let g:base16_gui06 = "b4a5c8"
+let g:base16_gui07 = "ebdcff"
+let g:base16_gui08 = "c79987"
+let g:base16_gui09 = "8865c6"
+let g:base16_gui0A = "c7c691"
+let g:base16_gui0B = "acc79b"
+let g:base16_gui0C = "9bc7bf"
+let g:base16_gui0D = "a5aad4"
+let g:base16_gui0E = "c594ff"
 let g:base16_gui0F = "c7ab87"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ebdcff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-still-alive.vim
+++ b/colors/base16-still-alive.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Still Alive
 " Scheme author: Derrick McKee (derrick.mckee@gmail.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-still-alive.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/still-alive.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/still-alive.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f0f0f0"
-let g:base16_gui00 = "f0f0f0"
+let g:tinted_gui00 = "f0f0f0"
 let s:gui01        = "f0d848"
-let g:base16_gui01 = "f0d848"
+let g:tinted_gui01 = "f0d848"
 let s:gui02        = "fff018"
-let g:base16_gui02 = "fff018"
+let g:tinted_gui02 = "fff018"
 let s:gui03        = "f01818"
-let g:base16_gui03 = "f01818"
+let g:tinted_gui03 = "f01818"
 let s:gui04        = "f00000"
-let g:base16_gui04 = "f00000"
+let g:tinted_gui04 = "f00000"
 let s:gui05        = "d80000"
-let g:base16_gui05 = "d80000"
+let g:tinted_gui05 = "d80000"
 let s:gui06        = "489000"
-let g:base16_gui06 = "489000"
+let g:tinted_gui06 = "489000"
 let s:gui07        = "30a860"
-let g:base16_gui07 = "30a860"
+let g:tinted_gui07 = "30a860"
 let s:gui08        = "487830"
-let g:base16_gui08 = "487830"
+let g:tinted_gui08 = "487830"
 let s:gui09        = "183048"
-let g:base16_gui09 = "183048"
+let g:tinted_gui09 = "183048"
 let s:gui0A        = "426395"
-let g:base16_gui0A = "426395"
+let g:tinted_gui0A = "426395"
 let s:gui0B        = "5c5c6a"
-let g:base16_gui0B = "5c5c6a"
+let g:tinted_gui0B = "5c5c6a"
 let s:gui0C        = "2c3c57"
-let g:base16_gui0C = "2c3c57"
+let g:tinted_gui0C = "2c3c57"
 let s:gui0D        = "001878"
-let g:base16_gui0D = "001878"
+let g:tinted_gui0D = "001878"
 let s:gui0E        = "900000"
-let g:base16_gui0E = "900000"
+let g:tinted_gui0E = "900000"
 let s:gui0F        = "140c0d"
+let g:tinted_gui0F = "140c0d"
+
+" Legacy
+let g:base16_gui00 = "f0f0f0"
+let g:base16_gui01 = "f0d848"
+let g:base16_gui02 = "fff018"
+let g:base16_gui03 = "f01818"
+let g:base16_gui04 = "f00000"
+let g:base16_gui05 = "d80000"
+let g:base16_gui06 = "489000"
+let g:base16_gui07 = "30a860"
+let g:base16_gui08 = "487830"
+let g:base16_gui09 = "183048"
+let g:base16_gui0A = "426395"
+let g:base16_gui0B = "5c5c6a"
+let g:base16_gui0C = "2c3c57"
+let g:base16_gui0D = "001878"
+let g:base16_gui0E = "900000"
 let g:base16_gui0F = "140c0d"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#30a860",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: summercamp
 " Scheme author: zoe firi (zoefiri.github.io)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-summercamp.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/summercamp.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/summercamp.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1c1810"
-let g:base16_gui00 = "1c1810"
+let g:tinted_gui00 = "1c1810"
 let s:gui01        = "2a261c"
-let g:base16_gui01 = "2a261c"
+let g:tinted_gui01 = "2a261c"
 let s:gui02        = "3a3527"
-let g:base16_gui02 = "3a3527"
+let g:tinted_gui02 = "3a3527"
 let s:gui03        = "504b38"
-let g:base16_gui03 = "504b38"
+let g:tinted_gui03 = "504b38"
 let s:gui04        = "5f5b45"
-let g:base16_gui04 = "5f5b45"
+let g:tinted_gui04 = "5f5b45"
 let s:gui05        = "736e55"
-let g:base16_gui05 = "736e55"
+let g:tinted_gui05 = "736e55"
 let s:gui06        = "bab696"
-let g:base16_gui06 = "bab696"
+let g:tinted_gui06 = "bab696"
 let s:gui07        = "f8f5de"
-let g:base16_gui07 = "f8f5de"
+let g:tinted_gui07 = "f8f5de"
 let s:gui08        = "e35142"
-let g:base16_gui08 = "e35142"
+let g:tinted_gui08 = "e35142"
 let s:gui09        = "fba11b"
-let g:base16_gui09 = "fba11b"
+let g:tinted_gui09 = "fba11b"
 let s:gui0A        = "f2ff27"
-let g:base16_gui0A = "f2ff27"
+let g:tinted_gui0A = "f2ff27"
 let s:gui0B        = "5ceb5a"
-let g:base16_gui0B = "5ceb5a"
+let g:tinted_gui0B = "5ceb5a"
 let s:gui0C        = "5aebbc"
-let g:base16_gui0C = "5aebbc"
+let g:tinted_gui0C = "5aebbc"
 let s:gui0D        = "489bf0"
-let g:base16_gui0D = "489bf0"
+let g:tinted_gui0D = "489bf0"
 let s:gui0E        = "ff8080"
-let g:base16_gui0E = "ff8080"
+let g:tinted_gui0E = "ff8080"
 let s:gui0F        = "f69be7"
+let g:tinted_gui0F = "f69be7"
+
+" Legacy
+let g:base16_gui00 = "1c1810"
+let g:base16_gui01 = "2a261c"
+let g:base16_gui02 = "3a3527"
+let g:base16_gui03 = "504b38"
+let g:base16_gui04 = "5f5b45"
+let g:base16_gui05 = "736e55"
+let g:base16_gui06 = "bab696"
+let g:base16_gui07 = "f8f5de"
+let g:base16_gui08 = "e35142"
+let g:base16_gui09 = "fba11b"
+let g:base16_gui0A = "f2ff27"
+let g:base16_gui0B = "5ceb5a"
+let g:base16_gui0C = "5aebbc"
+let g:base16_gui0D = "489bf0"
+let g:base16_gui0E = "ff8080"
 let g:base16_gui0F = "f69be7"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f8f5de",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Summerfruit Dark
 " Scheme author: Christopher Corley (http://christop.club/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-summerfruit-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/summerfruit-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/summerfruit-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "151515"
-let g:base16_gui00 = "151515"
+let g:tinted_gui00 = "151515"
 let s:gui01        = "202020"
-let g:base16_gui01 = "202020"
+let g:tinted_gui01 = "202020"
 let s:gui02        = "303030"
-let g:base16_gui02 = "303030"
+let g:tinted_gui02 = "303030"
 let s:gui03        = "505050"
-let g:base16_gui03 = "505050"
+let g:tinted_gui03 = "505050"
 let s:gui04        = "b0b0b0"
-let g:base16_gui04 = "b0b0b0"
+let g:tinted_gui04 = "b0b0b0"
 let s:gui05        = "d0d0d0"
-let g:base16_gui05 = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff0086"
-let g:base16_gui08 = "ff0086"
+let g:tinted_gui08 = "ff0086"
 let s:gui09        = "fd8900"
-let g:base16_gui09 = "fd8900"
+let g:tinted_gui09 = "fd8900"
 let s:gui0A        = "aba800"
-let g:base16_gui0A = "aba800"
+let g:tinted_gui0A = "aba800"
 let s:gui0B        = "00c918"
-let g:base16_gui0B = "00c918"
+let g:tinted_gui0B = "00c918"
 let s:gui0C        = "1faaaa"
-let g:base16_gui0C = "1faaaa"
+let g:tinted_gui0C = "1faaaa"
 let s:gui0D        = "3777e6"
-let g:base16_gui0D = "3777e6"
+let g:tinted_gui0D = "3777e6"
 let s:gui0E        = "ad00a1"
-let g:base16_gui0E = "ad00a1"
+let g:tinted_gui0E = "ad00a1"
 let s:gui0F        = "cc6633"
+let g:tinted_gui0F = "cc6633"
+
+" Legacy
+let g:base16_gui00 = "151515"
+let g:base16_gui01 = "202020"
+let g:base16_gui02 = "303030"
+let g:base16_gui03 = "505050"
+let g:base16_gui04 = "b0b0b0"
+let g:base16_gui05 = "d0d0d0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff0086"
+let g:base16_gui09 = "fd8900"
+let g:base16_gui0A = "aba800"
+let g:base16_gui0B = "00c918"
+let g:base16_gui0C = "1faaaa"
+let g:base16_gui0D = "3777e6"
+let g:base16_gui0E = "ad00a1"
 let g:base16_gui0F = "cc6633"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Summerfruit Light
 " Scheme author: Christopher Corley (http://christop.club/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-summerfruit-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/summerfruit-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/summerfruit-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "e0e0e0"
-let g:base16_gui01 = "e0e0e0"
+let g:tinted_gui01 = "e0e0e0"
 let s:gui02        = "d0d0d0"
-let g:base16_gui02 = "d0d0d0"
+let g:tinted_gui02 = "d0d0d0"
 let s:gui03        = "b0b0b0"
-let g:base16_gui03 = "b0b0b0"
+let g:tinted_gui03 = "b0b0b0"
 let s:gui04        = "000000"
-let g:base16_gui04 = "000000"
+let g:tinted_gui04 = "000000"
 let s:gui05        = "101010"
-let g:base16_gui05 = "101010"
+let g:tinted_gui05 = "101010"
 let s:gui06        = "151515"
-let g:base16_gui06 = "151515"
+let g:tinted_gui06 = "151515"
 let s:gui07        = "202020"
-let g:base16_gui07 = "202020"
+let g:tinted_gui07 = "202020"
 let s:gui08        = "ff0086"
-let g:base16_gui08 = "ff0086"
+let g:tinted_gui08 = "ff0086"
 let s:gui09        = "fd8900"
-let g:base16_gui09 = "fd8900"
+let g:tinted_gui09 = "fd8900"
 let s:gui0A        = "aba800"
-let g:base16_gui0A = "aba800"
+let g:tinted_gui0A = "aba800"
 let s:gui0B        = "00c918"
-let g:base16_gui0B = "00c918"
+let g:tinted_gui0B = "00c918"
 let s:gui0C        = "1faaaa"
-let g:base16_gui0C = "1faaaa"
+let g:tinted_gui0C = "1faaaa"
 let s:gui0D        = "3777e6"
-let g:base16_gui0D = "3777e6"
+let g:tinted_gui0D = "3777e6"
 let s:gui0E        = "ad00a1"
-let g:base16_gui0E = "ad00a1"
+let g:tinted_gui0E = "ad00a1"
 let s:gui0F        = "cc6633"
+let g:tinted_gui0F = "cc6633"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "e0e0e0"
+let g:base16_gui02 = "d0d0d0"
+let g:base16_gui03 = "b0b0b0"
+let g:base16_gui04 = "000000"
+let g:base16_gui05 = "101010"
+let g:base16_gui06 = "151515"
+let g:base16_gui07 = "202020"
+let g:base16_gui08 = "ff0086"
+let g:base16_gui09 = "fd8900"
+let g:base16_gui0A = "aba800"
+let g:base16_gui0B = "00c918"
+let g:base16_gui0C = "1faaaa"
+let g:base16_gui0D = "3777e6"
+let g:base16_gui0E = "ad00a1"
 let g:base16_gui0F = "cc6633"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#202020",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Synth Midnight Terminal Dark
 " Scheme author: Michaël Ball (http://github.com/michael-ball/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-synth-midnight-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/synth-midnight-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/synth-midnight-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "050608"
-let g:base16_gui00 = "050608"
+let g:tinted_gui00 = "050608"
 let s:gui01        = "1a1b1c"
-let g:base16_gui01 = "1a1b1c"
+let g:tinted_gui01 = "1a1b1c"
 let s:gui02        = "28292a"
-let g:base16_gui02 = "28292a"
+let g:tinted_gui02 = "28292a"
 let s:gui03        = "474849"
-let g:base16_gui03 = "474849"
+let g:tinted_gui03 = "474849"
 let s:gui04        = "a3a5a6"
-let g:base16_gui04 = "a3a5a6"
+let g:tinted_gui04 = "a3a5a6"
 let s:gui05        = "c1c3c4"
-let g:base16_gui05 = "c1c3c4"
+let g:tinted_gui05 = "c1c3c4"
 let s:gui06        = "cfd1d2"
-let g:base16_gui06 = "cfd1d2"
+let g:tinted_gui06 = "cfd1d2"
 let s:gui07        = "dddfe0"
-let g:base16_gui07 = "dddfe0"
+let g:tinted_gui07 = "dddfe0"
 let s:gui08        = "b53b50"
-let g:base16_gui08 = "b53b50"
+let g:tinted_gui08 = "b53b50"
 let s:gui09        = "ea770d"
-let g:base16_gui09 = "ea770d"
+let g:tinted_gui09 = "ea770d"
 let s:gui0A        = "c9d364"
-let g:base16_gui0A = "c9d364"
+let g:tinted_gui0A = "c9d364"
 let s:gui0B        = "06ea61"
-let g:base16_gui0B = "06ea61"
+let g:tinted_gui0B = "06ea61"
 let s:gui0C        = "42fff9"
-let g:base16_gui0C = "42fff9"
+let g:tinted_gui0C = "42fff9"
 let s:gui0D        = "03aeff"
-let g:base16_gui0D = "03aeff"
+let g:tinted_gui0D = "03aeff"
 let s:gui0E        = "ea5ce2"
-let g:base16_gui0E = "ea5ce2"
+let g:tinted_gui0E = "ea5ce2"
 let s:gui0F        = "cd6320"
+let g:tinted_gui0F = "cd6320"
+
+" Legacy
+let g:base16_gui00 = "050608"
+let g:base16_gui01 = "1a1b1c"
+let g:base16_gui02 = "28292a"
+let g:base16_gui03 = "474849"
+let g:base16_gui04 = "a3a5a6"
+let g:base16_gui05 = "c1c3c4"
+let g:base16_gui06 = "cfd1d2"
+let g:base16_gui07 = "dddfe0"
+let g:base16_gui08 = "b53b50"
+let g:base16_gui09 = "ea770d"
+let g:base16_gui0A = "c9d364"
+let g:base16_gui0B = "06ea61"
+let g:base16_gui0C = "42fff9"
+let g:base16_gui0D = "03aeff"
+let g:base16_gui0E = "ea5ce2"
 let g:base16_gui0F = "cd6320"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#dddfe0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Synth Midnight Terminal Light
 " Scheme author: Michaël Ball (http://github.com/michael-ball/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-synth-midnight-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/synth-midnight-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/synth-midnight-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "dddfe0"
-let g:base16_gui00 = "dddfe0"
+let g:tinted_gui00 = "dddfe0"
 let s:gui01        = "cfd1d2"
-let g:base16_gui01 = "cfd1d2"
+let g:tinted_gui01 = "cfd1d2"
 let s:gui02        = "c1c3c4"
-let g:base16_gui02 = "c1c3c4"
+let g:tinted_gui02 = "c1c3c4"
 let s:gui03        = "a3a5a6"
-let g:base16_gui03 = "a3a5a6"
+let g:tinted_gui03 = "a3a5a6"
 let s:gui04        = "474849"
-let g:base16_gui04 = "474849"
+let g:tinted_gui04 = "474849"
 let s:gui05        = "28292a"
-let g:base16_gui05 = "28292a"
+let g:tinted_gui05 = "28292a"
 let s:gui06        = "1a1b1c"
-let g:base16_gui06 = "1a1b1c"
+let g:tinted_gui06 = "1a1b1c"
 let s:gui07        = "050608"
-let g:base16_gui07 = "050608"
+let g:tinted_gui07 = "050608"
 let s:gui08        = "b53b50"
-let g:base16_gui08 = "b53b50"
+let g:tinted_gui08 = "b53b50"
 let s:gui09        = "ea770d"
-let g:base16_gui09 = "ea770d"
+let g:tinted_gui09 = "ea770d"
 let s:gui0A        = "c9d364"
-let g:base16_gui0A = "c9d364"
+let g:tinted_gui0A = "c9d364"
 let s:gui0B        = "06ea61"
-let g:base16_gui0B = "06ea61"
+let g:tinted_gui0B = "06ea61"
 let s:gui0C        = "42fff9"
-let g:base16_gui0C = "42fff9"
+let g:tinted_gui0C = "42fff9"
 let s:gui0D        = "03aeff"
-let g:base16_gui0D = "03aeff"
+let g:tinted_gui0D = "03aeff"
 let s:gui0E        = "ea5ce2"
-let g:base16_gui0E = "ea5ce2"
+let g:tinted_gui0E = "ea5ce2"
 let s:gui0F        = "cd6320"
+let g:tinted_gui0F = "cd6320"
+
+" Legacy
+let g:base16_gui00 = "dddfe0"
+let g:base16_gui01 = "cfd1d2"
+let g:base16_gui02 = "c1c3c4"
+let g:base16_gui03 = "a3a5a6"
+let g:base16_gui04 = "474849"
+let g:base16_gui05 = "28292a"
+let g:base16_gui06 = "1a1b1c"
+let g:base16_gui07 = "050608"
+let g:base16_gui08 = "b53b50"
+let g:base16_gui09 = "ea770d"
+let g:base16_gui0A = "c9d364"
+let g:base16_gui0B = "06ea61"
+let g:base16_gui0C = "42fff9"
+let g:base16_gui0D = "03aeff"
+let g:base16_gui0E = "ea5ce2"
 let g:base16_gui0F = "cd6320"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#050608",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tango
 " Scheme author: @Schnouki, based on the Tango Desktop Project
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tango.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tango.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tango.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2e3436"
-let g:base16_gui00 = "2e3436"
+let g:tinted_gui00 = "2e3436"
 let s:gui01        = "8ae234"
-let g:base16_gui01 = "8ae234"
+let g:tinted_gui01 = "8ae234"
 let s:gui02        = "fce94f"
-let g:base16_gui02 = "fce94f"
+let g:tinted_gui02 = "fce94f"
 let s:gui03        = "555753"
-let g:base16_gui03 = "555753"
+let g:tinted_gui03 = "555753"
 let s:gui04        = "729fcf"
-let g:base16_gui04 = "729fcf"
+let g:tinted_gui04 = "729fcf"
 let s:gui05        = "d3d7cf"
-let g:base16_gui05 = "d3d7cf"
+let g:tinted_gui05 = "d3d7cf"
 let s:gui06        = "ad7fa8"
-let g:base16_gui06 = "ad7fa8"
+let g:tinted_gui06 = "ad7fa8"
 let s:gui07        = "eeeeec"
-let g:base16_gui07 = "eeeeec"
+let g:tinted_gui07 = "eeeeec"
 let s:gui08        = "cc0000"
-let g:base16_gui08 = "cc0000"
+let g:tinted_gui08 = "cc0000"
 let s:gui09        = "ef2929"
-let g:base16_gui09 = "ef2929"
+let g:tinted_gui09 = "ef2929"
 let s:gui0A        = "c4a000"
-let g:base16_gui0A = "c4a000"
+let g:tinted_gui0A = "c4a000"
 let s:gui0B        = "4e9a06"
-let g:base16_gui0B = "4e9a06"
+let g:tinted_gui0B = "4e9a06"
 let s:gui0C        = "06989a"
-let g:base16_gui0C = "06989a"
+let g:tinted_gui0C = "06989a"
 let s:gui0D        = "3465a4"
-let g:base16_gui0D = "3465a4"
+let g:tinted_gui0D = "3465a4"
 let s:gui0E        = "75507b"
-let g:base16_gui0E = "75507b"
+let g:tinted_gui0E = "75507b"
 let s:gui0F        = "34e2e2"
+let g:tinted_gui0F = "34e2e2"
+
+" Legacy
+let g:base16_gui00 = "2e3436"
+let g:base16_gui01 = "8ae234"
+let g:base16_gui02 = "fce94f"
+let g:base16_gui03 = "555753"
+let g:base16_gui04 = "729fcf"
+let g:base16_gui05 = "d3d7cf"
+let g:base16_gui06 = "ad7fa8"
+let g:base16_gui07 = "eeeeec"
+let g:base16_gui08 = "cc0000"
+let g:base16_gui09 = "ef2929"
+let g:base16_gui0A = "c4a000"
+let g:base16_gui0B = "4e9a06"
+let g:base16_gui0C = "06989a"
+let g:base16_gui0D = "3465a4"
+let g:base16_gui0E = "75507b"
 let g:base16_gui0F = "34e2e2"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#eeeeec",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tarot.vim
+++ b/colors/base16-tarot.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: tarot
 " Scheme author: ed (https://codeberg.org/ed)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tarot.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tarot.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tarot.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0e091d"
-let g:base16_gui00 = "0e091d"
+let g:tinted_gui00 = "0e091d"
 let s:gui01        = "2a153c"
-let g:base16_gui01 = "2a153c"
+let g:tinted_gui01 = "2a153c"
 let s:gui02        = "4b2054"
-let g:base16_gui02 = "4b2054"
+let g:tinted_gui02 = "4b2054"
 let s:gui03        = "74316b"
-let g:base16_gui03 = "74316b"
+let g:tinted_gui03 = "74316b"
 let s:gui04        = "8c406f"
-let g:base16_gui04 = "8c406f"
+let g:tinted_gui04 = "8c406f"
 let s:gui05        = "aa556f"
-let g:base16_gui05 = "aa556f"
+let g:tinted_gui05 = "aa556f"
 let s:gui06        = "c4686d"
-let g:base16_gui06 = "c4686d"
+let g:tinted_gui06 = "c4686d"
 let s:gui07        = "dc8f7c"
-let g:base16_gui07 = "dc8f7c"
+let g:tinted_gui07 = "dc8f7c"
 let s:gui08        = "c53253"
-let g:base16_gui08 = "c53253"
+let g:tinted_gui08 = "c53253"
 let s:gui09        = "ea4d60"
-let g:base16_gui09 = "ea4d60"
+let g:tinted_gui09 = "ea4d60"
 let s:gui0A        = "ff6565"
-let g:base16_gui0A = "ff6565"
+let g:tinted_gui0A = "ff6565"
 let s:gui0B        = "a68e5a"
-let g:base16_gui0B = "a68e5a"
+let g:tinted_gui0B = "a68e5a"
 let s:gui0C        = "8c9785"
-let g:base16_gui0C = "8c9785"
+let g:tinted_gui0C = "8c9785"
 let s:gui0D        = "6e6080"
-let g:base16_gui0D = "6e6080"
+let g:tinted_gui0D = "6e6080"
 let s:gui0E        = "a45782"
-let g:base16_gui0E = "a45782"
+let g:tinted_gui0E = "a45782"
 let s:gui0F        = "984d51"
+let g:tinted_gui0F = "984d51"
+
+" Legacy
+let g:base16_gui00 = "0e091d"
+let g:base16_gui01 = "2a153c"
+let g:base16_gui02 = "4b2054"
+let g:base16_gui03 = "74316b"
+let g:base16_gui04 = "8c406f"
+let g:base16_gui05 = "aa556f"
+let g:base16_gui06 = "c4686d"
+let g:base16_gui07 = "dc8f7c"
+let g:base16_gui08 = "c53253"
+let g:base16_gui09 = "ea4d60"
+let g:base16_gui0A = "ff6565"
+let g:base16_gui0B = "a68e5a"
+let g:base16_gui0C = "8c9785"
+let g:base16_gui0D = "6e6080"
+let g:base16_gui0E = "a45782"
 let g:base16_gui0F = "984d51"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#dc8f7c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tender.vim
+++ b/colors/base16-tender.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: tender
 " Scheme author: Jacobo Tabernero (https://github/com/jacoborus/tender.vim)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tender.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tender.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tender.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282828"
-let g:base16_gui00 = "282828"
+let g:tinted_gui00 = "282828"
 let s:gui01        = "383838"
-let g:base16_gui01 = "383838"
+let g:tinted_gui01 = "383838"
 let s:gui02        = "484848"
-let g:base16_gui02 = "484848"
+let g:tinted_gui02 = "484848"
 let s:gui03        = "4c4c4c"
-let g:base16_gui03 = "4c4c4c"
+let g:tinted_gui03 = "4c4c4c"
 let s:gui04        = "b8b8b8"
-let g:base16_gui04 = "b8b8b8"
+let g:tinted_gui04 = "b8b8b8"
 let s:gui05        = "eeeeee"
-let g:base16_gui05 = "eeeeee"
+let g:tinted_gui05 = "eeeeee"
 let s:gui06        = "e8e8e8"
-let g:base16_gui06 = "e8e8e8"
+let g:tinted_gui06 = "e8e8e8"
 let s:gui07        = "feffff"
-let g:base16_gui07 = "feffff"
+let g:tinted_gui07 = "feffff"
 let s:gui08        = "f43753"
-let g:base16_gui08 = "f43753"
+let g:tinted_gui08 = "f43753"
 let s:gui09        = "dc9656"
-let g:base16_gui09 = "dc9656"
+let g:tinted_gui09 = "dc9656"
 let s:gui0A        = "ffc24b"
-let g:base16_gui0A = "ffc24b"
+let g:tinted_gui0A = "ffc24b"
 let s:gui0B        = "c9d05c"
-let g:base16_gui0B = "c9d05c"
+let g:tinted_gui0B = "c9d05c"
 let s:gui0C        = "73cef4"
-let g:base16_gui0C = "73cef4"
+let g:tinted_gui0C = "73cef4"
 let s:gui0D        = "b3deef"
-let g:base16_gui0D = "b3deef"
+let g:tinted_gui0D = "b3deef"
 let s:gui0E        = "d3b987"
-let g:base16_gui0E = "d3b987"
+let g:tinted_gui0E = "d3b987"
 let s:gui0F        = "a16946"
+let g:tinted_gui0F = "a16946"
+
+" Legacy
+let g:base16_gui00 = "282828"
+let g:base16_gui01 = "383838"
+let g:base16_gui02 = "484848"
+let g:base16_gui03 = "4c4c4c"
+let g:base16_gui04 = "b8b8b8"
+let g:base16_gui05 = "eeeeee"
+let g:base16_gui06 = "e8e8e8"
+let g:base16_gui07 = "feffff"
+let g:base16_gui08 = "f43753"
+let g:base16_gui09 = "dc9656"
+let g:base16_gui0A = "ffc24b"
+let g:base16_gui0B = "c9d05c"
+let g:base16_gui0C = "73cef4"
+let g:base16_gui0D = "b3deef"
+let g:base16_gui0E = "d3b987"
 let g:base16_gui0F = "a16946"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#feffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-terracotta-dark.vim
+++ b/colors/base16-terracotta-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Terracotta Dark
 " Scheme author: Alexander Rossell Hayes (https://github.com/rossellhayes)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-terracotta-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/terracotta-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/terracotta-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "241d1a"
-let g:base16_gui00 = "241d1a"
+let g:tinted_gui00 = "241d1a"
 let s:gui01        = "362b27"
-let g:base16_gui01 = "362b27"
+let g:tinted_gui01 = "362b27"
 let s:gui02        = "473933"
-let g:base16_gui02 = "473933"
+let g:tinted_gui02 = "473933"
 let s:gui03        = "594740"
-let g:base16_gui03 = "594740"
+let g:tinted_gui03 = "594740"
 let s:gui04        = "a78e84"
-let g:base16_gui04 = "a78e84"
+let g:tinted_gui04 = "a78e84"
 let s:gui05        = "b8a59d"
-let g:base16_gui05 = "b8a59d"
+let g:tinted_gui05 = "b8a59d"
 let s:gui06        = "cabbb5"
-let g:base16_gui06 = "cabbb5"
+let g:tinted_gui06 = "cabbb5"
 let s:gui07        = "dcd2ce"
-let g:base16_gui07 = "dcd2ce"
+let g:tinted_gui07 = "dcd2ce"
 let s:gui08        = "f6998f"
-let g:base16_gui08 = "f6998f"
+let g:tinted_gui08 = "f6998f"
 let s:gui09        = "ffa888"
-let g:base16_gui09 = "ffa888"
+let g:tinted_gui09 = "ffa888"
 let s:gui0A        = "ffc37a"
-let g:base16_gui0A = "ffc37a"
+let g:tinted_gui0A = "ffc37a"
 let s:gui0B        = "b6c68a"
-let g:base16_gui0B = "b6c68a"
+let g:tinted_gui0B = "b6c68a"
 let s:gui0C        = "c0bcdb"
-let g:base16_gui0C = "c0bcdb"
+let g:tinted_gui0C = "c0bcdb"
 let s:gui0D        = "b0a4c3"
-let g:base16_gui0D = "b0a4c3"
+let g:tinted_gui0D = "b0a4c3"
 let s:gui0E        = "d8a2b0"
-let g:base16_gui0E = "d8a2b0"
+let g:tinted_gui0E = "d8a2b0"
 let s:gui0F        = "f1ae97"
+let g:tinted_gui0F = "f1ae97"
+
+" Legacy
+let g:base16_gui00 = "241d1a"
+let g:base16_gui01 = "362b27"
+let g:base16_gui02 = "473933"
+let g:base16_gui03 = "594740"
+let g:base16_gui04 = "a78e84"
+let g:base16_gui05 = "b8a59d"
+let g:base16_gui06 = "cabbb5"
+let g:base16_gui07 = "dcd2ce"
+let g:base16_gui08 = "f6998f"
+let g:base16_gui09 = "ffa888"
+let g:base16_gui0A = "ffc37a"
+let g:base16_gui0B = "b6c68a"
+let g:base16_gui0C = "c0bcdb"
+let g:base16_gui0D = "b0a4c3"
+let g:base16_gui0E = "d8a2b0"
 let g:base16_gui0F = "f1ae97"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#dcd2ce",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-terracotta.vim
+++ b/colors/base16-terracotta.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Terracotta
 " Scheme author: Alexander Rossell Hayes (https://github.com/rossellhayes)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-terracotta.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/terracotta.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/terracotta.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "efeae8"
-let g:base16_gui00 = "efeae8"
+let g:tinted_gui00 = "efeae8"
 let s:gui01        = "dfd6d1"
-let g:base16_gui01 = "dfd6d1"
+let g:tinted_gui01 = "dfd6d1"
 let s:gui02        = "d0c1bb"
-let g:base16_gui02 = "d0c1bb"
+let g:tinted_gui02 = "d0c1bb"
 let s:gui03        = "c0aca4"
-let g:base16_gui03 = "c0aca4"
+let g:tinted_gui03 = "c0aca4"
 let s:gui04        = "59453d"
-let g:base16_gui04 = "59453d"
+let g:tinted_gui04 = "59453d"
 let s:gui05        = "473731"
-let g:base16_gui05 = "473731"
+let g:tinted_gui05 = "473731"
 let s:gui06        = "352a25"
-let g:base16_gui06 = "352a25"
+let g:tinted_gui06 = "352a25"
 let s:gui07        = "241c19"
-let g:base16_gui07 = "241c19"
+let g:tinted_gui07 = "241c19"
 let s:gui08        = "a75045"
-let g:base16_gui08 = "a75045"
+let g:tinted_gui08 = "a75045"
 let s:gui09        = "bd6942"
-let g:base16_gui09 = "bd6942"
+let g:tinted_gui09 = "bd6942"
 let s:gui0A        = "ce943e"
-let g:base16_gui0A = "ce943e"
+let g:tinted_gui0A = "ce943e"
 let s:gui0B        = "7a894a"
-let g:base16_gui0B = "7a894a"
+let g:tinted_gui0B = "7a894a"
 let s:gui0C        = "847f9e"
-let g:base16_gui0C = "847f9e"
+let g:tinted_gui0C = "847f9e"
 let s:gui0D        = "625574"
-let g:base16_gui0D = "625574"
+let g:tinted_gui0D = "625574"
 let s:gui0E        = "8d5968"
-let g:base16_gui0E = "8d5968"
+let g:tinted_gui0E = "8d5968"
 let s:gui0F        = "b07158"
+let g:tinted_gui0F = "b07158"
+
+" Legacy
+let g:base16_gui00 = "efeae8"
+let g:base16_gui01 = "dfd6d1"
+let g:base16_gui02 = "d0c1bb"
+let g:base16_gui03 = "c0aca4"
+let g:base16_gui04 = "59453d"
+let g:base16_gui05 = "473731"
+let g:base16_gui06 = "352a25"
+let g:base16_gui07 = "241c19"
+let g:base16_gui08 = "a75045"
+let g:base16_gui09 = "bd6942"
+let g:base16_gui0A = "ce943e"
+let g:base16_gui0B = "7a894a"
+let g:base16_gui0C = "847f9e"
+let g:base16_gui0D = "625574"
+let g:base16_gui0E = "8d5968"
 let g:base16_gui0F = "b07158"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#241c19",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-city-dark.vim
+++ b/colors/base16-tokyo-city-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo City Dark
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-city-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-city-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-city-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171d23"
-let g:base16_gui00 = "171d23"
+let g:tinted_gui00 = "171d23"
 let s:gui01        = "1d252c"
-let g:base16_gui01 = "1d252c"
+let g:tinted_gui01 = "1d252c"
 let s:gui02        = "28323a"
-let g:base16_gui02 = "28323a"
+let g:tinted_gui02 = "28323a"
 let s:gui03        = "526270"
-let g:base16_gui03 = "526270"
+let g:tinted_gui03 = "526270"
 let s:gui04        = "b7c5d3"
-let g:base16_gui04 = "b7c5d3"
+let g:tinted_gui04 = "b7c5d3"
 let s:gui05        = "d8e2ec"
-let g:base16_gui05 = "d8e2ec"
+let g:tinted_gui05 = "d8e2ec"
 let s:gui06        = "f6f6f8"
-let g:base16_gui06 = "f6f6f8"
+let g:tinted_gui06 = "f6f6f8"
 let s:gui07        = "fbfbfd"
-let g:base16_gui07 = "fbfbfd"
+let g:tinted_gui07 = "fbfbfd"
 let s:gui08        = "f7768e"
-let g:base16_gui08 = "f7768e"
+let g:tinted_gui08 = "f7768e"
 let s:gui09        = "ff9e64"
-let g:base16_gui09 = "ff9e64"
+let g:tinted_gui09 = "ff9e64"
 let s:gui0A        = "b7c5d3"
-let g:base16_gui0A = "b7c5d3"
+let g:tinted_gui0A = "b7c5d3"
 let s:gui0B        = "9ece6a"
-let g:base16_gui0B = "9ece6a"
+let g:tinted_gui0B = "9ece6a"
 let s:gui0C        = "89ddff"
-let g:base16_gui0C = "89ddff"
+let g:tinted_gui0C = "89ddff"
 let s:gui0D        = "7aa2f7"
-let g:base16_gui0D = "7aa2f7"
+let g:tinted_gui0D = "7aa2f7"
 let s:gui0E        = "bb9af7"
-let g:base16_gui0E = "bb9af7"
+let g:tinted_gui0E = "bb9af7"
 let s:gui0F        = "bb9af7"
+let g:tinted_gui0F = "bb9af7"
+
+" Legacy
+let g:base16_gui00 = "171d23"
+let g:base16_gui01 = "1d252c"
+let g:base16_gui02 = "28323a"
+let g:base16_gui03 = "526270"
+let g:base16_gui04 = "b7c5d3"
+let g:base16_gui05 = "d8e2ec"
+let g:base16_gui06 = "f6f6f8"
+let g:base16_gui07 = "fbfbfd"
+let g:base16_gui08 = "f7768e"
+let g:base16_gui09 = "ff9e64"
+let g:base16_gui0A = "b7c5d3"
+let g:base16_gui0B = "9ece6a"
+let g:base16_gui0C = "89ddff"
+let g:base16_gui0D = "7aa2f7"
+let g:base16_gui0E = "bb9af7"
 let g:base16_gui0F = "bb9af7"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbfbfd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-city-light.vim
+++ b/colors/base16-tokyo-city-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo City Light
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-city-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-city-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-city-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fbfbfd"
-let g:base16_gui00 = "fbfbfd"
+let g:tinted_gui00 = "fbfbfd"
 let s:gui01        = "f6f6f8"
-let g:base16_gui01 = "f6f6f8"
+let g:tinted_gui01 = "f6f6f8"
 let s:gui02        = "edeff6"
-let g:base16_gui02 = "edeff6"
+let g:tinted_gui02 = "edeff6"
 let s:gui03        = "9699a3"
-let g:base16_gui03 = "9699a3"
+let g:tinted_gui03 = "9699a3"
 let s:gui04        = "4c505e"
-let g:base16_gui04 = "4c505e"
+let g:tinted_gui04 = "4c505e"
 let s:gui05        = "343b59"
-let g:base16_gui05 = "343b59"
+let g:tinted_gui05 = "343b59"
 let s:gui06        = "1d252c"
-let g:base16_gui06 = "1d252c"
+let g:tinted_gui06 = "1d252c"
 let s:gui07        = "171d23"
-let g:base16_gui07 = "171d23"
+let g:tinted_gui07 = "171d23"
 let s:gui08        = "8c4351"
-let g:base16_gui08 = "8c4351"
+let g:tinted_gui08 = "8c4351"
 let s:gui09        = "965027"
-let g:base16_gui09 = "965027"
+let g:tinted_gui09 = "965027"
 let s:gui0A        = "4c505e"
-let g:base16_gui0A = "4c505e"
+let g:tinted_gui0A = "4c505e"
 let s:gui0B        = "485e30"
-let g:base16_gui0B = "485e30"
+let g:tinted_gui0B = "485e30"
 let s:gui0C        = "4c505e"
-let g:base16_gui0C = "4c505e"
+let g:tinted_gui0C = "4c505e"
 let s:gui0D        = "34548a"
-let g:base16_gui0D = "34548a"
+let g:tinted_gui0D = "34548a"
 let s:gui0E        = "5a4a78"
-let g:base16_gui0E = "5a4a78"
+let g:tinted_gui0E = "5a4a78"
 let s:gui0F        = "5a4a78"
+let g:tinted_gui0F = "5a4a78"
+
+" Legacy
+let g:base16_gui00 = "fbfbfd"
+let g:base16_gui01 = "f6f6f8"
+let g:base16_gui02 = "edeff6"
+let g:base16_gui03 = "9699a3"
+let g:base16_gui04 = "4c505e"
+let g:base16_gui05 = "343b59"
+let g:base16_gui06 = "1d252c"
+let g:base16_gui07 = "171d23"
+let g:base16_gui08 = "8c4351"
+let g:base16_gui09 = "965027"
+let g:base16_gui0A = "4c505e"
+let g:base16_gui0B = "485e30"
+let g:base16_gui0C = "4c505e"
+let g:base16_gui0D = "34548a"
+let g:base16_gui0E = "5a4a78"
 let g:base16_gui0F = "5a4a78"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#171d23",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-city-terminal-dark.vim
+++ b/colors/base16-tokyo-city-terminal-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo City Terminal Dark
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-city-terminal-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-city-terminal-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-city-terminal-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "171d23"
-let g:base16_gui00 = "171d23"
+let g:tinted_gui00 = "171d23"
 let s:gui01        = "1d252c"
-let g:base16_gui01 = "1d252c"
+let g:tinted_gui01 = "1d252c"
 let s:gui02        = "28323a"
-let g:base16_gui02 = "28323a"
+let g:tinted_gui02 = "28323a"
 let s:gui03        = "526270"
-let g:base16_gui03 = "526270"
+let g:tinted_gui03 = "526270"
 let s:gui04        = "b7c5d3"
-let g:base16_gui04 = "b7c5d3"
+let g:tinted_gui04 = "b7c5d3"
 let s:gui05        = "d8e2ec"
-let g:base16_gui05 = "d8e2ec"
+let g:tinted_gui05 = "d8e2ec"
 let s:gui06        = "f6f6f8"
-let g:base16_gui06 = "f6f6f8"
+let g:tinted_gui06 = "f6f6f8"
 let s:gui07        = "fbfbfd"
-let g:base16_gui07 = "fbfbfd"
+let g:tinted_gui07 = "fbfbfd"
 let s:gui08        = "d95468"
-let g:base16_gui08 = "d95468"
+let g:tinted_gui08 = "d95468"
 let s:gui09        = "ff9e64"
-let g:base16_gui09 = "ff9e64"
+let g:tinted_gui09 = "ff9e64"
 let s:gui0A        = "ebbf83"
-let g:base16_gui0A = "ebbf83"
+let g:tinted_gui0A = "ebbf83"
 let s:gui0B        = "8bd49c"
-let g:base16_gui0B = "8bd49c"
+let g:tinted_gui0B = "8bd49c"
 let s:gui0C        = "70e1e8"
-let g:base16_gui0C = "70e1e8"
+let g:tinted_gui0C = "70e1e8"
 let s:gui0D        = "539afc"
-let g:base16_gui0D = "539afc"
+let g:tinted_gui0D = "539afc"
 let s:gui0E        = "b62d65"
-let g:base16_gui0E = "b62d65"
+let g:tinted_gui0E = "b62d65"
 let s:gui0F        = "dd9d82"
+let g:tinted_gui0F = "dd9d82"
+
+" Legacy
+let g:base16_gui00 = "171d23"
+let g:base16_gui01 = "1d252c"
+let g:base16_gui02 = "28323a"
+let g:base16_gui03 = "526270"
+let g:base16_gui04 = "b7c5d3"
+let g:base16_gui05 = "d8e2ec"
+let g:base16_gui06 = "f6f6f8"
+let g:base16_gui07 = "fbfbfd"
+let g:base16_gui08 = "d95468"
+let g:base16_gui09 = "ff9e64"
+let g:base16_gui0A = "ebbf83"
+let g:base16_gui0B = "8bd49c"
+let g:base16_gui0C = "70e1e8"
+let g:base16_gui0D = "539afc"
+let g:base16_gui0E = "b62d65"
 let g:base16_gui0F = "dd9d82"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fbfbfd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-city-terminal-light.vim
+++ b/colors/base16-tokyo-city-terminal-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo City Terminal Light
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-city-terminal-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-city-terminal-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-city-terminal-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fbfbfd"
-let g:base16_gui00 = "fbfbfd"
+let g:tinted_gui00 = "fbfbfd"
 let s:gui01        = "f6f6f8"
-let g:base16_gui01 = "f6f6f8"
+let g:tinted_gui01 = "f6f6f8"
 let s:gui02        = "d8e2ec"
-let g:base16_gui02 = "d8e2ec"
+let g:tinted_gui02 = "d8e2ec"
 let s:gui03        = "b7c5d3"
-let g:base16_gui03 = "b7c5d3"
+let g:tinted_gui03 = "b7c5d3"
 let s:gui04        = "526270"
-let g:base16_gui04 = "526270"
+let g:tinted_gui04 = "526270"
 let s:gui05        = "28323a"
-let g:base16_gui05 = "28323a"
+let g:tinted_gui05 = "28323a"
 let s:gui06        = "1d252c"
-let g:base16_gui06 = "1d252c"
+let g:tinted_gui06 = "1d252c"
 let s:gui07        = "171d23"
-let g:base16_gui07 = "171d23"
+let g:tinted_gui07 = "171d23"
 let s:gui08        = "8c4351"
-let g:base16_gui08 = "8c4351"
+let g:tinted_gui08 = "8c4351"
 let s:gui09        = "965027"
-let g:base16_gui09 = "965027"
+let g:tinted_gui09 = "965027"
 let s:gui0A        = "8f5e15"
-let g:base16_gui0A = "8f5e15"
+let g:tinted_gui0A = "8f5e15"
 let s:gui0B        = "33635c"
-let g:base16_gui0B = "33635c"
+let g:tinted_gui0B = "33635c"
 let s:gui0C        = "0f4b6e"
-let g:base16_gui0C = "0f4b6e"
+let g:tinted_gui0C = "0f4b6e"
 let s:gui0D        = "34548a"
-let g:base16_gui0D = "34548a"
+let g:tinted_gui0D = "34548a"
 let s:gui0E        = "5a4a78"
-let g:base16_gui0E = "5a4a78"
+let g:tinted_gui0E = "5a4a78"
 let s:gui0F        = "7e5140"
+let g:tinted_gui0F = "7e5140"
+
+" Legacy
+let g:base16_gui00 = "fbfbfd"
+let g:base16_gui01 = "f6f6f8"
+let g:base16_gui02 = "d8e2ec"
+let g:base16_gui03 = "b7c5d3"
+let g:base16_gui04 = "526270"
+let g:base16_gui05 = "28323a"
+let g:base16_gui06 = "1d252c"
+let g:base16_gui07 = "171d23"
+let g:base16_gui08 = "8c4351"
+let g:base16_gui09 = "965027"
+let g:base16_gui0A = "8f5e15"
+let g:base16_gui0B = "33635c"
+let g:base16_gui0C = "0f4b6e"
+let g:base16_gui0D = "34548a"
+let g:base16_gui0E = "5a4a78"
 let g:base16_gui0F = "7e5140"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#171d23",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-dark.vim
+++ b/colors/base16-tokyo-night-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Dark
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1a1b26"
-let g:base16_gui00 = "1a1b26"
+let g:tinted_gui00 = "1a1b26"
 let s:gui01        = "16161e"
-let g:base16_gui01 = "16161e"
+let g:tinted_gui01 = "16161e"
 let s:gui02        = "2f3549"
-let g:base16_gui02 = "2f3549"
+let g:tinted_gui02 = "2f3549"
 let s:gui03        = "444b6a"
-let g:base16_gui03 = "444b6a"
+let g:tinted_gui03 = "444b6a"
 let s:gui04        = "787c99"
-let g:base16_gui04 = "787c99"
+let g:tinted_gui04 = "787c99"
 let s:gui05        = "a9b1d6"
-let g:base16_gui05 = "a9b1d6"
+let g:tinted_gui05 = "a9b1d6"
 let s:gui06        = "cbccd1"
-let g:base16_gui06 = "cbccd1"
+let g:tinted_gui06 = "cbccd1"
 let s:gui07        = "d5d6db"
-let g:base16_gui07 = "d5d6db"
+let g:tinted_gui07 = "d5d6db"
 let s:gui08        = "c0caf5"
-let g:base16_gui08 = "c0caf5"
+let g:tinted_gui08 = "c0caf5"
 let s:gui09        = "a9b1d6"
-let g:base16_gui09 = "a9b1d6"
+let g:tinted_gui09 = "a9b1d6"
 let s:gui0A        = "0db9d7"
-let g:base16_gui0A = "0db9d7"
+let g:tinted_gui0A = "0db9d7"
 let s:gui0B        = "9ece6a"
-let g:base16_gui0B = "9ece6a"
+let g:tinted_gui0B = "9ece6a"
 let s:gui0C        = "b4f9f8"
-let g:base16_gui0C = "b4f9f8"
+let g:tinted_gui0C = "b4f9f8"
 let s:gui0D        = "2ac3de"
-let g:base16_gui0D = "2ac3de"
+let g:tinted_gui0D = "2ac3de"
 let s:gui0E        = "bb9af7"
-let g:base16_gui0E = "bb9af7"
+let g:tinted_gui0E = "bb9af7"
 let s:gui0F        = "f7768e"
+let g:tinted_gui0F = "f7768e"
+
+" Legacy
+let g:base16_gui00 = "1a1b26"
+let g:base16_gui01 = "16161e"
+let g:base16_gui02 = "2f3549"
+let g:base16_gui03 = "444b6a"
+let g:base16_gui04 = "787c99"
+let g:base16_gui05 = "a9b1d6"
+let g:base16_gui06 = "cbccd1"
+let g:base16_gui07 = "d5d6db"
+let g:base16_gui08 = "c0caf5"
+let g:base16_gui09 = "a9b1d6"
+let g:base16_gui0A = "0db9d7"
+let g:base16_gui0B = "9ece6a"
+let g:base16_gui0C = "b4f9f8"
+let g:base16_gui0D = "2ac3de"
+let g:base16_gui0E = "bb9af7"
 let g:base16_gui0F = "f7768e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d5d6db",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-light.vim
+++ b/colors/base16-tokyo-night-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Light
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "d5d6db"
-let g:base16_gui00 = "d5d6db"
+let g:tinted_gui00 = "d5d6db"
 let s:gui01        = "cbccd1"
-let g:base16_gui01 = "cbccd1"
+let g:tinted_gui01 = "cbccd1"
 let s:gui02        = "dfe0e5"
-let g:base16_gui02 = "dfe0e5"
+let g:tinted_gui02 = "dfe0e5"
 let s:gui03        = "9699a3"
-let g:base16_gui03 = "9699a3"
+let g:tinted_gui03 = "9699a3"
 let s:gui04        = "4c505e"
-let g:base16_gui04 = "4c505e"
+let g:tinted_gui04 = "4c505e"
 let s:gui05        = "343b59"
-let g:base16_gui05 = "343b59"
+let g:tinted_gui05 = "343b59"
 let s:gui06        = "1a1b26"
-let g:base16_gui06 = "1a1b26"
+let g:tinted_gui06 = "1a1b26"
 let s:gui07        = "1a1b26"
-let g:base16_gui07 = "1a1b26"
+let g:tinted_gui07 = "1a1b26"
 let s:gui08        = "343b58"
-let g:base16_gui08 = "343b58"
+let g:tinted_gui08 = "343b58"
 let s:gui09        = "965027"
-let g:base16_gui09 = "965027"
+let g:tinted_gui09 = "965027"
 let s:gui0A        = "166775"
-let g:base16_gui0A = "166775"
+let g:tinted_gui0A = "166775"
 let s:gui0B        = "485e30"
-let g:base16_gui0B = "485e30"
+let g:tinted_gui0B = "485e30"
 let s:gui0C        = "3e6968"
-let g:base16_gui0C = "3e6968"
+let g:tinted_gui0C = "3e6968"
 let s:gui0D        = "34548a"
-let g:base16_gui0D = "34548a"
+let g:tinted_gui0D = "34548a"
 let s:gui0E        = "5a4a78"
-let g:base16_gui0E = "5a4a78"
+let g:tinted_gui0E = "5a4a78"
 let s:gui0F        = "8c4351"
+let g:tinted_gui0F = "8c4351"
+
+" Legacy
+let g:base16_gui00 = "d5d6db"
+let g:base16_gui01 = "cbccd1"
+let g:base16_gui02 = "dfe0e5"
+let g:base16_gui03 = "9699a3"
+let g:base16_gui04 = "4c505e"
+let g:base16_gui05 = "343b59"
+let g:base16_gui06 = "1a1b26"
+let g:base16_gui07 = "1a1b26"
+let g:base16_gui08 = "343b58"
+let g:base16_gui09 = "965027"
+let g:base16_gui0A = "166775"
+let g:base16_gui0B = "485e30"
+let g:base16_gui0C = "3e6968"
+let g:base16_gui0D = "34548a"
+let g:base16_gui0E = "5a4a78"
 let g:base16_gui0F = "8c4351"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1a1b26",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-moon.vim
+++ b/colors/base16-tokyo-night-moon.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Moon
 " Scheme author: Ólafur Bjarki Bogason
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-moon.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-moon.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-moon.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "222436"
-let g:base16_gui00 = "222436"
+let g:tinted_gui00 = "222436"
 let s:gui01        = "1e2030"
-let g:base16_gui01 = "1e2030"
+let g:tinted_gui01 = "1e2030"
 let s:gui02        = "2d3f76"
-let g:base16_gui02 = "2d3f76"
+let g:tinted_gui02 = "2d3f76"
 let s:gui03        = "636da6"
-let g:base16_gui03 = "636da6"
+let g:tinted_gui03 = "636da6"
 let s:gui04        = "828bb8"
-let g:base16_gui04 = "828bb8"
+let g:tinted_gui04 = "828bb8"
 let s:gui05        = "3b4261"
-let g:base16_gui05 = "3b4261"
+let g:tinted_gui05 = "3b4261"
 let s:gui06        = "828bb8"
-let g:base16_gui06 = "828bb8"
+let g:tinted_gui06 = "828bb8"
 let s:gui07        = "c8d3f5"
-let g:base16_gui07 = "c8d3f5"
+let g:tinted_gui07 = "c8d3f5"
 let s:gui08        = "ff757f"
-let g:base16_gui08 = "ff757f"
+let g:tinted_gui08 = "ff757f"
 let s:gui09        = "ffc777"
-let g:base16_gui09 = "ffc777"
+let g:tinted_gui09 = "ffc777"
 let s:gui0A        = "ffc777"
-let g:base16_gui0A = "ffc777"
+let g:tinted_gui0A = "ffc777"
 let s:gui0B        = "c3e88d"
-let g:base16_gui0B = "c3e88d"
+let g:tinted_gui0B = "c3e88d"
 let s:gui0C        = "86e1fc"
-let g:base16_gui0C = "86e1fc"
+let g:tinted_gui0C = "86e1fc"
 let s:gui0D        = "82aaff"
-let g:base16_gui0D = "82aaff"
+let g:tinted_gui0D = "82aaff"
 let s:gui0E        = "fca7ea"
-let g:base16_gui0E = "fca7ea"
+let g:tinted_gui0E = "fca7ea"
 let s:gui0F        = "c53b53"
+let g:tinted_gui0F = "c53b53"
+
+" Legacy
+let g:base16_gui00 = "222436"
+let g:base16_gui01 = "1e2030"
+let g:base16_gui02 = "2d3f76"
+let g:base16_gui03 = "636da6"
+let g:base16_gui04 = "828bb8"
+let g:base16_gui05 = "3b4261"
+let g:base16_gui06 = "828bb8"
+let g:base16_gui07 = "c8d3f5"
+let g:base16_gui08 = "ff757f"
+let g:base16_gui09 = "ffc777"
+let g:base16_gui0A = "ffc777"
+let g:base16_gui0B = "c3e88d"
+let g:base16_gui0C = "86e1fc"
+let g:base16_gui0D = "82aaff"
+let g:base16_gui0E = "fca7ea"
 let g:base16_gui0F = "c53b53"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#c8d3f5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-storm.vim
+++ b/colors/base16-tokyo-night-storm.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Storm
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-storm.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-storm.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-storm.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "24283b"
-let g:base16_gui00 = "24283b"
+let g:tinted_gui00 = "24283b"
 let s:gui01        = "16161e"
-let g:base16_gui01 = "16161e"
+let g:tinted_gui01 = "16161e"
 let s:gui02        = "343a52"
-let g:base16_gui02 = "343a52"
+let g:tinted_gui02 = "343a52"
 let s:gui03        = "444b6a"
-let g:base16_gui03 = "444b6a"
+let g:tinted_gui03 = "444b6a"
 let s:gui04        = "787c99"
-let g:base16_gui04 = "787c99"
+let g:tinted_gui04 = "787c99"
 let s:gui05        = "a9b1d6"
-let g:base16_gui05 = "a9b1d6"
+let g:tinted_gui05 = "a9b1d6"
 let s:gui06        = "cbccd1"
-let g:base16_gui06 = "cbccd1"
+let g:tinted_gui06 = "cbccd1"
 let s:gui07        = "d5d6db"
-let g:base16_gui07 = "d5d6db"
+let g:tinted_gui07 = "d5d6db"
 let s:gui08        = "c0caf5"
-let g:base16_gui08 = "c0caf5"
+let g:tinted_gui08 = "c0caf5"
 let s:gui09        = "a9b1d6"
-let g:base16_gui09 = "a9b1d6"
+let g:tinted_gui09 = "a9b1d6"
 let s:gui0A        = "0db9d7"
-let g:base16_gui0A = "0db9d7"
+let g:tinted_gui0A = "0db9d7"
 let s:gui0B        = "9ece6a"
-let g:base16_gui0B = "9ece6a"
+let g:tinted_gui0B = "9ece6a"
 let s:gui0C        = "b4f9f8"
-let g:base16_gui0C = "b4f9f8"
+let g:tinted_gui0C = "b4f9f8"
 let s:gui0D        = "2ac3de"
-let g:base16_gui0D = "2ac3de"
+let g:tinted_gui0D = "2ac3de"
 let s:gui0E        = "bb9af7"
-let g:base16_gui0E = "bb9af7"
+let g:tinted_gui0E = "bb9af7"
 let s:gui0F        = "f7768e"
+let g:tinted_gui0F = "f7768e"
+
+" Legacy
+let g:base16_gui00 = "24283b"
+let g:base16_gui01 = "16161e"
+let g:base16_gui02 = "343a52"
+let g:base16_gui03 = "444b6a"
+let g:base16_gui04 = "787c99"
+let g:base16_gui05 = "a9b1d6"
+let g:base16_gui06 = "cbccd1"
+let g:base16_gui07 = "d5d6db"
+let g:base16_gui08 = "c0caf5"
+let g:base16_gui09 = "a9b1d6"
+let g:base16_gui0A = "0db9d7"
+let g:base16_gui0B = "9ece6a"
+let g:base16_gui0C = "b4f9f8"
+let g:base16_gui0D = "2ac3de"
+let g:base16_gui0E = "bb9af7"
 let g:base16_gui0F = "f7768e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d5d6db",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-terminal-dark.vim
+++ b/colors/base16-tokyo-night-terminal-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Terminal Dark
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-terminal-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-terminal-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-terminal-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "16161e"
-let g:base16_gui00 = "16161e"
+let g:tinted_gui00 = "16161e"
 let s:gui01        = "1a1b26"
-let g:base16_gui01 = "1a1b26"
+let g:tinted_gui01 = "1a1b26"
 let s:gui02        = "2f3549"
-let g:base16_gui02 = "2f3549"
+let g:tinted_gui02 = "2f3549"
 let s:gui03        = "444b6a"
-let g:base16_gui03 = "444b6a"
+let g:tinted_gui03 = "444b6a"
 let s:gui04        = "787c99"
-let g:base16_gui04 = "787c99"
+let g:tinted_gui04 = "787c99"
 let s:gui05        = "787c99"
-let g:base16_gui05 = "787c99"
+let g:tinted_gui05 = "787c99"
 let s:gui06        = "cbccd1"
-let g:base16_gui06 = "cbccd1"
+let g:tinted_gui06 = "cbccd1"
 let s:gui07        = "d5d6db"
-let g:base16_gui07 = "d5d6db"
+let g:tinted_gui07 = "d5d6db"
 let s:gui08        = "f7768e"
-let g:base16_gui08 = "f7768e"
+let g:tinted_gui08 = "f7768e"
 let s:gui09        = "ff9e64"
-let g:base16_gui09 = "ff9e64"
+let g:tinted_gui09 = "ff9e64"
 let s:gui0A        = "e0af68"
-let g:base16_gui0A = "e0af68"
+let g:tinted_gui0A = "e0af68"
 let s:gui0B        = "41a6b5"
-let g:base16_gui0B = "41a6b5"
+let g:tinted_gui0B = "41a6b5"
 let s:gui0C        = "7dcfff"
-let g:base16_gui0C = "7dcfff"
+let g:tinted_gui0C = "7dcfff"
 let s:gui0D        = "7aa2f7"
-let g:base16_gui0D = "7aa2f7"
+let g:tinted_gui0D = "7aa2f7"
 let s:gui0E        = "bb9af7"
-let g:base16_gui0E = "bb9af7"
+let g:tinted_gui0E = "bb9af7"
 let s:gui0F        = "d18616"
+let g:tinted_gui0F = "d18616"
+
+" Legacy
+let g:base16_gui00 = "16161e"
+let g:base16_gui01 = "1a1b26"
+let g:base16_gui02 = "2f3549"
+let g:base16_gui03 = "444b6a"
+let g:base16_gui04 = "787c99"
+let g:base16_gui05 = "787c99"
+let g:base16_gui06 = "cbccd1"
+let g:base16_gui07 = "d5d6db"
+let g:base16_gui08 = "f7768e"
+let g:base16_gui09 = "ff9e64"
+let g:base16_gui0A = "e0af68"
+let g:base16_gui0B = "41a6b5"
+let g:base16_gui0C = "7dcfff"
+let g:base16_gui0D = "7aa2f7"
+let g:base16_gui0E = "bb9af7"
 let g:base16_gui0F = "d18616"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d5d6db",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-terminal-light.vim
+++ b/colors/base16-tokyo-night-terminal-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Terminal Light
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-terminal-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-terminal-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-terminal-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "d5d6db"
-let g:base16_gui00 = "d5d6db"
+let g:tinted_gui00 = "d5d6db"
 let s:gui01        = "cbccd1"
-let g:base16_gui01 = "cbccd1"
+let g:tinted_gui01 = "cbccd1"
 let s:gui02        = "dfe0e5"
-let g:base16_gui02 = "dfe0e5"
+let g:tinted_gui02 = "dfe0e5"
 let s:gui03        = "9699a3"
-let g:base16_gui03 = "9699a3"
+let g:tinted_gui03 = "9699a3"
 let s:gui04        = "4c505e"
-let g:base16_gui04 = "4c505e"
+let g:tinted_gui04 = "4c505e"
 let s:gui05        = "4c505e"
-let g:base16_gui05 = "4c505e"
+let g:tinted_gui05 = "4c505e"
 let s:gui06        = "1a1b26"
-let g:base16_gui06 = "1a1b26"
+let g:tinted_gui06 = "1a1b26"
 let s:gui07        = "1a1b26"
-let g:base16_gui07 = "1a1b26"
+let g:tinted_gui07 = "1a1b26"
 let s:gui08        = "8c4351"
-let g:base16_gui08 = "8c4351"
+let g:tinted_gui08 = "8c4351"
 let s:gui09        = "965027"
-let g:base16_gui09 = "965027"
+let g:tinted_gui09 = "965027"
 let s:gui0A        = "8f5e15"
-let g:base16_gui0A = "8f5e15"
+let g:tinted_gui0A = "8f5e15"
 let s:gui0B        = "33635c"
-let g:base16_gui0B = "33635c"
+let g:tinted_gui0B = "33635c"
 let s:gui0C        = "0f4b6e"
-let g:base16_gui0C = "0f4b6e"
+let g:tinted_gui0C = "0f4b6e"
 let s:gui0D        = "34548a"
-let g:base16_gui0D = "34548a"
+let g:tinted_gui0D = "34548a"
 let s:gui0E        = "5a4a78"
-let g:base16_gui0E = "5a4a78"
+let g:tinted_gui0E = "5a4a78"
 let s:gui0F        = "655259"
+let g:tinted_gui0F = "655259"
+
+" Legacy
+let g:base16_gui00 = "d5d6db"
+let g:base16_gui01 = "cbccd1"
+let g:base16_gui02 = "dfe0e5"
+let g:base16_gui03 = "9699a3"
+let g:base16_gui04 = "4c505e"
+let g:base16_gui05 = "4c505e"
+let g:base16_gui06 = "1a1b26"
+let g:base16_gui07 = "1a1b26"
+let g:base16_gui08 = "8c4351"
+let g:base16_gui09 = "965027"
+let g:base16_gui0A = "8f5e15"
+let g:base16_gui0B = "33635c"
+let g:base16_gui0C = "0f4b6e"
+let g:base16_gui0D = "34548a"
+let g:base16_gui0E = "5a4a78"
 let g:base16_gui0F = "655259"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1a1b26",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyo-night-terminal-storm.vim
+++ b/colors/base16-tokyo-night-terminal-storm.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyo Night Terminal Storm
 " Scheme author: Michaël Ball
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyo-night-terminal-storm.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyo-night-terminal-storm.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyo-night-terminal-storm.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "24283b"
-let g:base16_gui00 = "24283b"
+let g:tinted_gui00 = "24283b"
 let s:gui01        = "1a1b26"
-let g:base16_gui01 = "1a1b26"
+let g:tinted_gui01 = "1a1b26"
 let s:gui02        = "343a52"
-let g:base16_gui02 = "343a52"
+let g:tinted_gui02 = "343a52"
 let s:gui03        = "444b6a"
-let g:base16_gui03 = "444b6a"
+let g:tinted_gui03 = "444b6a"
 let s:gui04        = "787c99"
-let g:base16_gui04 = "787c99"
+let g:tinted_gui04 = "787c99"
 let s:gui05        = "787c99"
-let g:base16_gui05 = "787c99"
+let g:tinted_gui05 = "787c99"
 let s:gui06        = "cbccd1"
-let g:base16_gui06 = "cbccd1"
+let g:tinted_gui06 = "cbccd1"
 let s:gui07        = "d5d6db"
-let g:base16_gui07 = "d5d6db"
+let g:tinted_gui07 = "d5d6db"
 let s:gui08        = "f7768e"
-let g:base16_gui08 = "f7768e"
+let g:tinted_gui08 = "f7768e"
 let s:gui09        = "ff9e64"
-let g:base16_gui09 = "ff9e64"
+let g:tinted_gui09 = "ff9e64"
 let s:gui0A        = "e0af68"
-let g:base16_gui0A = "e0af68"
+let g:tinted_gui0A = "e0af68"
 let s:gui0B        = "41a6b5"
-let g:base16_gui0B = "41a6b5"
+let g:tinted_gui0B = "41a6b5"
 let s:gui0C        = "7dcfff"
-let g:base16_gui0C = "7dcfff"
+let g:tinted_gui0C = "7dcfff"
 let s:gui0D        = "7aa2f7"
-let g:base16_gui0D = "7aa2f7"
+let g:tinted_gui0D = "7aa2f7"
 let s:gui0E        = "bb9af7"
-let g:base16_gui0E = "bb9af7"
+let g:tinted_gui0E = "bb9af7"
 let s:gui0F        = "d18616"
+let g:tinted_gui0F = "d18616"
+
+" Legacy
+let g:base16_gui00 = "24283b"
+let g:base16_gui01 = "1a1b26"
+let g:base16_gui02 = "343a52"
+let g:base16_gui03 = "444b6a"
+let g:base16_gui04 = "787c99"
+let g:base16_gui05 = "787c99"
+let g:base16_gui06 = "cbccd1"
+let g:base16_gui07 = "d5d6db"
+let g:base16_gui08 = "f7768e"
+let g:base16_gui09 = "ff9e64"
+let g:base16_gui0A = "e0af68"
+let g:base16_gui0B = "41a6b5"
+let g:base16_gui0C = "7dcfff"
+let g:base16_gui0D = "7aa2f7"
+let g:base16_gui0E = "bb9af7"
 let g:base16_gui0F = "d18616"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d5d6db",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyodark-terminal.vim
+++ b/colors/base16-tokyodark-terminal.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyodark Terminal
 " Scheme author: Tiagovla (https://github.com/tiagovla/)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyodark-terminal.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyodark-terminal.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyodark-terminal.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "11121d"
-let g:base16_gui00 = "11121d"
+let g:tinted_gui00 = "11121d"
 let s:gui01        = "1a1b2a"
-let g:base16_gui01 = "1a1b2a"
+let g:tinted_gui01 = "1a1b2a"
 let s:gui02        = "212234"
-let g:base16_gui02 = "212234"
+let g:tinted_gui02 = "212234"
 let s:gui03        = "282c34"
-let g:base16_gui03 = "282c34"
+let g:tinted_gui03 = "282c34"
 let s:gui04        = "4a5057"
-let g:base16_gui04 = "4a5057"
+let g:tinted_gui04 = "4a5057"
 let s:gui05        = "a0a8cd"
-let g:base16_gui05 = "a0a8cd"
+let g:tinted_gui05 = "a0a8cd"
 let s:gui06        = "a0a8cd"
-let g:base16_gui06 = "a0a8cd"
+let g:tinted_gui06 = "a0a8cd"
 let s:gui07        = "a0a8cd"
-let g:base16_gui07 = "a0a8cd"
+let g:tinted_gui07 = "a0a8cd"
 let s:gui08        = "ee6d85"
-let g:base16_gui08 = "ee6d85"
+let g:tinted_gui08 = "ee6d85"
 let s:gui09        = "f6955b"
-let g:base16_gui09 = "f6955b"
+let g:tinted_gui09 = "f6955b"
 let s:gui0A        = "d7a65f"
-let g:base16_gui0A = "d7a65f"
+let g:tinted_gui0A = "d7a65f"
 let s:gui0B        = "95c561"
-let g:base16_gui0B = "95c561"
+let g:tinted_gui0B = "95c561"
 let s:gui0C        = "38a89d"
-let g:base16_gui0C = "38a89d"
+let g:tinted_gui0C = "38a89d"
 let s:gui0D        = "7199ee"
-let g:base16_gui0D = "7199ee"
+let g:tinted_gui0D = "7199ee"
 let s:gui0E        = "a485dd"
-let g:base16_gui0E = "a485dd"
+let g:tinted_gui0E = "a485dd"
 let s:gui0F        = "773440"
+let g:tinted_gui0F = "773440"
+
+" Legacy
+let g:base16_gui00 = "11121d"
+let g:base16_gui01 = "1a1b2a"
+let g:base16_gui02 = "212234"
+let g:base16_gui03 = "282c34"
+let g:base16_gui04 = "4a5057"
+let g:base16_gui05 = "a0a8cd"
+let g:base16_gui06 = "a0a8cd"
+let g:base16_gui07 = "a0a8cd"
+let g:base16_gui08 = "ee6d85"
+let g:base16_gui09 = "f6955b"
+let g:base16_gui0A = "d7a65f"
+let g:base16_gui0B = "95c561"
+let g:base16_gui0C = "38a89d"
+let g:base16_gui0D = "7199ee"
+let g:base16_gui0E = "a485dd"
 let g:base16_gui0F = "773440"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#a0a8cd",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tokyodark.vim
+++ b/colors/base16-tokyodark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tokyodark
 " Scheme author: Jamy Golden (https://github.com/JamyGolden), Based on Tokyodark.nvim (https://github.com/tiagovla/tokyodark.nvim)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tokyodark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tokyodark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tokyodark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "11121d"
-let g:base16_gui00 = "11121d"
+let g:tinted_gui00 = "11121d"
 let s:gui01        = "212234"
-let g:base16_gui01 = "212234"
+let g:tinted_gui01 = "212234"
 let s:gui02        = "212234"
-let g:base16_gui02 = "212234"
+let g:tinted_gui02 = "212234"
 let s:gui03        = "353945"
-let g:base16_gui03 = "353945"
+let g:tinted_gui03 = "353945"
 let s:gui04        = "4a5057"
-let g:base16_gui04 = "4a5057"
+let g:tinted_gui04 = "4a5057"
 let s:gui05        = "a0a8cd"
-let g:base16_gui05 = "a0a8cd"
+let g:tinted_gui05 = "a0a8cd"
 let s:gui06        = "abb2bf"
-let g:base16_gui06 = "abb2bf"
+let g:tinted_gui06 = "abb2bf"
 let s:gui07        = "bcc2dc"
-let g:base16_gui07 = "bcc2dc"
+let g:tinted_gui07 = "bcc2dc"
 let s:gui08        = "ee6d85"
-let g:base16_gui08 = "ee6d85"
+let g:tinted_gui08 = "ee6d85"
 let s:gui09        = "f6955b"
-let g:base16_gui09 = "f6955b"
+let g:tinted_gui09 = "f6955b"
 let s:gui0A        = "d7a65f"
-let g:base16_gui0A = "d7a65f"
+let g:tinted_gui0A = "d7a65f"
 let s:gui0B        = "95c561"
-let g:base16_gui0B = "95c561"
+let g:tinted_gui0B = "95c561"
 let s:gui0C        = "9fbbf3"
-let g:base16_gui0C = "9fbbf3"
+let g:tinted_gui0C = "9fbbf3"
 let s:gui0D        = "7199ee"
-let g:base16_gui0D = "7199ee"
+let g:tinted_gui0D = "7199ee"
 let s:gui0E        = "a485dd"
-let g:base16_gui0E = "a485dd"
+let g:tinted_gui0E = "a485dd"
 let s:gui0F        = "773440"
+let g:tinted_gui0F = "773440"
+
+" Legacy
+let g:base16_gui00 = "11121d"
+let g:base16_gui01 = "212234"
+let g:base16_gui02 = "212234"
+let g:base16_gui03 = "353945"
+let g:base16_gui04 = "4a5057"
+let g:base16_gui05 = "a0a8cd"
+let g:base16_gui06 = "abb2bf"
+let g:base16_gui07 = "bcc2dc"
+let g:base16_gui08 = "ee6d85"
+let g:base16_gui09 = "f6955b"
+let g:base16_gui0A = "d7a65f"
+let g:base16_gui0B = "95c561"
+let g:base16_gui0C = "9fbbf3"
+let g:base16_gui0D = "7199ee"
+let g:base16_gui0E = "a485dd"
 let g:base16_gui0F = "773440"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#bcc2dc",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tomorrow Night Eighties
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tomorrow-night-eighties.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tomorrow-night-eighties.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tomorrow-night-eighties.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2d2d2d"
-let g:base16_gui00 = "2d2d2d"
+let g:tinted_gui00 = "2d2d2d"
 let s:gui01        = "393939"
-let g:base16_gui01 = "393939"
+let g:tinted_gui01 = "393939"
 let s:gui02        = "515151"
-let g:base16_gui02 = "515151"
+let g:tinted_gui02 = "515151"
 let s:gui03        = "999999"
-let g:base16_gui03 = "999999"
+let g:tinted_gui03 = "999999"
 let s:gui04        = "b4b7b4"
-let g:base16_gui04 = "b4b7b4"
+let g:tinted_gui04 = "b4b7b4"
 let s:gui05        = "cccccc"
-let g:base16_gui05 = "cccccc"
+let g:tinted_gui05 = "cccccc"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "f2777a"
-let g:base16_gui08 = "f2777a"
+let g:tinted_gui08 = "f2777a"
 let s:gui09        = "f99157"
-let g:base16_gui09 = "f99157"
+let g:tinted_gui09 = "f99157"
 let s:gui0A        = "ffcc66"
-let g:base16_gui0A = "ffcc66"
+let g:tinted_gui0A = "ffcc66"
 let s:gui0B        = "99cc99"
-let g:base16_gui0B = "99cc99"
+let g:tinted_gui0B = "99cc99"
 let s:gui0C        = "66cccc"
-let g:base16_gui0C = "66cccc"
+let g:tinted_gui0C = "66cccc"
 let s:gui0D        = "6699cc"
-let g:base16_gui0D = "6699cc"
+let g:tinted_gui0D = "6699cc"
 let s:gui0E        = "cc99cc"
-let g:base16_gui0E = "cc99cc"
+let g:tinted_gui0E = "cc99cc"
 let s:gui0F        = "a3685a"
+let g:tinted_gui0F = "a3685a"
+
+" Legacy
+let g:base16_gui00 = "2d2d2d"
+let g:base16_gui01 = "393939"
+let g:base16_gui02 = "515151"
+let g:base16_gui03 = "999999"
+let g:base16_gui04 = "b4b7b4"
+let g:base16_gui05 = "cccccc"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "f2777a"
+let g:base16_gui09 = "f99157"
+let g:base16_gui0A = "ffcc66"
+let g:base16_gui0B = "99cc99"
+let g:base16_gui0C = "66cccc"
+let g:base16_gui0D = "6699cc"
+let g:base16_gui0E = "cc99cc"
 let g:base16_gui0F = "a3685a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tomorrow Night
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tomorrow-night.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tomorrow-night.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tomorrow-night.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1d1f21"
-let g:base16_gui00 = "1d1f21"
+let g:tinted_gui00 = "1d1f21"
 let s:gui01        = "282a2e"
-let g:base16_gui01 = "282a2e"
+let g:tinted_gui01 = "282a2e"
 let s:gui02        = "373b41"
-let g:base16_gui02 = "373b41"
+let g:tinted_gui02 = "373b41"
 let s:gui03        = "969896"
-let g:base16_gui03 = "969896"
+let g:tinted_gui03 = "969896"
 let s:gui04        = "b4b7b4"
-let g:base16_gui04 = "b4b7b4"
+let g:tinted_gui04 = "b4b7b4"
 let s:gui05        = "c5c8c6"
-let g:base16_gui05 = "c5c8c6"
+let g:tinted_gui05 = "c5c8c6"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "cc6666"
-let g:base16_gui08 = "cc6666"
+let g:tinted_gui08 = "cc6666"
 let s:gui09        = "de935f"
-let g:base16_gui09 = "de935f"
+let g:tinted_gui09 = "de935f"
 let s:gui0A        = "f0c674"
-let g:base16_gui0A = "f0c674"
+let g:tinted_gui0A = "f0c674"
 let s:gui0B        = "b5bd68"
-let g:base16_gui0B = "b5bd68"
+let g:tinted_gui0B = "b5bd68"
 let s:gui0C        = "8abeb7"
-let g:base16_gui0C = "8abeb7"
+let g:tinted_gui0C = "8abeb7"
 let s:gui0D        = "81a2be"
-let g:base16_gui0D = "81a2be"
+let g:tinted_gui0D = "81a2be"
 let s:gui0E        = "b294bb"
-let g:base16_gui0E = "b294bb"
+let g:tinted_gui0E = "b294bb"
 let s:gui0F        = "a3685a"
+let g:tinted_gui0F = "a3685a"
+
+" Legacy
+let g:base16_gui00 = "1d1f21"
+let g:base16_gui01 = "282a2e"
+let g:base16_gui02 = "373b41"
+let g:base16_gui03 = "969896"
+let g:base16_gui04 = "b4b7b4"
+let g:base16_gui05 = "c5c8c6"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "cc6666"
+let g:base16_gui09 = "de935f"
+let g:base16_gui0A = "f0c674"
+let g:base16_gui0B = "b5bd68"
+let g:base16_gui0C = "8abeb7"
+let g:base16_gui0D = "81a2be"
+let g:base16_gui0E = "b294bb"
 let g:base16_gui0F = "a3685a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Tomorrow
 " Scheme author: Chris Kempson (http://chriskempson.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tomorrow.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tomorrow.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tomorrow.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "e0e0e0"
-let g:base16_gui01 = "e0e0e0"
+let g:tinted_gui01 = "e0e0e0"
 let s:gui02        = "d6d6d6"
-let g:base16_gui02 = "d6d6d6"
+let g:tinted_gui02 = "d6d6d6"
 let s:gui03        = "8e908c"
-let g:base16_gui03 = "8e908c"
+let g:tinted_gui03 = "8e908c"
 let s:gui04        = "969896"
-let g:base16_gui04 = "969896"
+let g:tinted_gui04 = "969896"
 let s:gui05        = "4d4d4c"
-let g:base16_gui05 = "4d4d4c"
+let g:tinted_gui05 = "4d4d4c"
 let s:gui06        = "282a2e"
-let g:base16_gui06 = "282a2e"
+let g:tinted_gui06 = "282a2e"
 let s:gui07        = "1d1f21"
-let g:base16_gui07 = "1d1f21"
+let g:tinted_gui07 = "1d1f21"
 let s:gui08        = "c82829"
-let g:base16_gui08 = "c82829"
+let g:tinted_gui08 = "c82829"
 let s:gui09        = "f5871f"
-let g:base16_gui09 = "f5871f"
+let g:tinted_gui09 = "f5871f"
 let s:gui0A        = "eab700"
-let g:base16_gui0A = "eab700"
+let g:tinted_gui0A = "eab700"
 let s:gui0B        = "718c00"
-let g:base16_gui0B = "718c00"
+let g:tinted_gui0B = "718c00"
 let s:gui0C        = "3e999f"
-let g:base16_gui0C = "3e999f"
+let g:tinted_gui0C = "3e999f"
 let s:gui0D        = "4271ae"
-let g:base16_gui0D = "4271ae"
+let g:tinted_gui0D = "4271ae"
 let s:gui0E        = "8959a8"
-let g:base16_gui0E = "8959a8"
+let g:tinted_gui0E = "8959a8"
 let s:gui0F        = "a3685a"
+let g:tinted_gui0F = "a3685a"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "e0e0e0"
+let g:base16_gui02 = "d6d6d6"
+let g:base16_gui03 = "8e908c"
+let g:base16_gui04 = "969896"
+let g:base16_gui05 = "4d4d4c"
+let g:base16_gui06 = "282a2e"
+let g:base16_gui07 = "1d1f21"
+let g:base16_gui08 = "c82829"
+let g:base16_gui09 = "f5871f"
+let g:base16_gui0A = "eab700"
+let g:base16_gui0B = "718c00"
+let g:base16_gui0C = "3e999f"
+let g:base16_gui0D = "4271ae"
+let g:base16_gui0E = "8959a8"
 let g:base16_gui0F = "a3685a"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#1d1f21",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: London Tube
 " Scheme author: Jan T. Sott
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-tube.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/tube.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/tube.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "231f20"
-let g:base16_gui00 = "231f20"
+let g:tinted_gui00 = "231f20"
 let s:gui01        = "1c3f95"
-let g:base16_gui01 = "1c3f95"
+let g:tinted_gui01 = "1c3f95"
 let s:gui02        = "5a5758"
-let g:base16_gui02 = "5a5758"
+let g:tinted_gui02 = "5a5758"
 let s:gui03        = "737171"
-let g:base16_gui03 = "737171"
+let g:tinted_gui03 = "737171"
 let s:gui04        = "959ca1"
-let g:base16_gui04 = "959ca1"
+let g:tinted_gui04 = "959ca1"
 let s:gui05        = "d9d8d8"
-let g:base16_gui05 = "d9d8d8"
+let g:tinted_gui05 = "d9d8d8"
 let s:gui06        = "e7e7e8"
-let g:base16_gui06 = "e7e7e8"
+let g:tinted_gui06 = "e7e7e8"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ee2e24"
-let g:base16_gui08 = "ee2e24"
+let g:tinted_gui08 = "ee2e24"
 let s:gui09        = "f386a1"
-let g:base16_gui09 = "f386a1"
+let g:tinted_gui09 = "f386a1"
 let s:gui0A        = "ffd204"
-let g:base16_gui0A = "ffd204"
+let g:tinted_gui0A = "ffd204"
 let s:gui0B        = "00853e"
-let g:base16_gui0B = "00853e"
+let g:tinted_gui0B = "00853e"
 let s:gui0C        = "85cebc"
-let g:base16_gui0C = "85cebc"
+let g:tinted_gui0C = "85cebc"
 let s:gui0D        = "009ddc"
-let g:base16_gui0D = "009ddc"
+let g:tinted_gui0D = "009ddc"
 let s:gui0E        = "98005d"
-let g:base16_gui0E = "98005d"
+let g:tinted_gui0E = "98005d"
 let s:gui0F        = "b06110"
+let g:tinted_gui0F = "b06110"
+
+" Legacy
+let g:base16_gui00 = "231f20"
+let g:base16_gui01 = "1c3f95"
+let g:base16_gui02 = "5a5758"
+let g:base16_gui03 = "737171"
+let g:base16_gui04 = "959ca1"
+let g:base16_gui05 = "d9d8d8"
+let g:base16_gui06 = "e7e7e8"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ee2e24"
+let g:base16_gui09 = "f386a1"
+let g:base16_gui0A = "ffd204"
+let g:base16_gui0B = "00853e"
+let g:base16_gui0C = "85cebc"
+let g:base16_gui0D = "009ddc"
+let g:base16_gui0E = "98005d"
 let g:base16_gui0F = "b06110"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Twilight
 " Scheme author: David Hart (https://github.com/hartbit)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-twilight.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/twilight.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/twilight.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "1e1e1e"
-let g:base16_gui00 = "1e1e1e"
+let g:tinted_gui00 = "1e1e1e"
 let s:gui01        = "323537"
-let g:base16_gui01 = "323537"
+let g:tinted_gui01 = "323537"
 let s:gui02        = "464b50"
-let g:base16_gui02 = "464b50"
+let g:tinted_gui02 = "464b50"
 let s:gui03        = "5f5a60"
-let g:base16_gui03 = "5f5a60"
+let g:tinted_gui03 = "5f5a60"
 let s:gui04        = "838184"
-let g:base16_gui04 = "838184"
+let g:tinted_gui04 = "838184"
 let s:gui05        = "a7a7a7"
-let g:base16_gui05 = "a7a7a7"
+let g:tinted_gui05 = "a7a7a7"
 let s:gui06        = "c3c3c3"
-let g:base16_gui06 = "c3c3c3"
+let g:tinted_gui06 = "c3c3c3"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "cf6a4c"
-let g:base16_gui08 = "cf6a4c"
+let g:tinted_gui08 = "cf6a4c"
 let s:gui09        = "cda869"
-let g:base16_gui09 = "cda869"
+let g:tinted_gui09 = "cda869"
 let s:gui0A        = "f9ee98"
-let g:base16_gui0A = "f9ee98"
+let g:tinted_gui0A = "f9ee98"
 let s:gui0B        = "8f9d6a"
-let g:base16_gui0B = "8f9d6a"
+let g:tinted_gui0B = "8f9d6a"
 let s:gui0C        = "afc4db"
-let g:base16_gui0C = "afc4db"
+let g:tinted_gui0C = "afc4db"
 let s:gui0D        = "7587a6"
-let g:base16_gui0D = "7587a6"
+let g:tinted_gui0D = "7587a6"
 let s:gui0E        = "9b859d"
-let g:base16_gui0E = "9b859d"
+let g:tinted_gui0E = "9b859d"
 let s:gui0F        = "9b703f"
+let g:tinted_gui0F = "9b703f"
+
+" Legacy
+let g:base16_gui00 = "1e1e1e"
+let g:base16_gui01 = "323537"
+let g:base16_gui02 = "464b50"
+let g:base16_gui03 = "5f5a60"
+let g:base16_gui04 = "838184"
+let g:base16_gui05 = "a7a7a7"
+let g:base16_gui06 = "c3c3c3"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "cf6a4c"
+let g:base16_gui09 = "cda869"
+let g:base16_gui0A = "f9ee98"
+let g:base16_gui0B = "8f9d6a"
+let g:base16_gui0C = "afc4db"
+let g:base16_gui0D = "7587a6"
+let g:base16_gui0E = "9b859d"
 let g:base16_gui0F = "9b703f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Unikitty Dark
 " Scheme author: Josh W Lewis (@joshwlewis)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-unikitty-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/unikitty-dark.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/unikitty-dark.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2e2a31"
-let g:base16_gui00 = "2e2a31"
+let g:tinted_gui00 = "2e2a31"
 let s:gui01        = "4a464d"
-let g:base16_gui01 = "4a464d"
+let g:tinted_gui01 = "4a464d"
 let s:gui02        = "666369"
-let g:base16_gui02 = "666369"
+let g:tinted_gui02 = "666369"
 let s:gui03        = "838085"
-let g:base16_gui03 = "838085"
+let g:tinted_gui03 = "838085"
 let s:gui04        = "9f9da2"
-let g:base16_gui04 = "9f9da2"
+let g:tinted_gui04 = "9f9da2"
 let s:gui05        = "bcbabe"
-let g:base16_gui05 = "bcbabe"
+let g:tinted_gui05 = "bcbabe"
 let s:gui06        = "d8d7da"
-let g:base16_gui06 = "d8d7da"
+let g:tinted_gui06 = "d8d7da"
 let s:gui07        = "f5f4f7"
-let g:base16_gui07 = "f5f4f7"
+let g:tinted_gui07 = "f5f4f7"
 let s:gui08        = "d8137f"
-let g:base16_gui08 = "d8137f"
+let g:tinted_gui08 = "d8137f"
 let s:gui09        = "d65407"
-let g:base16_gui09 = "d65407"
+let g:tinted_gui09 = "d65407"
 let s:gui0A        = "dc8a0e"
-let g:base16_gui0A = "dc8a0e"
+let g:tinted_gui0A = "dc8a0e"
 let s:gui0B        = "17ad98"
-let g:base16_gui0B = "17ad98"
+let g:tinted_gui0B = "17ad98"
 let s:gui0C        = "149bda"
-let g:base16_gui0C = "149bda"
+let g:tinted_gui0C = "149bda"
 let s:gui0D        = "796af5"
-let g:base16_gui0D = "796af5"
+let g:tinted_gui0D = "796af5"
 let s:gui0E        = "bb60ea"
-let g:base16_gui0E = "bb60ea"
+let g:tinted_gui0E = "bb60ea"
 let s:gui0F        = "c720ca"
+let g:tinted_gui0F = "c720ca"
+
+" Legacy
+let g:base16_gui00 = "2e2a31"
+let g:base16_gui01 = "4a464d"
+let g:base16_gui02 = "666369"
+let g:base16_gui03 = "838085"
+let g:base16_gui04 = "9f9da2"
+let g:base16_gui05 = "bcbabe"
+let g:base16_gui06 = "d8d7da"
+let g:base16_gui07 = "f5f4f7"
+let g:base16_gui08 = "d8137f"
+let g:base16_gui09 = "d65407"
+let g:base16_gui0A = "dc8a0e"
+let g:base16_gui0B = "17ad98"
+let g:base16_gui0C = "149bda"
+let g:base16_gui0D = "796af5"
+let g:base16_gui0E = "bb60ea"
 let g:base16_gui0F = "c720ca"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f5f4f7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Unikitty Light
 " Scheme author: Josh W Lewis (@joshwlewis)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-unikitty-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/unikitty-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/unikitty-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "e1e1e2"
-let g:base16_gui01 = "e1e1e2"
+let g:tinted_gui01 = "e1e1e2"
 let s:gui02        = "c4c3c5"
-let g:base16_gui02 = "c4c3c5"
+let g:tinted_gui02 = "c4c3c5"
 let s:gui03        = "a7a5a8"
-let g:base16_gui03 = "a7a5a8"
+let g:tinted_gui03 = "a7a5a8"
 let s:gui04        = "89878b"
-let g:base16_gui04 = "89878b"
+let g:tinted_gui04 = "89878b"
 let s:gui05        = "6c696e"
-let g:base16_gui05 = "6c696e"
+let g:tinted_gui05 = "6c696e"
 let s:gui06        = "4f4b51"
-let g:base16_gui06 = "4f4b51"
+let g:tinted_gui06 = "4f4b51"
 let s:gui07        = "322d34"
-let g:base16_gui07 = "322d34"
+let g:tinted_gui07 = "322d34"
 let s:gui08        = "d8137f"
-let g:base16_gui08 = "d8137f"
+let g:tinted_gui08 = "d8137f"
 let s:gui09        = "d65407"
-let g:base16_gui09 = "d65407"
+let g:tinted_gui09 = "d65407"
 let s:gui0A        = "dc8a0e"
-let g:base16_gui0A = "dc8a0e"
+let g:tinted_gui0A = "dc8a0e"
 let s:gui0B        = "17ad98"
-let g:base16_gui0B = "17ad98"
+let g:tinted_gui0B = "17ad98"
 let s:gui0C        = "149bda"
-let g:base16_gui0C = "149bda"
+let g:tinted_gui0C = "149bda"
 let s:gui0D        = "775dff"
-let g:base16_gui0D = "775dff"
+let g:tinted_gui0D = "775dff"
 let s:gui0E        = "aa17e6"
-let g:base16_gui0E = "aa17e6"
+let g:tinted_gui0E = "aa17e6"
 let s:gui0F        = "e013d0"
+let g:tinted_gui0F = "e013d0"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "e1e1e2"
+let g:base16_gui02 = "c4c3c5"
+let g:base16_gui03 = "a7a5a8"
+let g:base16_gui04 = "89878b"
+let g:base16_gui05 = "6c696e"
+let g:base16_gui06 = "4f4b51"
+let g:base16_gui07 = "322d34"
+let g:base16_gui08 = "d8137f"
+let g:base16_gui09 = "d65407"
+let g:base16_gui0A = "dc8a0e"
+let g:base16_gui0B = "17ad98"
+let g:base16_gui0C = "149bda"
+let g:base16_gui0D = "775dff"
+let g:base16_gui0E = "aa17e6"
 let g:base16_gui0F = "e013d0"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#322d34",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-unikitty-reversible.vim
+++ b/colors/base16-unikitty-reversible.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Unikitty Reversible
 " Scheme author: Josh W Lewis (@joshwlewis)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-unikitty-reversible.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/unikitty-reversible.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/unikitty-reversible.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "2e2a31"
-let g:base16_gui00 = "2e2a31"
+let g:tinted_gui00 = "2e2a31"
 let s:gui01        = "4b484e"
-let g:base16_gui01 = "4b484e"
+let g:tinted_gui01 = "4b484e"
 let s:gui02        = "69666b"
-let g:base16_gui02 = "69666b"
+let g:tinted_gui02 = "69666b"
 let s:gui03        = "878589"
-let g:base16_gui03 = "878589"
+let g:tinted_gui03 = "878589"
 let s:gui04        = "a5a3a6"
-let g:base16_gui04 = "a5a3a6"
+let g:tinted_gui04 = "a5a3a6"
 let s:gui05        = "c3c2c4"
-let g:base16_gui05 = "c3c2c4"
+let g:tinted_gui05 = "c3c2c4"
 let s:gui06        = "e1e0e1"
-let g:base16_gui06 = "e1e0e1"
+let g:tinted_gui06 = "e1e0e1"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "d8137f"
-let g:base16_gui08 = "d8137f"
+let g:tinted_gui08 = "d8137f"
 let s:gui09        = "d65407"
-let g:base16_gui09 = "d65407"
+let g:tinted_gui09 = "d65407"
 let s:gui0A        = "dc8a0e"
-let g:base16_gui0A = "dc8a0e"
+let g:tinted_gui0A = "dc8a0e"
 let s:gui0B        = "17ad98"
-let g:base16_gui0B = "17ad98"
+let g:tinted_gui0B = "17ad98"
 let s:gui0C        = "149bda"
-let g:base16_gui0C = "149bda"
+let g:tinted_gui0C = "149bda"
 let s:gui0D        = "7864fa"
-let g:base16_gui0D = "7864fa"
+let g:tinted_gui0D = "7864fa"
 let s:gui0E        = "b33ce8"
-let g:base16_gui0E = "b33ce8"
+let g:tinted_gui0E = "b33ce8"
 let s:gui0F        = "d41acd"
+let g:tinted_gui0F = "d41acd"
+
+" Legacy
+let g:base16_gui00 = "2e2a31"
+let g:base16_gui01 = "4b484e"
+let g:base16_gui02 = "69666b"
+let g:base16_gui03 = "878589"
+let g:base16_gui04 = "a5a3a6"
+let g:base16_gui05 = "c3c2c4"
+let g:base16_gui06 = "e1e0e1"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "d8137f"
+let g:base16_gui09 = "d65407"
+let g:base16_gui0A = "dc8a0e"
+let g:base16_gui0B = "17ad98"
+let g:base16_gui0C = "149bda"
+let g:base16_gui0D = "7864fa"
+let g:base16_gui0E = "b33ce8"
 let g:base16_gui0F = "d41acd"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-uwunicorn.vim
+++ b/colors/base16-uwunicorn.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: UwUnicorn
 " Scheme author: Fernando Marques (https://github.com/RakkiUwU) and Gabriel Fontes (https://github.com/Misterio77)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-uwunicorn.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/uwunicorn.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/uwunicorn.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "241b26"
-let g:base16_gui00 = "241b26"
+let g:tinted_gui00 = "241b26"
 let s:gui01        = "2f2a3f"
-let g:base16_gui01 = "2f2a3f"
+let g:tinted_gui01 = "2f2a3f"
 let s:gui02        = "46354a"
-let g:base16_gui02 = "46354a"
+let g:tinted_gui02 = "46354a"
 let s:gui03        = "6c3cb2"
-let g:base16_gui03 = "6c3cb2"
+let g:tinted_gui03 = "6c3cb2"
 let s:gui04        = "7e5f83"
-let g:base16_gui04 = "7e5f83"
+let g:tinted_gui04 = "7e5f83"
 let s:gui05        = "eed5d9"
-let g:base16_gui05 = "eed5d9"
+let g:tinted_gui05 = "eed5d9"
 let s:gui06        = "d9c2c6"
-let g:base16_gui06 = "d9c2c6"
+let g:tinted_gui06 = "d9c2c6"
 let s:gui07        = "e4ccd0"
-let g:base16_gui07 = "e4ccd0"
+let g:tinted_gui07 = "e4ccd0"
 let s:gui08        = "877bb6"
-let g:base16_gui08 = "877bb6"
+let g:tinted_gui08 = "877bb6"
 let s:gui09        = "de5b44"
-let g:base16_gui09 = "de5b44"
+let g:tinted_gui09 = "de5b44"
 let s:gui0A        = "a84a73"
-let g:base16_gui0A = "a84a73"
+let g:tinted_gui0A = "a84a73"
 let s:gui0B        = "c965bf"
-let g:base16_gui0B = "c965bf"
+let g:tinted_gui0B = "c965bf"
 let s:gui0C        = "9c5fce"
-let g:base16_gui0C = "9c5fce"
+let g:tinted_gui0C = "9c5fce"
 let s:gui0D        = "6a9eb5"
-let g:base16_gui0D = "6a9eb5"
+let g:tinted_gui0D = "6a9eb5"
 let s:gui0E        = "78a38f"
-let g:base16_gui0E = "78a38f"
+let g:tinted_gui0E = "78a38f"
 let s:gui0F        = "a3a079"
+let g:tinted_gui0F = "a3a079"
+
+" Legacy
+let g:base16_gui00 = "241b26"
+let g:base16_gui01 = "2f2a3f"
+let g:base16_gui02 = "46354a"
+let g:base16_gui03 = "6c3cb2"
+let g:base16_gui04 = "7e5f83"
+let g:base16_gui05 = "eed5d9"
+let g:base16_gui06 = "d9c2c6"
+let g:base16_gui07 = "e4ccd0"
+let g:base16_gui08 = "877bb6"
+let g:base16_gui09 = "de5b44"
+let g:base16_gui0A = "a84a73"
+let g:base16_gui0B = "c965bf"
+let g:base16_gui0C = "9c5fce"
+let g:base16_gui0D = "6a9eb5"
+let g:base16_gui0E = "78a38f"
 let g:base16_gui0F = "a3a079"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e4ccd0",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-vesper.vim
+++ b/colors/base16-vesper.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Vesper
 " Scheme author: FormalSnake (https://github.com/formalsnake)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-vesper.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/vesper.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/vesper.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "101010"
-let g:base16_gui00 = "101010"
+let g:tinted_gui00 = "101010"
 let s:gui01        = "232323"
-let g:base16_gui01 = "232323"
+let g:tinted_gui01 = "232323"
 let s:gui02        = "222222"
-let g:base16_gui02 = "222222"
+let g:tinted_gui02 = "222222"
 let s:gui03        = "333333"
-let g:base16_gui03 = "333333"
+let g:tinted_gui03 = "333333"
 let s:gui04        = "999999"
-let g:base16_gui04 = "999999"
+let g:tinted_gui04 = "999999"
 let s:gui05        = "b7b7b7"
-let g:base16_gui05 = "b7b7b7"
+let g:tinted_gui05 = "b7b7b7"
 let s:gui06        = "c1c1c1"
-let g:base16_gui06 = "c1c1c1"
+let g:tinted_gui06 = "c1c1c1"
 let s:gui07        = "d5d5d5"
-let g:base16_gui07 = "d5d5d5"
+let g:tinted_gui07 = "d5d5d5"
 let s:gui08        = "de6e6e"
-let g:base16_gui08 = "de6e6e"
+let g:tinted_gui08 = "de6e6e"
 let s:gui09        = "dab083"
-let g:base16_gui09 = "dab083"
+let g:tinted_gui09 = "dab083"
 let s:gui0A        = "ffc799"
-let g:base16_gui0A = "ffc799"
+let g:tinted_gui0A = "ffc799"
 let s:gui0B        = "5f8787"
-let g:base16_gui0B = "5f8787"
+let g:tinted_gui0B = "5f8787"
 let s:gui0C        = "60a592"
-let g:base16_gui0C = "60a592"
+let g:tinted_gui0C = "60a592"
 let s:gui0D        = "8eaaaa"
-let g:base16_gui0D = "8eaaaa"
+let g:tinted_gui0D = "8eaaaa"
 let s:gui0E        = "d69094"
-let g:base16_gui0E = "d69094"
+let g:tinted_gui0E = "d69094"
 let s:gui0F        = "876c4f"
+let g:tinted_gui0F = "876c4f"
+
+" Legacy
+let g:base16_gui00 = "101010"
+let g:base16_gui01 = "232323"
+let g:base16_gui02 = "222222"
+let g:base16_gui03 = "333333"
+let g:base16_gui04 = "999999"
+let g:base16_gui05 = "b7b7b7"
+let g:base16_gui06 = "c1c1c1"
+let g:base16_gui07 = "d5d5d5"
+let g:base16_gui08 = "de6e6e"
+let g:base16_gui09 = "dab083"
+let g:base16_gui0A = "ffc799"
+let g:base16_gui0B = "5f8787"
+let g:base16_gui0C = "60a592"
+let g:base16_gui0D = "8eaaaa"
+let g:base16_gui0E = "d69094"
 let g:base16_gui0F = "876c4f"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#d5d5d5",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-vice.vim
+++ b/colors/base16-vice.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: vice
 " Scheme author: Thomas Leon Highbaugh thighbaugh@zoho.com
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-vice.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/vice.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/vice.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "17191e"
-let g:base16_gui00 = "17191e"
+let g:tinted_gui00 = "17191e"
 let s:gui01        = "22262d"
-let g:base16_gui01 = "22262d"
+let g:tinted_gui01 = "22262d"
 let s:gui02        = "3c3f4c"
-let g:base16_gui02 = "3c3f4c"
+let g:tinted_gui02 = "3c3f4c"
 let s:gui03        = "383a47"
-let g:base16_gui03 = "383a47"
+let g:tinted_gui03 = "383a47"
 let s:gui04        = "555e70"
-let g:base16_gui04 = "555e70"
+let g:tinted_gui04 = "555e70"
 let s:gui05        = "8b9cbe"
-let g:base16_gui05 = "8b9cbe"
+let g:tinted_gui05 = "8b9cbe"
 let s:gui06        = "b2bfd9"
-let g:base16_gui06 = "b2bfd9"
+let g:tinted_gui06 = "b2bfd9"
 let s:gui07        = "f4f4f7"
-let g:base16_gui07 = "f4f4f7"
+let g:tinted_gui07 = "f4f4f7"
 let s:gui08        = "ff29a8"
-let g:base16_gui08 = "ff29a8"
+let g:tinted_gui08 = "ff29a8"
 let s:gui09        = "85ffe0"
-let g:base16_gui09 = "85ffe0"
+let g:tinted_gui09 = "85ffe0"
 let s:gui0A        = "f0ffaa"
-let g:base16_gui0A = "f0ffaa"
+let g:tinted_gui0A = "f0ffaa"
 let s:gui0B        = "0badff"
-let g:base16_gui0B = "0badff"
+let g:tinted_gui0B = "0badff"
 let s:gui0C        = "8265ff"
-let g:base16_gui0C = "8265ff"
+let g:tinted_gui0C = "8265ff"
 let s:gui0D        = "00eaff"
-let g:base16_gui0D = "00eaff"
+let g:tinted_gui0D = "00eaff"
 let s:gui0E        = "00f6d9"
-let g:base16_gui0E = "00f6d9"
+let g:tinted_gui0E = "00f6d9"
 let s:gui0F        = "ff3d81"
+let g:tinted_gui0F = "ff3d81"
+
+" Legacy
+let g:base16_gui00 = "17191e"
+let g:base16_gui01 = "22262d"
+let g:base16_gui02 = "3c3f4c"
+let g:base16_gui03 = "383a47"
+let g:base16_gui04 = "555e70"
+let g:base16_gui05 = "8b9cbe"
+let g:base16_gui06 = "b2bfd9"
+let g:base16_gui07 = "f4f4f7"
+let g:base16_gui08 = "ff29a8"
+let g:base16_gui09 = "85ffe0"
+let g:base16_gui0A = "f0ffaa"
+let g:base16_gui0B = "0badff"
+let g:base16_gui0C = "8265ff"
+let g:base16_gui0D = "00eaff"
+let g:base16_gui0E = "00f6d9"
 let g:base16_gui0F = "ff3d81"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f4f4f7",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: vulcan
 " Scheme author: Andrey Varfolomeev
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-vulcan.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/vulcan.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/vulcan.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "041523"
-let g:base16_gui00 = "041523"
+let g:tinted_gui00 = "041523"
 let s:gui01        = "122339"
-let g:base16_gui01 = "122339"
+let g:tinted_gui01 = "122339"
 let s:gui02        = "003552"
-let g:base16_gui02 = "003552"
+let g:tinted_gui02 = "003552"
 let s:gui03        = "7a5759"
-let g:base16_gui03 = "7a5759"
+let g:tinted_gui03 = "7a5759"
 let s:gui04        = "6b6977"
-let g:base16_gui04 = "6b6977"
+let g:tinted_gui04 = "6b6977"
 let s:gui05        = "5b778c"
-let g:base16_gui05 = "5b778c"
+let g:tinted_gui05 = "5b778c"
 let s:gui06        = "333238"
-let g:base16_gui06 = "333238"
+let g:tinted_gui06 = "333238"
 let s:gui07        = "214d68"
-let g:base16_gui07 = "214d68"
+let g:tinted_gui07 = "214d68"
 let s:gui08        = "818591"
-let g:base16_gui08 = "818591"
+let g:tinted_gui08 = "818591"
 let s:gui09        = "9198a3"
-let g:base16_gui09 = "9198a3"
+let g:tinted_gui09 = "9198a3"
 let s:gui0A        = "adb4b9"
-let g:base16_gui0A = "adb4b9"
+let g:tinted_gui0A = "adb4b9"
 let s:gui0B        = "977d7c"
-let g:base16_gui0B = "977d7c"
+let g:tinted_gui0B = "977d7c"
 let s:gui0C        = "977d7c"
-let g:base16_gui0C = "977d7c"
+let g:tinted_gui0C = "977d7c"
 let s:gui0D        = "977d7c"
-let g:base16_gui0D = "977d7c"
+let g:tinted_gui0D = "977d7c"
 let s:gui0E        = "9198a3"
-let g:base16_gui0E = "9198a3"
+let g:tinted_gui0E = "9198a3"
 let s:gui0F        = "977d7c"
+let g:tinted_gui0F = "977d7c"
+
+" Legacy
+let g:base16_gui00 = "041523"
+let g:base16_gui01 = "122339"
+let g:base16_gui02 = "003552"
+let g:base16_gui03 = "7a5759"
+let g:base16_gui04 = "6b6977"
+let g:base16_gui05 = "5b778c"
+let g:base16_gui06 = "333238"
+let g:base16_gui07 = "214d68"
+let g:base16_gui08 = "818591"
+let g:base16_gui09 = "9198a3"
+let g:base16_gui0A = "adb4b9"
+let g:base16_gui0B = "977d7c"
+let g:base16_gui0C = "977d7c"
+let g:base16_gui0D = "977d7c"
+let g:base16_gui0E = "9198a3"
 let g:base16_gui0F = "977d7c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#214d68",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-10-light.vim
+++ b/colors/base16-windows-10-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows 10 Light
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-10-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-10-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-10-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "f2f2f2"
-let g:base16_gui00 = "f2f2f2"
+let g:tinted_gui00 = "f2f2f2"
 let s:gui01        = "e5e5e5"
-let g:base16_gui01 = "e5e5e5"
+let g:tinted_gui01 = "e5e5e5"
 let s:gui02        = "d9d9d9"
-let g:base16_gui02 = "d9d9d9"
+let g:tinted_gui02 = "d9d9d9"
 let s:gui03        = "cccccc"
-let g:base16_gui03 = "cccccc"
+let g:tinted_gui03 = "cccccc"
 let s:gui04        = "ababab"
-let g:base16_gui04 = "ababab"
+let g:tinted_gui04 = "ababab"
 let s:gui05        = "767676"
-let g:base16_gui05 = "767676"
+let g:tinted_gui05 = "767676"
 let s:gui06        = "414141"
-let g:base16_gui06 = "414141"
+let g:tinted_gui06 = "414141"
 let s:gui07        = "0c0c0c"
-let g:base16_gui07 = "0c0c0c"
+let g:tinted_gui07 = "0c0c0c"
 let s:gui08        = "c50f1f"
-let g:base16_gui08 = "c50f1f"
+let g:tinted_gui08 = "c50f1f"
 let s:gui09        = "f9f1a5"
-let g:base16_gui09 = "f9f1a5"
+let g:tinted_gui09 = "f9f1a5"
 let s:gui0A        = "c19c00"
-let g:base16_gui0A = "c19c00"
+let g:tinted_gui0A = "c19c00"
 let s:gui0B        = "13a10e"
-let g:base16_gui0B = "13a10e"
+let g:tinted_gui0B = "13a10e"
 let s:gui0C        = "3a96dd"
-let g:base16_gui0C = "3a96dd"
+let g:tinted_gui0C = "3a96dd"
 let s:gui0D        = "0037da"
-let g:base16_gui0D = "0037da"
+let g:tinted_gui0D = "0037da"
 let s:gui0E        = "881798"
-let g:base16_gui0E = "881798"
+let g:tinted_gui0E = "881798"
 let s:gui0F        = "16c60c"
+let g:tinted_gui0F = "16c60c"
+
+" Legacy
+let g:base16_gui00 = "f2f2f2"
+let g:base16_gui01 = "e5e5e5"
+let g:base16_gui02 = "d9d9d9"
+let g:base16_gui03 = "cccccc"
+let g:base16_gui04 = "ababab"
+let g:base16_gui05 = "767676"
+let g:base16_gui06 = "414141"
+let g:base16_gui07 = "0c0c0c"
+let g:base16_gui08 = "c50f1f"
+let g:base16_gui09 = "f9f1a5"
+let g:base16_gui0A = "c19c00"
+let g:base16_gui0B = "13a10e"
+let g:base16_gui0C = "3a96dd"
+let g:base16_gui0D = "0037da"
+let g:base16_gui0E = "881798"
 let g:base16_gui0F = "16c60c"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#0c0c0c",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-10.vim
+++ b/colors/base16-windows-10.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows 10
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-10.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-10.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-10.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "0c0c0c"
-let g:base16_gui00 = "0c0c0c"
+let g:tinted_gui00 = "0c0c0c"
 let s:gui01        = "2f2f2f"
-let g:base16_gui01 = "2f2f2f"
+let g:tinted_gui01 = "2f2f2f"
 let s:gui02        = "535353"
-let g:base16_gui02 = "535353"
+let g:tinted_gui02 = "535353"
 let s:gui03        = "767676"
-let g:base16_gui03 = "767676"
+let g:tinted_gui03 = "767676"
 let s:gui04        = "b9b9b9"
-let g:base16_gui04 = "b9b9b9"
+let g:tinted_gui04 = "b9b9b9"
 let s:gui05        = "cccccc"
-let g:base16_gui05 = "cccccc"
+let g:tinted_gui05 = "cccccc"
 let s:gui06        = "dfdfdf"
-let g:base16_gui06 = "dfdfdf"
+let g:tinted_gui06 = "dfdfdf"
 let s:gui07        = "f2f2f2"
-let g:base16_gui07 = "f2f2f2"
+let g:tinted_gui07 = "f2f2f2"
 let s:gui08        = "e74856"
-let g:base16_gui08 = "e74856"
+let g:tinted_gui08 = "e74856"
 let s:gui09        = "c19c00"
-let g:base16_gui09 = "c19c00"
+let g:tinted_gui09 = "c19c00"
 let s:gui0A        = "f9f1a5"
-let g:base16_gui0A = "f9f1a5"
+let g:tinted_gui0A = "f9f1a5"
 let s:gui0B        = "16c60c"
-let g:base16_gui0B = "16c60c"
+let g:tinted_gui0B = "16c60c"
 let s:gui0C        = "61d6d6"
-let g:base16_gui0C = "61d6d6"
+let g:tinted_gui0C = "61d6d6"
 let s:gui0D        = "3b78ff"
-let g:base16_gui0D = "3b78ff"
+let g:tinted_gui0D = "3b78ff"
 let s:gui0E        = "b4009e"
-let g:base16_gui0E = "b4009e"
+let g:tinted_gui0E = "b4009e"
 let s:gui0F        = "13a10e"
+let g:tinted_gui0F = "13a10e"
+
+" Legacy
+let g:base16_gui00 = "0c0c0c"
+let g:base16_gui01 = "2f2f2f"
+let g:base16_gui02 = "535353"
+let g:base16_gui03 = "767676"
+let g:base16_gui04 = "b9b9b9"
+let g:base16_gui05 = "cccccc"
+let g:base16_gui06 = "dfdfdf"
+let g:base16_gui07 = "f2f2f2"
+let g:base16_gui08 = "e74856"
+let g:base16_gui09 = "c19c00"
+let g:base16_gui0A = "f9f1a5"
+let g:base16_gui0B = "16c60c"
+let g:base16_gui0C = "61d6d6"
+let g:base16_gui0D = "3b78ff"
+let g:base16_gui0E = "b4009e"
 let g:base16_gui0F = "13a10e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#f2f2f2",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-95-light.vim
+++ b/colors/base16-windows-95-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows 95 Light
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-95-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-95-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-95-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fcfcfc"
-let g:base16_gui00 = "fcfcfc"
+let g:tinted_gui00 = "fcfcfc"
 let s:gui01        = "e0e0e0"
-let g:base16_gui01 = "e0e0e0"
+let g:tinted_gui01 = "e0e0e0"
 let s:gui02        = "c4c4c4"
-let g:base16_gui02 = "c4c4c4"
+let g:tinted_gui02 = "c4c4c4"
 let s:gui03        = "a8a8a8"
-let g:base16_gui03 = "a8a8a8"
+let g:tinted_gui03 = "a8a8a8"
 let s:gui04        = "7e7e7e"
-let g:base16_gui04 = "7e7e7e"
+let g:tinted_gui04 = "7e7e7e"
 let s:gui05        = "545454"
-let g:base16_gui05 = "545454"
+let g:tinted_gui05 = "545454"
 let s:gui06        = "2a2a2a"
-let g:base16_gui06 = "2a2a2a"
+let g:tinted_gui06 = "2a2a2a"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "a80000"
-let g:base16_gui08 = "a80000"
+let g:tinted_gui08 = "a80000"
 let s:gui09        = "fcfc54"
-let g:base16_gui09 = "fcfc54"
+let g:tinted_gui09 = "fcfc54"
 let s:gui0A        = "a85400"
-let g:base16_gui0A = "a85400"
+let g:tinted_gui0A = "a85400"
 let s:gui0B        = "00a800"
-let g:base16_gui0B = "00a800"
+let g:tinted_gui0B = "00a800"
 let s:gui0C        = "00a8a8"
-let g:base16_gui0C = "00a8a8"
+let g:tinted_gui0C = "00a8a8"
 let s:gui0D        = "0000a8"
-let g:base16_gui0D = "0000a8"
+let g:tinted_gui0D = "0000a8"
 let s:gui0E        = "a800a8"
-let g:base16_gui0E = "a800a8"
+let g:tinted_gui0E = "a800a8"
 let s:gui0F        = "54fc54"
+let g:tinted_gui0F = "54fc54"
+
+" Legacy
+let g:base16_gui00 = "fcfcfc"
+let g:base16_gui01 = "e0e0e0"
+let g:base16_gui02 = "c4c4c4"
+let g:base16_gui03 = "a8a8a8"
+let g:base16_gui04 = "7e7e7e"
+let g:base16_gui05 = "545454"
+let g:base16_gui06 = "2a2a2a"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "a80000"
+let g:base16_gui09 = "fcfc54"
+let g:base16_gui0A = "a85400"
+let g:base16_gui0B = "00a800"
+let g:base16_gui0C = "00a8a8"
+let g:base16_gui0D = "0000a8"
+let g:base16_gui0E = "a800a8"
 let g:base16_gui0F = "54fc54"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-95.vim
+++ b/colors/base16-windows-95.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows 95
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-95.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-95.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-95.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "1c1c1c"
-let g:base16_gui01 = "1c1c1c"
+let g:tinted_gui01 = "1c1c1c"
 let s:gui02        = "383838"
-let g:base16_gui02 = "383838"
+let g:tinted_gui02 = "383838"
 let s:gui03        = "545454"
-let g:base16_gui03 = "545454"
+let g:tinted_gui03 = "545454"
 let s:gui04        = "7e7e7e"
-let g:base16_gui04 = "7e7e7e"
+let g:tinted_gui04 = "7e7e7e"
 let s:gui05        = "a8a8a8"
-let g:base16_gui05 = "a8a8a8"
+let g:tinted_gui05 = "a8a8a8"
 let s:gui06        = "d2d2d2"
-let g:base16_gui06 = "d2d2d2"
+let g:tinted_gui06 = "d2d2d2"
 let s:gui07        = "fcfcfc"
-let g:base16_gui07 = "fcfcfc"
+let g:tinted_gui07 = "fcfcfc"
 let s:gui08        = "fc5454"
-let g:base16_gui08 = "fc5454"
+let g:tinted_gui08 = "fc5454"
 let s:gui09        = "a85400"
-let g:base16_gui09 = "a85400"
+let g:tinted_gui09 = "a85400"
 let s:gui0A        = "fcfc54"
-let g:base16_gui0A = "fcfc54"
+let g:tinted_gui0A = "fcfc54"
 let s:gui0B        = "54fc54"
-let g:base16_gui0B = "54fc54"
+let g:tinted_gui0B = "54fc54"
 let s:gui0C        = "54fcfc"
-let g:base16_gui0C = "54fcfc"
+let g:tinted_gui0C = "54fcfc"
 let s:gui0D        = "5454fc"
-let g:base16_gui0D = "5454fc"
+let g:tinted_gui0D = "5454fc"
 let s:gui0E        = "fc54fc"
-let g:base16_gui0E = "fc54fc"
+let g:tinted_gui0E = "fc54fc"
 let s:gui0F        = "00a800"
+let g:tinted_gui0F = "00a800"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "1c1c1c"
+let g:base16_gui02 = "383838"
+let g:base16_gui03 = "545454"
+let g:base16_gui04 = "7e7e7e"
+let g:base16_gui05 = "a8a8a8"
+let g:base16_gui06 = "d2d2d2"
+let g:base16_gui07 = "fcfcfc"
+let g:base16_gui08 = "fc5454"
+let g:base16_gui09 = "a85400"
+let g:base16_gui0A = "fcfc54"
+let g:base16_gui0B = "54fc54"
+let g:base16_gui0C = "54fcfc"
+let g:base16_gui0D = "5454fc"
+let g:base16_gui0E = "fc54fc"
 let g:base16_gui0F = "00a800"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fcfcfc",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-highcontrast-light.vim
+++ b/colors/base16-windows-highcontrast-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows High Contrast Light
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-highcontrast-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-highcontrast-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-highcontrast-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "fcfcfc"
-let g:base16_gui00 = "fcfcfc"
+let g:tinted_gui00 = "fcfcfc"
 let s:gui01        = "e8e8e8"
-let g:base16_gui01 = "e8e8e8"
+let g:tinted_gui01 = "e8e8e8"
 let s:gui02        = "d4d4d4"
-let g:base16_gui02 = "d4d4d4"
+let g:tinted_gui02 = "d4d4d4"
 let s:gui03        = "c0c0c0"
-let g:base16_gui03 = "c0c0c0"
+let g:tinted_gui03 = "c0c0c0"
 let s:gui04        = "7e7e7e"
-let g:base16_gui04 = "7e7e7e"
+let g:tinted_gui04 = "7e7e7e"
 let s:gui05        = "545454"
-let g:base16_gui05 = "545454"
+let g:tinted_gui05 = "545454"
 let s:gui06        = "2a2a2a"
-let g:base16_gui06 = "2a2a2a"
+let g:tinted_gui06 = "2a2a2a"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "800000"
-let g:base16_gui08 = "800000"
+let g:tinted_gui08 = "800000"
 let s:gui09        = "fcfc54"
-let g:base16_gui09 = "fcfc54"
+let g:tinted_gui09 = "fcfc54"
 let s:gui0A        = "808000"
-let g:base16_gui0A = "808000"
+let g:tinted_gui0A = "808000"
 let s:gui0B        = "008000"
-let g:base16_gui0B = "008000"
+let g:tinted_gui0B = "008000"
 let s:gui0C        = "008080"
-let g:base16_gui0C = "008080"
+let g:tinted_gui0C = "008080"
 let s:gui0D        = "000080"
-let g:base16_gui0D = "000080"
+let g:tinted_gui0D = "000080"
 let s:gui0E        = "800080"
-let g:base16_gui0E = "800080"
+let g:tinted_gui0E = "800080"
 let s:gui0F        = "54fc54"
+let g:tinted_gui0F = "54fc54"
+
+" Legacy
+let g:base16_gui00 = "fcfcfc"
+let g:base16_gui01 = "e8e8e8"
+let g:base16_gui02 = "d4d4d4"
+let g:base16_gui03 = "c0c0c0"
+let g:base16_gui04 = "7e7e7e"
+let g:base16_gui05 = "545454"
+let g:base16_gui06 = "2a2a2a"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "800000"
+let g:base16_gui09 = "fcfc54"
+let g:base16_gui0A = "808000"
+let g:base16_gui0B = "008000"
+let g:base16_gui0C = "008080"
+let g:base16_gui0D = "000080"
+let g:base16_gui0E = "800080"
 let g:base16_gui0F = "54fc54"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-highcontrast.vim
+++ b/colors/base16-windows-highcontrast.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows High Contrast
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-highcontrast.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-highcontrast.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-highcontrast.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "1c1c1c"
-let g:base16_gui01 = "1c1c1c"
+let g:tinted_gui01 = "1c1c1c"
 let s:gui02        = "383838"
-let g:base16_gui02 = "383838"
+let g:tinted_gui02 = "383838"
 let s:gui03        = "545454"
-let g:base16_gui03 = "545454"
+let g:tinted_gui03 = "545454"
 let s:gui04        = "a2a2a2"
-let g:base16_gui04 = "a2a2a2"
+let g:tinted_gui04 = "a2a2a2"
 let s:gui05        = "c0c0c0"
-let g:base16_gui05 = "c0c0c0"
+let g:tinted_gui05 = "c0c0c0"
 let s:gui06        = "dedede"
-let g:base16_gui06 = "dedede"
+let g:tinted_gui06 = "dedede"
 let s:gui07        = "fcfcfc"
-let g:base16_gui07 = "fcfcfc"
+let g:tinted_gui07 = "fcfcfc"
 let s:gui08        = "fc5454"
-let g:base16_gui08 = "fc5454"
+let g:tinted_gui08 = "fc5454"
 let s:gui09        = "808000"
-let g:base16_gui09 = "808000"
+let g:tinted_gui09 = "808000"
 let s:gui0A        = "fcfc54"
-let g:base16_gui0A = "fcfc54"
+let g:tinted_gui0A = "fcfc54"
 let s:gui0B        = "54fc54"
-let g:base16_gui0B = "54fc54"
+let g:tinted_gui0B = "54fc54"
 let s:gui0C        = "54fcfc"
-let g:base16_gui0C = "54fcfc"
+let g:tinted_gui0C = "54fcfc"
 let s:gui0D        = "5454fc"
-let g:base16_gui0D = "5454fc"
+let g:tinted_gui0D = "5454fc"
 let s:gui0E        = "fc54fc"
-let g:base16_gui0E = "fc54fc"
+let g:tinted_gui0E = "fc54fc"
 let s:gui0F        = "008000"
+let g:tinted_gui0F = "008000"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "1c1c1c"
+let g:base16_gui02 = "383838"
+let g:base16_gui03 = "545454"
+let g:base16_gui04 = "a2a2a2"
+let g:base16_gui05 = "c0c0c0"
+let g:base16_gui06 = "dedede"
+let g:base16_gui07 = "fcfcfc"
+let g:base16_gui08 = "fc5454"
+let g:base16_gui09 = "808000"
+let g:base16_gui0A = "fcfc54"
+let g:base16_gui0B = "54fc54"
+let g:base16_gui0C = "54fcfc"
+let g:base16_gui0D = "5454fc"
+let g:base16_gui0E = "fc54fc"
 let g:base16_gui0F = "008000"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#fcfcfc",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-nt-light.vim
+++ b/colors/base16-windows-nt-light.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows NT Light
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-nt-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-nt-light.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-nt-light.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "ffffff"
-let g:base16_gui00 = "ffffff"
+let g:tinted_gui00 = "ffffff"
 let s:gui01        = "eaeaea"
-let g:base16_gui01 = "eaeaea"
+let g:tinted_gui01 = "eaeaea"
 let s:gui02        = "d5d5d5"
-let g:base16_gui02 = "d5d5d5"
+let g:tinted_gui02 = "d5d5d5"
 let s:gui03        = "c0c0c0"
-let g:base16_gui03 = "c0c0c0"
+let g:tinted_gui03 = "c0c0c0"
 let s:gui04        = "a0a0a0"
-let g:base16_gui04 = "a0a0a0"
+let g:tinted_gui04 = "a0a0a0"
 let s:gui05        = "808080"
-let g:base16_gui05 = "808080"
+let g:tinted_gui05 = "808080"
 let s:gui06        = "404040"
-let g:base16_gui06 = "404040"
+let g:tinted_gui06 = "404040"
 let s:gui07        = "000000"
-let g:base16_gui07 = "000000"
+let g:tinted_gui07 = "000000"
 let s:gui08        = "800000"
-let g:base16_gui08 = "800000"
+let g:tinted_gui08 = "800000"
 let s:gui09        = "ffff00"
-let g:base16_gui09 = "ffff00"
+let g:tinted_gui09 = "ffff00"
 let s:gui0A        = "808000"
-let g:base16_gui0A = "808000"
+let g:tinted_gui0A = "808000"
 let s:gui0B        = "008000"
-let g:base16_gui0B = "008000"
+let g:tinted_gui0B = "008000"
 let s:gui0C        = "008080"
-let g:base16_gui0C = "008080"
+let g:tinted_gui0C = "008080"
 let s:gui0D        = "000080"
-let g:base16_gui0D = "000080"
+let g:tinted_gui0D = "000080"
 let s:gui0E        = "800080"
-let g:base16_gui0E = "800080"
+let g:tinted_gui0E = "800080"
 let s:gui0F        = "00ff00"
+let g:tinted_gui0F = "00ff00"
+
+" Legacy
+let g:base16_gui00 = "ffffff"
+let g:base16_gui01 = "eaeaea"
+let g:base16_gui02 = "d5d5d5"
+let g:base16_gui03 = "c0c0c0"
+let g:base16_gui04 = "a0a0a0"
+let g:base16_gui05 = "808080"
+let g:base16_gui06 = "404040"
+let g:base16_gui07 = "000000"
+let g:base16_gui08 = "800000"
+let g:base16_gui09 = "ffff00"
+let g:base16_gui0A = "808000"
+let g:base16_gui0B = "008000"
+let g:base16_gui0C = "008080"
+let g:base16_gui0D = "000080"
+let g:base16_gui0E = "800080"
 let g:base16_gui0F = "00ff00"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#000000",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-windows-nt.vim
+++ b/colors/base16-windows-nt.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Windows NT
 " Scheme author: Fergus Collins (https://github.com/C-Fergus)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-windows-nt.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/windows-nt.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/windows-nt.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "000000"
-let g:base16_gui00 = "000000"
+let g:tinted_gui00 = "000000"
 let s:gui01        = "2a2a2a"
-let g:base16_gui01 = "2a2a2a"
+let g:tinted_gui01 = "2a2a2a"
 let s:gui02        = "555555"
-let g:base16_gui02 = "555555"
+let g:tinted_gui02 = "555555"
 let s:gui03        = "808080"
-let g:base16_gui03 = "808080"
+let g:tinted_gui03 = "808080"
 let s:gui04        = "a1a1a1"
-let g:base16_gui04 = "a1a1a1"
+let g:tinted_gui04 = "a1a1a1"
 let s:gui05        = "c0c0c0"
-let g:base16_gui05 = "c0c0c0"
+let g:tinted_gui05 = "c0c0c0"
 let s:gui06        = "e0e0e0"
-let g:base16_gui06 = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "ff0000"
-let g:base16_gui08 = "ff0000"
+let g:tinted_gui08 = "ff0000"
 let s:gui09        = "808000"
-let g:base16_gui09 = "808000"
+let g:tinted_gui09 = "808000"
 let s:gui0A        = "ffff00"
-let g:base16_gui0A = "ffff00"
+let g:tinted_gui0A = "ffff00"
 let s:gui0B        = "00ff00"
-let g:base16_gui0B = "00ff00"
+let g:tinted_gui0B = "00ff00"
 let s:gui0C        = "00ffff"
-let g:base16_gui0C = "00ffff"
+let g:tinted_gui0C = "00ffff"
 let s:gui0D        = "0000ff"
-let g:base16_gui0D = "0000ff"
+let g:tinted_gui0D = "0000ff"
 let s:gui0E        = "ff00ff"
-let g:base16_gui0E = "ff00ff"
+let g:tinted_gui0E = "ff00ff"
 let s:gui0F        = "008000"
+let g:tinted_gui0F = "008000"
+
+" Legacy
+let g:base16_gui00 = "000000"
+let g:base16_gui01 = "2a2a2a"
+let g:base16_gui02 = "555555"
+let g:base16_gui03 = "808080"
+let g:base16_gui04 = "a1a1a1"
+let g:base16_gui05 = "c0c0c0"
+let g:base16_gui06 = "e0e0e0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "ff0000"
+let g:base16_gui09 = "808000"
+let g:base16_gui0A = "ffff00"
+let g:base16_gui0B = "00ff00"
+let g:base16_gui0C = "00ffff"
+let g:base16_gui0D = "0000ff"
+let g:base16_gui0E = "ff00ff"
 let g:base16_gui0F = "008000"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Woodland
 " Scheme author: Jay Cornwall (https://jcornwall.com)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-woodland.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/woodland.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/woodland.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "231e18"
-let g:base16_gui00 = "231e18"
+let g:tinted_gui00 = "231e18"
 let s:gui01        = "302b25"
-let g:base16_gui01 = "302b25"
+let g:tinted_gui01 = "302b25"
 let s:gui02        = "48413a"
-let g:base16_gui02 = "48413a"
+let g:tinted_gui02 = "48413a"
 let s:gui03        = "9d8b70"
-let g:base16_gui03 = "9d8b70"
+let g:tinted_gui03 = "9d8b70"
 let s:gui04        = "b4a490"
-let g:base16_gui04 = "b4a490"
+let g:tinted_gui04 = "b4a490"
 let s:gui05        = "cabcb1"
-let g:base16_gui05 = "cabcb1"
+let g:tinted_gui05 = "cabcb1"
 let s:gui06        = "d7c8bc"
-let g:base16_gui06 = "d7c8bc"
+let g:tinted_gui06 = "d7c8bc"
 let s:gui07        = "e4d4c8"
-let g:base16_gui07 = "e4d4c8"
+let g:tinted_gui07 = "e4d4c8"
 let s:gui08        = "d35c5c"
-let g:base16_gui08 = "d35c5c"
+let g:tinted_gui08 = "d35c5c"
 let s:gui09        = "ca7f32"
-let g:base16_gui09 = "ca7f32"
+let g:tinted_gui09 = "ca7f32"
 let s:gui0A        = "e0ac16"
-let g:base16_gui0A = "e0ac16"
+let g:tinted_gui0A = "e0ac16"
 let s:gui0B        = "b7ba53"
-let g:base16_gui0B = "b7ba53"
+let g:tinted_gui0B = "b7ba53"
 let s:gui0C        = "6eb958"
-let g:base16_gui0C = "6eb958"
+let g:tinted_gui0C = "6eb958"
 let s:gui0D        = "88a4d3"
-let g:base16_gui0D = "88a4d3"
+let g:tinted_gui0D = "88a4d3"
 let s:gui0E        = "bb90e2"
-let g:base16_gui0E = "bb90e2"
+let g:tinted_gui0E = "bb90e2"
 let s:gui0F        = "b49368"
+let g:tinted_gui0F = "b49368"
+
+" Legacy
+let g:base16_gui00 = "231e18"
+let g:base16_gui01 = "302b25"
+let g:base16_gui02 = "48413a"
+let g:base16_gui03 = "9d8b70"
+let g:base16_gui04 = "b4a490"
+let g:base16_gui05 = "cabcb1"
+let g:base16_gui06 = "d7c8bc"
+let g:base16_gui07 = "e4d4c8"
+let g:base16_gui08 = "d35c5c"
+let g:base16_gui09 = "ca7f32"
+let g:base16_gui0A = "e0ac16"
+let g:base16_gui0B = "b7ba53"
+let g:base16_gui0C = "6eb958"
+let g:base16_gui0D = "88a4d3"
+let g:base16_gui0E = "bb90e2"
 let g:base16_gui0F = "b49368"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#e4d4c8",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: XCode Dusk
 " Scheme author: Elsa Gonsiorowski (https://github.com/gonsie)
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-xcode-dusk.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/xcode-dusk.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/xcode-dusk.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "282b35"
-let g:base16_gui00 = "282b35"
+let g:tinted_gui00 = "282b35"
 let s:gui01        = "3d4048"
-let g:base16_gui01 = "3d4048"
+let g:tinted_gui01 = "3d4048"
 let s:gui02        = "53555d"
-let g:base16_gui02 = "53555d"
+let g:tinted_gui02 = "53555d"
 let s:gui03        = "686a71"
-let g:base16_gui03 = "686a71"
+let g:tinted_gui03 = "686a71"
 let s:gui04        = "7e8086"
-let g:base16_gui04 = "7e8086"
+let g:tinted_gui04 = "7e8086"
 let s:gui05        = "939599"
-let g:base16_gui05 = "939599"
+let g:tinted_gui05 = "939599"
 let s:gui06        = "a9aaae"
-let g:base16_gui06 = "a9aaae"
+let g:tinted_gui06 = "a9aaae"
 let s:gui07        = "bebfc2"
-let g:base16_gui07 = "bebfc2"
+let g:tinted_gui07 = "bebfc2"
 let s:gui08        = "b21889"
-let g:base16_gui08 = "b21889"
+let g:tinted_gui08 = "b21889"
 let s:gui09        = "786dc5"
-let g:base16_gui09 = "786dc5"
+let g:tinted_gui09 = "786dc5"
 let s:gui0A        = "438288"
-let g:base16_gui0A = "438288"
+let g:tinted_gui0A = "438288"
 let s:gui0B        = "df0002"
-let g:base16_gui0B = "df0002"
+let g:tinted_gui0B = "df0002"
 let s:gui0C        = "00a0be"
-let g:base16_gui0C = "00a0be"
+let g:tinted_gui0C = "00a0be"
 let s:gui0D        = "790ead"
-let g:base16_gui0D = "790ead"
+let g:tinted_gui0D = "790ead"
 let s:gui0E        = "b21889"
-let g:base16_gui0E = "b21889"
+let g:tinted_gui0E = "b21889"
 let s:gui0F        = "c77c48"
+let g:tinted_gui0F = "c77c48"
+
+" Legacy
+let g:base16_gui00 = "282b35"
+let g:base16_gui01 = "3d4048"
+let g:base16_gui02 = "53555d"
+let g:base16_gui03 = "686a71"
+let g:base16_gui04 = "7e8086"
+let g:base16_gui05 = "939599"
+let g:base16_gui06 = "a9aaae"
+let g:base16_gui07 = "bebfc2"
+let g:base16_gui08 = "b21889"
+let g:base16_gui09 = "786dc5"
+let g:base16_gui0A = "438288"
+let g:base16_gui0B = "df0002"
+let g:base16_gui0C = "00a0be"
+let g:base16_gui0D = "790ead"
+let g:base16_gui0E = "b21889"
 let g:base16_gui0F = "c77c48"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#bebfc2",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-zenbones.vim
+++ b/colors/base16-zenbones.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Zenbones
 " Scheme author: mcchrish
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-zenbones.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/zenbones.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/zenbones.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "191919"
-let g:base16_gui00 = "191919"
+let g:tinted_gui00 = "191919"
 let s:gui01        = "de6e7c"
-let g:base16_gui01 = "de6e7c"
+let g:tinted_gui01 = "de6e7c"
 let s:gui02        = "819b69"
-let g:base16_gui02 = "819b69"
+let g:tinted_gui02 = "819b69"
 let s:gui03        = "b77e64"
-let g:base16_gui03 = "b77e64"
+let g:tinted_gui03 = "b77e64"
 let s:gui04        = "6099c0"
-let g:base16_gui04 = "6099c0"
+let g:tinted_gui04 = "6099c0"
 let s:gui05        = "b279a7"
-let g:base16_gui05 = "b279a7"
+let g:tinted_gui05 = "b279a7"
 let s:gui06        = "66a5ad"
-let g:base16_gui06 = "66a5ad"
+let g:tinted_gui06 = "66a5ad"
 let s:gui07        = "bbbbbb"
-let g:base16_gui07 = "bbbbbb"
+let g:tinted_gui07 = "bbbbbb"
 let s:gui08        = "3d3839"
-let g:base16_gui08 = "3d3839"
+let g:tinted_gui08 = "3d3839"
 let s:gui09        = "e8838f"
-let g:base16_gui09 = "e8838f"
+let g:tinted_gui09 = "e8838f"
 let s:gui0A        = "8bae68"
-let g:base16_gui0A = "8bae68"
+let g:tinted_gui0A = "8bae68"
 let s:gui0B        = "d68c67"
-let g:base16_gui0B = "d68c67"
+let g:tinted_gui0B = "d68c67"
 let s:gui0C        = "61abda"
-let g:base16_gui0C = "61abda"
+let g:tinted_gui0C = "61abda"
 let s:gui0D        = "cf86c1"
-let g:base16_gui0D = "cf86c1"
+let g:tinted_gui0D = "cf86c1"
 let s:gui0E        = "65b8c1"
-let g:base16_gui0E = "65b8c1"
+let g:tinted_gui0E = "65b8c1"
 let s:gui0F        = "8e8e8e"
+let g:tinted_gui0F = "8e8e8e"
+
+" Legacy
+let g:base16_gui00 = "191919"
+let g:base16_gui01 = "de6e7c"
+let g:base16_gui02 = "819b69"
+let g:base16_gui03 = "b77e64"
+let g:base16_gui04 = "6099c0"
+let g:base16_gui05 = "b279a7"
+let g:base16_gui06 = "66a5ad"
+let g:base16_gui07 = "bbbbbb"
+let g:base16_gui08 = "3d3839"
+let g:base16_gui09 = "e8838f"
+let g:base16_gui0A = "8bae68"
+let g:base16_gui0B = "d68c67"
+let g:base16_gui0C = "61abda"
+let g:base16_gui0D = "cf86c1"
+let g:base16_gui0E = "65b8c1"
 let g:base16_gui0F = "8e8e8e"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#bbbbbb",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -1,6 +1,6 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: Zenburn
 " Scheme author: elnawe
 " Template author: Tinted Theming (https://github.com/tinted-theming)
@@ -11,42 +11,63 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-zenburn.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/zenburn.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/zenburn.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "383838"
-let g:base16_gui00 = "383838"
+let g:tinted_gui00 = "383838"
 let s:gui01        = "404040"
-let g:base16_gui01 = "404040"
+let g:tinted_gui01 = "404040"
 let s:gui02        = "606060"
-let g:base16_gui02 = "606060"
+let g:tinted_gui02 = "606060"
 let s:gui03        = "6f6f6f"
-let g:base16_gui03 = "6f6f6f"
+let g:tinted_gui03 = "6f6f6f"
 let s:gui04        = "808080"
-let g:base16_gui04 = "808080"
+let g:tinted_gui04 = "808080"
 let s:gui05        = "dcdccc"
-let g:base16_gui05 = "dcdccc"
+let g:tinted_gui05 = "dcdccc"
 let s:gui06        = "c0c0c0"
-let g:base16_gui06 = "c0c0c0"
+let g:tinted_gui06 = "c0c0c0"
 let s:gui07        = "ffffff"
-let g:base16_gui07 = "ffffff"
+let g:tinted_gui07 = "ffffff"
 let s:gui08        = "dca3a3"
-let g:base16_gui08 = "dca3a3"
+let g:tinted_gui08 = "dca3a3"
 let s:gui09        = "dfaf8f"
-let g:base16_gui09 = "dfaf8f"
+let g:tinted_gui09 = "dfaf8f"
 let s:gui0A        = "e0cf9f"
-let g:base16_gui0A = "e0cf9f"
+let g:tinted_gui0A = "e0cf9f"
 let s:gui0B        = "5f7f5f"
-let g:base16_gui0B = "5f7f5f"
+let g:tinted_gui0B = "5f7f5f"
 let s:gui0C        = "93e0e3"
-let g:base16_gui0C = "93e0e3"
+let g:tinted_gui0C = "93e0e3"
 let s:gui0D        = "7cb8bb"
-let g:base16_gui0D = "7cb8bb"
+let g:tinted_gui0D = "7cb8bb"
 let s:gui0E        = "dc8cc3"
-let g:base16_gui0E = "dc8cc3"
+let g:tinted_gui0E = "dc8cc3"
 let s:gui0F        = "000000"
+let g:tinted_gui0F = "000000"
+
+" Legacy
+let g:base16_gui00 = "383838"
+let g:base16_gui01 = "404040"
+let g:base16_gui02 = "606060"
+let g:base16_gui03 = "6f6f6f"
+let g:base16_gui04 = "808080"
+let g:base16_gui05 = "dcdccc"
+let g:base16_gui06 = "c0c0c0"
+let g:base16_gui07 = "ffffff"
+let g:base16_gui08 = "dca3a3"
+let g:base16_gui09 = "dfaf8f"
+let g:base16_gui0A = "e0cf9f"
+let g:base16_gui0B = "5f7f5f"
+let g:base16_gui0C = "93e0e3"
+let g:base16_gui0D = "7cb8bb"
+let g:base16_gui0E = "dc8cc3"
 let g:base16_gui0F = "000000"
 
 " Terminal color definitions
@@ -70,10 +91,10 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -145,7 +166,8 @@ elseif has("terminal")
         \ "#ffffff",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -421,7 +443,6 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
@@ -629,7 +650,7 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML

--- a/colors/base24-ayu-dark.vim
+++ b/colors/base24-ayu-dark.vim
@@ -1,0 +1,688 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Ayu Dark
+" Scheme author: Jamy Golden (https://github.com/JamyGolden)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/base24-ayu-dark.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "0f131a"
+let g:base24_gui00 = "0f131a"
+let s:gui01        = "122132"
+let g:base24_gui01 = "122132"
+let s:gui02        = "202229"
+let g:base24_gui02 = "202229"
+let s:gui03        = "565b66"
+let g:base24_gui03 = "565b66"
+let s:gui04        = "898f99"
+let g:base24_gui04 = "898f99"
+let s:gui05        = "bfbdb6"
+let g:base24_gui05 = "bfbdb6"
+let s:gui06        = "e6e1cf"
+let g:base24_gui06 = "e6e1cf"
+let s:gui07        = "f3f4f5"
+let g:base24_gui07 = "f3f4f5"
+let s:gui08        = "f07178"
+let g:base24_gui08 = "f07178"
+let s:gui09        = "f29668"
+let g:base24_gui09 = "f29668"
+let s:gui0A        = "ffb454"
+let g:base24_gui0A = "ffb454"
+let s:gui0B        = "aad94c"
+let g:base24_gui0B = "aad94c"
+let s:gui0C        = "95e6cb"
+let g:base24_gui0C = "95e6cb"
+let s:gui0D        = "59c2ff"
+let g:base24_gui0D = "59c2ff"
+let s:gui0E        = "6c5980"
+let g:base24_gui0E = "6c5980"
+let s:gui0F        = "e6b673"
+let s:gui10        = "0d1017"
+let g:base24_gui10 = "0d1017"
+let s:gui11        = "06070a"
+let g:base24_gui11 = "06070a"
+let s:gui12        = "d95757"
+let g:base24_gui12 = "d95757"
+let s:gui13        = "ff8f40"
+let g:base24_gui13 = "ff8f40"
+let s:gui14        = "7fd962"
+let g:base24_gui14 = "7fd962"
+let s:gui15        = "95e6cb"
+let g:base24_gui15 = "95e6cb"
+let s:gui16        = "409fff"
+let g:base24_gui16 = "409fff"
+let s:gui17        = "d2a6ff"
+let g:base24_gui17 = "d2a6ff"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#0f131a"
+  let g:terminal_color_1 =  "#f07178"
+  let g:terminal_color_2 =  "#aad94c"
+  let g:terminal_color_3 =  "#ffb454"
+  let g:terminal_color_4 =  "#59c2ff"
+  let g:terminal_color_5 =  "#6c5980"
+  let g:terminal_color_6 =  "#95e6cb"
+  let g:terminal_color_7 =  "#bfbdb6"
+  let g:terminal_color_8 =  "#565b66"
+  let g:terminal_color_9 =  "#d95757"
+  let g:terminal_color_10 = "#7fd962"
+  let g:terminal_color_11 = "#ff8f40"
+  let g:terminal_color_12 = "#409fff"
+  let g:terminal_color_13 = "#d2a6ff"
+  let g:terminal_color_14 = "#95e6cb"
+  let g:terminal_color_15 = "#f3f4f5"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#0f131a",
+        \ "#f07178",
+        \ "#aad94c",
+        \ "#f29668",
+        \ "#59c2ff",
+        \ "#6c5980",
+        \ "#95e6cb",
+        \ "#e6e1cf",
+        \ "#202229",
+        \ "#d95757",
+        \ "#7fd962",
+        \ "#ff8f40",
+        \ "#409fff",
+        \ "#d2a6ff",
+        \ "#95e6cb",
+        \ "#f3f4f5",
+        \ ]
+endif
+if exists("base24_background_transparent") && base24_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-ayu-dark"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-brogrammer.vim
+++ b/colors/base24-brogrammer.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Brogrammer
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/brogrammer.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "131313"
+let g:tinted_gui00 = "131313"
+let s:gui01        = "1f1f1f"
+let g:tinted_gui01 = "1f1f1f"
+let s:gui02        = "2a3141"
+let g:tinted_gui02 = "2a3141"
+let s:gui03        = "343d50"
+let g:tinted_gui03 = "343d50"
+let s:gui04        = "d6dae4"
+let g:tinted_gui04 = "d6dae4"
+let s:gui05        = "c1c8d7"
+let g:tinted_gui05 = "c1c8d7"
+let s:gui06        = "e3e6ed"
+let g:tinted_gui06 = "e3e6ed"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "f71118"
+let g:tinted_gui08 = "f71118"
+let s:gui09        = "ecb90f"
+let g:tinted_gui09 = "ecb90f"
+let s:gui0A        = "0f80d5"
+let g:tinted_gui0A = "0f80d5"
+let s:gui0B        = "2cc55d"
+let g:tinted_gui0B = "2cc55d"
+let s:gui0C        = "0f80d5"
+let g:tinted_gui0C = "0f80d5"
+let s:gui0D        = "2a84d2"
+let g:tinted_gui0D = "2a84d2"
+let s:gui0E        = "4e59b7"
+let g:tinted_gui0E = "4e59b7"
+let s:gui0F        = "7b080c"
+let g:tinted_gui0f = "7b080c"
+let s:gui10        = "0a0a0a"
+let g:tinted_gui10 = "0a0a0a"
+let s:gui11        = "020202"
+let g:tinted_gui11 = "020202"
+let s:gui12        = "de342e"
+let g:tinted_gui12 = "de342e"
+let s:gui13        = "f2bd09"
+let g:tinted_gui13 = "f2bd09"
+let s:gui14        = "1dd260"
+let g:tinted_gui14 = "1dd260"
+let s:gui15        = "289af0"
+let g:tinted_gui15 = "289af0"
+let s:gui16        = "509bdc"
+let g:tinted_gui16 = "509bdc"
+let s:gui17        = "524fb9"
+let g:tinted_gui17 = "524fb9"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#131313"
+  let g:terminal_color_1 =  "#f71118"
+  let g:terminal_color_2 =  "#2cc55d"
+  let g:terminal_color_3 =  "#0f80d5"
+  let g:terminal_color_4 =  "#2a84d2"
+  let g:terminal_color_5 =  "#4e59b7"
+  let g:terminal_color_6 =  "#0f80d5"
+  let g:terminal_color_7 =  "#c1c8d7"
+  let g:terminal_color_8 =  "#343d50"
+  let g:terminal_color_9 =  "#de342e"
+  let g:terminal_color_10 = "#1dd260"
+  let g:terminal_color_11 = "#f2bd09"
+  let g:terminal_color_12 = "#509bdc"
+  let g:terminal_color_13 = "#524fb9"
+  let g:terminal_color_14 = "#289af0"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#131313",
+        \ "#f71118",
+        \ "#2cc55d",
+        \ "#ecb90f",
+        \ "#2a84d2",
+        \ "#4e59b7",
+        \ "#0f80d5",
+        \ "#e3e6ed",
+        \ "#2a3141",
+        \ "#de342e",
+        \ "#1dd260",
+        \ "#f2bd09",
+        \ "#509bdc",
+        \ "#524fb9",
+        \ "#289af0",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-brogrammer"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-chalk.vim
+++ b/colors/base24-chalk.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Chalk
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/chalk.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "151515"
+let g:tinted_gui00 = "151515"
+let s:gui01        = "202020"
+let g:tinted_gui01 = "202020"
+let s:gui02        = "303030"
+let g:tinted_gui02 = "303030"
+let s:gui03        = "505050"
+let g:tinted_gui03 = "505050"
+let s:gui04        = "b0b0b0"
+let g:tinted_gui04 = "b0b0b0"
+let s:gui05        = "d0d0d0"
+let g:tinted_gui05 = "d0d0d0"
+let s:gui06        = "e0e0e0"
+let g:tinted_gui06 = "e0e0e0"
+let s:gui07        = "f5f5f5"
+let g:tinted_gui07 = "f5f5f5"
+let s:gui08        = "fa859c"
+let g:tinted_gui08 = "fa859c"
+let s:gui09        = "ea9971"
+let g:tinted_gui09 = "ea9971"
+let s:gui0A        = "ddb26f"
+let g:tinted_gui0A = "ddb26f"
+let s:gui0B        = "a1bb54"
+let g:tinted_gui0B = "a1bb54"
+let s:gui0C        = "10bcad"
+let g:tinted_gui0C = "10bcad"
+let s:gui0D        = "5ab9ed"
+let g:tinted_gui0D = "5ab9ed"
+let s:gui0E        = "db8fea"
+let g:tinted_gui0E = "db8fea"
+let s:gui0F        = "deaf8f"
+let g:tinted_gui0f = "deaf8f"
+let s:gui10        = "0b0b0b"
+let g:tinted_gui10 = "0b0b0b"
+let s:gui11        = "060606"
+let g:tinted_gui11 = "060606"
+let s:gui12        = "fb9fb1"
+let g:tinted_gui12 = "fb9fb1"
+let s:gui13        = "eda987"
+let g:tinted_gui13 = "eda987"
+let s:gui14        = "acc267"
+let g:tinted_gui14 = "acc267"
+let s:gui15        = "12cfc0"
+let g:tinted_gui15 = "12cfc0"
+let s:gui16        = "6fc2ef"
+let g:tinted_gui16 = "6fc2ef"
+let s:gui17        = "e1a3ee"
+let g:tinted_gui17 = "e1a3ee"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#151515"
+  let g:terminal_color_1 =  "#fa859c"
+  let g:terminal_color_2 =  "#a1bb54"
+  let g:terminal_color_3 =  "#ddb26f"
+  let g:terminal_color_4 =  "#5ab9ed"
+  let g:terminal_color_5 =  "#db8fea"
+  let g:terminal_color_6 =  "#10bcad"
+  let g:terminal_color_7 =  "#d0d0d0"
+  let g:terminal_color_8 =  "#505050"
+  let g:terminal_color_9 =  "#fb9fb1"
+  let g:terminal_color_10 = "#acc267"
+  let g:terminal_color_11 = "#eda987"
+  let g:terminal_color_12 = "#6fc2ef"
+  let g:terminal_color_13 = "#e1a3ee"
+  let g:terminal_color_14 = "#12cfc0"
+  let g:terminal_color_15 = "#f5f5f5"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#151515",
+        \ "#fa859c",
+        \ "#a1bb54",
+        \ "#ea9971",
+        \ "#5ab9ed",
+        \ "#db8fea",
+        \ "#10bcad",
+        \ "#e0e0e0",
+        \ "#303030",
+        \ "#fb9fb1",
+        \ "#acc267",
+        \ "#eda987",
+        \ "#6fc2ef",
+        \ "#e1a3ee",
+        \ "#12cfc0",
+        \ "#f5f5f5",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-chalk"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-deep-oceanic-next.vim
+++ b/colors/base24-deep-oceanic-next.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Deep Oceanic Next
+" Scheme author: spearkkk (https://github.com/spearkkk/deep-oceanic-next)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/deep-oceanic-next.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "003b46"
+let g:tinted_gui00 = "003b46"
+let s:gui01        = "004f5e"
+let g:tinted_gui01 = "004f5e"
+let s:gui02        = "006374"
+let g:tinted_gui02 = "006374"
+let s:gui03        = "007a8a"
+let g:tinted_gui03 = "007a8a"
+let s:gui04        = "0093a3"
+let g:tinted_gui04 = "0093a3"
+let s:gui05        = "dce3e8"
+let g:tinted_gui05 = "dce3e8"
+let s:gui06        = "e6ebf0"
+let g:tinted_gui06 = "e6ebf0"
+let s:gui07        = "f0f5f5"
+let g:tinted_gui07 = "f0f5f5"
+let s:gui08        = "e6454b"
+let g:tinted_gui08 = "e6454b"
+let s:gui09        = "ff6a4b"
+let g:tinted_gui09 = "ff6a4b"
+let s:gui0A        = "ffcc66"
+let g:tinted_gui0A = "ffcc66"
+let s:gui0B        = "85b57a"
+let g:tinted_gui0B = "85b57a"
+let s:gui0C        = "4da6a6"
+let g:tinted_gui0C = "4da6a6"
+let s:gui0D        = "3a82e6"
+let g:tinted_gui0D = "3a82e6"
+let s:gui0E        = "8c4de6"
+let g:tinted_gui0E = "8c4de6"
+let s:gui0F        = "e673a3"
+let g:tinted_gui0f = "e673a3"
+let s:gui10        = "001114"
+let g:tinted_gui10 = "001114"
+let s:gui11        = "000a0d"
+let g:tinted_gui11 = "000a0d"
+let s:gui12        = "ff5a61"
+let g:tinted_gui12 = "ff5a61"
+let s:gui13        = "ffdd80"
+let g:tinted_gui13 = "ffdd80"
+let s:gui14        = "99d8a0"
+let g:tinted_gui14 = "99d8a0"
+let s:gui15        = "66cccc"
+let g:tinted_gui15 = "66cccc"
+let s:gui16        = "4da6ff"
+let g:tinted_gui16 = "4da6ff"
+let s:gui17        = "a366ff"
+let g:tinted_gui17 = "a366ff"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#003b46"
+  let g:terminal_color_1 =  "#e6454b"
+  let g:terminal_color_2 =  "#85b57a"
+  let g:terminal_color_3 =  "#ffcc66"
+  let g:terminal_color_4 =  "#3a82e6"
+  let g:terminal_color_5 =  "#8c4de6"
+  let g:terminal_color_6 =  "#4da6a6"
+  let g:terminal_color_7 =  "#dce3e8"
+  let g:terminal_color_8 =  "#007a8a"
+  let g:terminal_color_9 =  "#ff5a61"
+  let g:terminal_color_10 = "#99d8a0"
+  let g:terminal_color_11 = "#ffdd80"
+  let g:terminal_color_12 = "#4da6ff"
+  let g:terminal_color_13 = "#a366ff"
+  let g:terminal_color_14 = "#66cccc"
+  let g:terminal_color_15 = "#f0f5f5"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#003b46",
+        \ "#e6454b",
+        \ "#85b57a",
+        \ "#ff6a4b",
+        \ "#3a82e6",
+        \ "#8c4de6",
+        \ "#4da6a6",
+        \ "#e6ebf0",
+        \ "#006374",
+        \ "#ff5a61",
+        \ "#99d8a0",
+        \ "#ffdd80",
+        \ "#4da6ff",
+        \ "#a366ff",
+        \ "#66cccc",
+        \ "#f0f5f5",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-deep-oceanic-next"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-dracula.vim
+++ b/colors/base24-dracula.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Dracula
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/dracula.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "282a36"
+let g:tinted_gui00 = "282a36"
+let s:gui01        = "363447"
+let g:tinted_gui01 = "363447"
+let s:gui02        = "44475a"
+let g:tinted_gui02 = "44475a"
+let s:gui03        = "6272a4"
+let g:tinted_gui03 = "6272a4"
+let s:gui04        = "9ea8c7"
+let g:tinted_gui04 = "9ea8c7"
+let s:gui05        = "f8f8f2"
+let g:tinted_gui05 = "f8f8f2"
+let s:gui06        = "f0f1f4"
+let g:tinted_gui06 = "f0f1f4"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "ff5555"
+let g:tinted_gui08 = "ff5555"
+let s:gui09        = "ffb86c"
+let g:tinted_gui09 = "ffb86c"
+let s:gui0A        = "f1fa8c"
+let g:tinted_gui0A = "f1fa8c"
+let s:gui0B        = "50fa7b"
+let g:tinted_gui0B = "50fa7b"
+let s:gui0C        = "8be9fd"
+let g:tinted_gui0C = "8be9fd"
+let s:gui0D        = "80bfff"
+let g:tinted_gui0D = "80bfff"
+let s:gui0E        = "ff79c6"
+let g:tinted_gui0E = "ff79c6"
+let s:gui0F        = "bd93f9"
+let g:tinted_gui0f = "bd93f9"
+let s:gui10        = "1e2029"
+let g:tinted_gui10 = "1e2029"
+let s:gui11        = "16171d"
+let g:tinted_gui11 = "16171d"
+let s:gui12        = "f28c8c"
+let g:tinted_gui12 = "f28c8c"
+let s:gui13        = "eef5a3"
+let g:tinted_gui13 = "eef5a3"
+let s:gui14        = "a3f5b8"
+let g:tinted_gui14 = "a3f5b8"
+let s:gui15        = "baedf7"
+let g:tinted_gui15 = "baedf7"
+let s:gui16        = "a3ccf5"
+let g:tinted_gui16 = "a3ccf5"
+let s:gui17        = "f5a3d2"
+let g:tinted_gui17 = "f5a3d2"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#282a36"
+  let g:terminal_color_1 =  "#ff5555"
+  let g:terminal_color_2 =  "#50fa7b"
+  let g:terminal_color_3 =  "#f1fa8c"
+  let g:terminal_color_4 =  "#80bfff"
+  let g:terminal_color_5 =  "#ff79c6"
+  let g:terminal_color_6 =  "#8be9fd"
+  let g:terminal_color_7 =  "#f8f8f2"
+  let g:terminal_color_8 =  "#6272a4"
+  let g:terminal_color_9 =  "#f28c8c"
+  let g:terminal_color_10 = "#a3f5b8"
+  let g:terminal_color_11 = "#eef5a3"
+  let g:terminal_color_12 = "#a3ccf5"
+  let g:terminal_color_13 = "#f5a3d2"
+  let g:terminal_color_14 = "#baedf7"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#282a36",
+        \ "#ff5555",
+        \ "#50fa7b",
+        \ "#ffb86c",
+        \ "#80bfff",
+        \ "#ff79c6",
+        \ "#8be9fd",
+        \ "#f0f1f4",
+        \ "#44475a",
+        \ "#f28c8c",
+        \ "#a3f5b8",
+        \ "#eef5a3",
+        \ "#a3ccf5",
+        \ "#f5a3d2",
+        \ "#baedf7",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-dracula"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-espresso.vim
+++ b/colors/base24-espresso.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Espresso
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/espresso.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "262626"
+let g:tinted_gui00 = "262626"
+let s:gui01        = "343434"
+let g:tinted_gui01 = "343434"
+let s:gui02        = "535353"
+let g:tinted_gui02 = "535353"
+let s:gui03        = "797979"
+let g:tinted_gui03 = "797979"
+let s:gui04        = "a0a09f"
+let g:tinted_gui04 = "a0a09f"
+let s:gui05        = "c7c7c5"
+let g:tinted_gui05 = "c7c7c5"
+let s:gui06        = "eeeeec"
+let g:tinted_gui06 = "eeeeec"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "d25151"
+let g:tinted_gui08 = "d25151"
+let s:gui09        = "ffc66d"
+let g:tinted_gui09 = "ffc66d"
+let s:gui0A        = "8ab7d9"
+let g:tinted_gui0A = "8ab7d9"
+let s:gui0B        = "a5c261"
+let g:tinted_gui0B = "a5c261"
+let s:gui0C        = "bed6ff"
+let g:tinted_gui0C = "bed6ff"
+let s:gui0D        = "6c99bb"
+let g:tinted_gui0D = "6c99bb"
+let s:gui0E        = "d197d9"
+let g:tinted_gui0E = "d197d9"
+let s:gui0F        = "692828"
+let g:tinted_gui0f = "692828"
+let s:gui10        = "373737"
+let g:tinted_gui10 = "373737"
+let s:gui11        = "1b1b1b"
+let g:tinted_gui11 = "1b1b1b"
+let s:gui12        = "f00c0c"
+let g:tinted_gui12 = "f00c0c"
+let s:gui13        = "e1e38b"
+let g:tinted_gui13 = "e1e38b"
+let s:gui14        = "c2e075"
+let g:tinted_gui14 = "c2e075"
+let s:gui15        = "dcf3ff"
+let g:tinted_gui15 = "dcf3ff"
+let s:gui16        = "8ab7d9"
+let g:tinted_gui16 = "8ab7d9"
+let s:gui17        = "efb5f7"
+let g:tinted_gui17 = "efb5f7"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#262626"
+  let g:terminal_color_1 =  "#d25151"
+  let g:terminal_color_2 =  "#a5c261"
+  let g:terminal_color_3 =  "#8ab7d9"
+  let g:terminal_color_4 =  "#6c99bb"
+  let g:terminal_color_5 =  "#d197d9"
+  let g:terminal_color_6 =  "#bed6ff"
+  let g:terminal_color_7 =  "#c7c7c5"
+  let g:terminal_color_8 =  "#797979"
+  let g:terminal_color_9 =  "#f00c0c"
+  let g:terminal_color_10 = "#c2e075"
+  let g:terminal_color_11 = "#e1e38b"
+  let g:terminal_color_12 = "#8ab7d9"
+  let g:terminal_color_13 = "#efb5f7"
+  let g:terminal_color_14 = "#dcf3ff"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#262626",
+        \ "#d25151",
+        \ "#a5c261",
+        \ "#ffc66d",
+        \ "#6c99bb",
+        \ "#d197d9",
+        \ "#bed6ff",
+        \ "#eeeeec",
+        \ "#535353",
+        \ "#f00c0c",
+        \ "#c2e075",
+        \ "#e1e38b",
+        \ "#8ab7d9",
+        \ "#efb5f7",
+        \ "#dcf3ff",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-espresso"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-flat.vim
+++ b/colors/base24-flat.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Flat
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/flat.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "082845"
+let g:tinted_gui00 = "082845"
+let s:gui01        = "1d2845"
+let g:tinted_gui01 = "1d2845"
+let s:gui02        = "2e2e45"
+let g:tinted_gui02 = "2e2e45"
+let s:gui03        = "444e5b"
+let g:tinted_gui03 = "444e5b"
+let s:gui04        = "68717b"
+let g:tinted_gui04 = "68717b"
+let s:gui05        = "8c939a"
+let g:tinted_gui05 = "8c939a"
+let s:gui06        = "b0b6ba"
+let g:tinted_gui06 = "b0b6ba"
+let s:gui07        = "e7eced"
+let g:tinted_gui07 = "e7eced"
+let s:gui08        = "a82320"
+let g:tinted_gui08 = "a82320"
+let s:gui09        = "e58d11"
+let g:tinted_gui09 = "e58d11"
+let s:gui0A        = "3c7dd2"
+let g:tinted_gui0A = "3c7dd2"
+let s:gui0B        = "2d9440"
+let g:tinted_gui0B = "2d9440"
+let s:gui0C        = "2c9370"
+let g:tinted_gui0C = "2c9370"
+let s:gui0D        = "3167ac"
+let g:tinted_gui0D = "3167ac"
+let s:gui0E        = "781aa0"
+let g:tinted_gui0E = "781aa0"
+let s:gui0F        = "541110"
+let g:tinted_gui0f = "541110"
+let s:gui10        = "002240"
+let g:tinted_gui10 = "002240"
+let s:gui11        = "001629"
+let g:tinted_gui11 = "001629"
+let s:gui12        = "d4312e"
+let g:tinted_gui12 = "d4312e"
+let s:gui13        = "e5be0c"
+let g:tinted_gui13 = "e5be0c"
+let s:gui14        = "32a548"
+let g:tinted_gui14 = "32a548"
+let s:gui15        = "35b387"
+let g:tinted_gui15 = "35b387"
+let s:gui16        = "3c7dd2"
+let g:tinted_gui16 = "3c7dd2"
+let s:gui17        = "8230a7"
+let g:tinted_gui17 = "8230a7"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#082845"
+  let g:terminal_color_1 =  "#a82320"
+  let g:terminal_color_2 =  "#2d9440"
+  let g:terminal_color_3 =  "#3c7dd2"
+  let g:terminal_color_4 =  "#3167ac"
+  let g:terminal_color_5 =  "#781aa0"
+  let g:terminal_color_6 =  "#2c9370"
+  let g:terminal_color_7 =  "#8c939a"
+  let g:terminal_color_8 =  "#444e5b"
+  let g:terminal_color_9 =  "#d4312e"
+  let g:terminal_color_10 = "#32a548"
+  let g:terminal_color_11 = "#e5be0c"
+  let g:terminal_color_12 = "#3c7dd2"
+  let g:terminal_color_13 = "#8230a7"
+  let g:terminal_color_14 = "#35b387"
+  let g:terminal_color_15 = "#e7eced"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#082845",
+        \ "#a82320",
+        \ "#2d9440",
+        \ "#e58d11",
+        \ "#3167ac",
+        \ "#781aa0",
+        \ "#2c9370",
+        \ "#b0b6ba",
+        \ "#2e2e45",
+        \ "#d4312e",
+        \ "#32a548",
+        \ "#e5be0c",
+        \ "#3c7dd2",
+        \ "#8230a7",
+        \ "#35b387",
+        \ "#e7eced",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-flat"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-framer.vim
+++ b/colors/base24-framer.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Framer
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/framer.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "111111"
+let g:tinted_gui00 = "111111"
+let s:gui01        = "141414"
+let g:tinted_gui01 = "141414"
+let s:gui02        = "414141"
+let g:tinted_gui02 = "414141"
+let s:gui03        = "636363"
+let g:tinted_gui03 = "636363"
+let s:gui04        = "868686"
+let g:tinted_gui04 = "868686"
+let s:gui05        = "a9a9a9"
+let g:tinted_gui05 = "a9a9a9"
+let s:gui06        = "cccccc"
+let g:tinted_gui06 = "cccccc"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "ff5555"
+let g:tinted_gui08 = "ff5555"
+let s:gui09        = "ffcc33"
+let g:tinted_gui09 = "ffcc33"
+let s:gui0A        = "33bbff"
+let g:tinted_gui0A = "33bbff"
+let s:gui0B        = "98ec65"
+let g:tinted_gui0B = "98ec65"
+let s:gui0C        = "88ddff"
+let g:tinted_gui0C = "88ddff"
+let s:gui0D        = "00aaff"
+let g:tinted_gui0D = "00aaff"
+let s:gui0E        = "aa88ff"
+let g:tinted_gui0E = "aa88ff"
+let s:gui0F        = "7f2a2a"
+let g:tinted_gui0f = "7f2a2a"
+let s:gui10        = "2b2b2b"
+let g:tinted_gui10 = "2b2b2b"
+let s:gui11        = "151515"
+let g:tinted_gui11 = "151515"
+let s:gui12        = "ff8888"
+let g:tinted_gui12 = "ff8888"
+let s:gui13        = "ffd966"
+let g:tinted_gui13 = "ffd966"
+let s:gui14        = "b6f292"
+let g:tinted_gui14 = "b6f292"
+let s:gui15        = "bbecff"
+let g:tinted_gui15 = "bbecff"
+let s:gui16        = "33bbff"
+let g:tinted_gui16 = "33bbff"
+let s:gui17        = "cebbff"
+let g:tinted_gui17 = "cebbff"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#111111"
+  let g:terminal_color_1 =  "#ff5555"
+  let g:terminal_color_2 =  "#98ec65"
+  let g:terminal_color_3 =  "#33bbff"
+  let g:terminal_color_4 =  "#00aaff"
+  let g:terminal_color_5 =  "#aa88ff"
+  let g:terminal_color_6 =  "#88ddff"
+  let g:terminal_color_7 =  "#a9a9a9"
+  let g:terminal_color_8 =  "#636363"
+  let g:terminal_color_9 =  "#ff8888"
+  let g:terminal_color_10 = "#b6f292"
+  let g:terminal_color_11 = "#ffd966"
+  let g:terminal_color_12 = "#33bbff"
+  let g:terminal_color_13 = "#cebbff"
+  let g:terminal_color_14 = "#bbecff"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#111111",
+        \ "#ff5555",
+        \ "#98ec65",
+        \ "#ffcc33",
+        \ "#00aaff",
+        \ "#aa88ff",
+        \ "#88ddff",
+        \ "#cccccc",
+        \ "#414141",
+        \ "#ff8888",
+        \ "#b6f292",
+        \ "#ffd966",
+        \ "#33bbff",
+        \ "#cebbff",
+        \ "#bbecff",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-framer"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-github.vim
+++ b/colors/base24-github.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Github
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/github.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "f4f4f4"
+let g:tinted_gui00 = "f4f4f4"
+let s:gui01        = "3e3e3e"
+let g:tinted_gui01 = "3e3e3e"
+let s:gui02        = "666666"
+let g:tinted_gui02 = "666666"
+let s:gui03        = "8c8c8c"
+let g:tinted_gui03 = "8c8c8c"
+let s:gui04        = "b2b2b2"
+let g:tinted_gui04 = "b2b2b2"
+let s:gui05        = "d8d8d8"
+let g:tinted_gui05 = "d8d8d8"
+let s:gui06        = "ffffff"
+let g:tinted_gui06 = "ffffff"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "970b16"
+let g:tinted_gui08 = "970b16"
+let s:gui09        = "f8eec7"
+let g:tinted_gui09 = "f8eec7"
+let s:gui0A        = "2e6cba"
+let g:tinted_gui0A = "2e6cba"
+let s:gui0B        = "07962a"
+let g:tinted_gui0B = "07962a"
+let s:gui0C        = "89d1ec"
+let g:tinted_gui0C = "89d1ec"
+let s:gui0D        = "003e8a"
+let g:tinted_gui0D = "003e8a"
+let s:gui0E        = "e94691"
+let g:tinted_gui0E = "e94691"
+let s:gui0F        = "4b050b"
+let g:tinted_gui0f = "4b050b"
+let s:gui10        = "444444"
+let g:tinted_gui10 = "444444"
+let s:gui11        = "222222"
+let g:tinted_gui11 = "222222"
+let s:gui12        = "de0000"
+let g:tinted_gui12 = "de0000"
+let s:gui13        = "f1d007"
+let g:tinted_gui13 = "f1d007"
+let s:gui14        = "87d5a2"
+let g:tinted_gui14 = "87d5a2"
+let s:gui15        = "1cfafe"
+let g:tinted_gui15 = "1cfafe"
+let s:gui16        = "2e6cba"
+let g:tinted_gui16 = "2e6cba"
+let s:gui17        = "ffa29f"
+let g:tinted_gui17 = "ffa29f"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#f4f4f4"
+  let g:terminal_color_1 =  "#970b16"
+  let g:terminal_color_2 =  "#07962a"
+  let g:terminal_color_3 =  "#2e6cba"
+  let g:terminal_color_4 =  "#003e8a"
+  let g:terminal_color_5 =  "#e94691"
+  let g:terminal_color_6 =  "#89d1ec"
+  let g:terminal_color_7 =  "#d8d8d8"
+  let g:terminal_color_8 =  "#8c8c8c"
+  let g:terminal_color_9 =  "#de0000"
+  let g:terminal_color_10 = "#87d5a2"
+  let g:terminal_color_11 = "#f1d007"
+  let g:terminal_color_12 = "#2e6cba"
+  let g:terminal_color_13 = "#ffa29f"
+  let g:terminal_color_14 = "#1cfafe"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#f4f4f4",
+        \ "#970b16",
+        \ "#07962a",
+        \ "#f8eec7",
+        \ "#003e8a",
+        \ "#e94691",
+        \ "#89d1ec",
+        \ "#ffffff",
+        \ "#666666",
+        \ "#de0000",
+        \ "#87d5a2",
+        \ "#f1d007",
+        \ "#2e6cba",
+        \ "#ffa29f",
+        \ "#1cfafe",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-github"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-hardcore.vim
+++ b/colors/base24-hardcore.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Hardcore
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/hardcore.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "111111"
+let g:tinted_gui00 = "111111"
+let s:gui01        = "141414"
+let g:tinted_gui01 = "141414"
+let s:gui02        = "414141"
+let g:tinted_gui02 = "414141"
+let s:gui03        = "636363"
+let g:tinted_gui03 = "636363"
+let s:gui04        = "868686"
+let g:tinted_gui04 = "868686"
+let s:gui05        = "a9a9a9"
+let g:tinted_gui05 = "a9a9a9"
+let s:gui06        = "cccccc"
+let g:tinted_gui06 = "cccccc"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "ff5555"
+let g:tinted_gui08 = "ff5555"
+let s:gui09        = "ffcc33"
+let g:tinted_gui09 = "ffcc33"
+let s:gui0A        = "33bbff"
+let g:tinted_gui0A = "33bbff"
+let s:gui0B        = "98ec65"
+let g:tinted_gui0B = "98ec65"
+let s:gui0C        = "88ddff"
+let g:tinted_gui0C = "88ddff"
+let s:gui0D        = "00aaff"
+let g:tinted_gui0D = "00aaff"
+let s:gui0E        = "aa88ff"
+let g:tinted_gui0E = "aa88ff"
+let s:gui0F        = "7f2a2a"
+let g:tinted_gui0f = "7f2a2a"
+let s:gui10        = "0a0a0a"
+let g:tinted_gui10 = "0a0a0a"
+let s:gui11        = "060606"
+let g:tinted_gui11 = "060606"
+let s:gui12        = "ff8888"
+let g:tinted_gui12 = "ff8888"
+let s:gui13        = "ffd966"
+let g:tinted_gui13 = "ffd966"
+let s:gui14        = "b6f292"
+let g:tinted_gui14 = "b6f292"
+let s:gui15        = "bbecff"
+let g:tinted_gui15 = "bbecff"
+let s:gui16        = "33bbff"
+let g:tinted_gui16 = "33bbff"
+let s:gui17        = "cebbff"
+let g:tinted_gui17 = "cebbff"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#111111"
+  let g:terminal_color_1 =  "#ff5555"
+  let g:terminal_color_2 =  "#98ec65"
+  let g:terminal_color_3 =  "#33bbff"
+  let g:terminal_color_4 =  "#00aaff"
+  let g:terminal_color_5 =  "#aa88ff"
+  let g:terminal_color_6 =  "#88ddff"
+  let g:terminal_color_7 =  "#a9a9a9"
+  let g:terminal_color_8 =  "#636363"
+  let g:terminal_color_9 =  "#ff8888"
+  let g:terminal_color_10 = "#b6f292"
+  let g:terminal_color_11 = "#ffd966"
+  let g:terminal_color_12 = "#33bbff"
+  let g:terminal_color_13 = "#cebbff"
+  let g:terminal_color_14 = "#bbecff"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#111111",
+        \ "#ff5555",
+        \ "#98ec65",
+        \ "#ffcc33",
+        \ "#00aaff",
+        \ "#aa88ff",
+        \ "#88ddff",
+        \ "#cccccc",
+        \ "#414141",
+        \ "#ff8888",
+        \ "#b6f292",
+        \ "#ffd966",
+        \ "#33bbff",
+        \ "#cebbff",
+        \ "#bbecff",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-hardcore"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-one-black.vim
+++ b/colors/base24-one-black.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: One Black
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/one-black.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "000000"
+let g:tinted_gui00 = "000000"
+let s:gui01        = "000000"
+let g:tinted_gui01 = "000000"
+let s:gui02        = "4f5666"
+let g:tinted_gui02 = "4f5666"
+let s:gui03        = "545862"
+let g:tinted_gui03 = "545862"
+let s:gui04        = "9196a1"
+let g:tinted_gui04 = "9196a1"
+let s:gui05        = "abb2bf"
+let g:tinted_gui05 = "abb2bf"
+let s:gui06        = "e6e6e6"
+let g:tinted_gui06 = "e6e6e6"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "e05561"
+let g:tinted_gui08 = "e05561"
+let s:gui09        = "d18f52"
+let g:tinted_gui09 = "d18f52"
+let s:gui0A        = "e6b965"
+let g:tinted_gui0A = "e6b965"
+let s:gui0B        = "8cc265"
+let g:tinted_gui0B = "8cc265"
+let s:gui0C        = "42b3c2"
+let g:tinted_gui0C = "42b3c2"
+let s:gui0D        = "4aa5f0"
+let g:tinted_gui0D = "4aa5f0"
+let s:gui0E        = "c162de"
+let g:tinted_gui0E = "c162de"
+let s:gui0F        = "bf4034"
+let g:tinted_gui0f = "bf4034"
+let s:gui10        = "000000"
+let g:tinted_gui10 = "000000"
+let s:gui11        = "000000"
+let g:tinted_gui11 = "000000"
+let s:gui12        = "ff616e"
+let g:tinted_gui12 = "ff616e"
+let s:gui13        = "f0a45d"
+let g:tinted_gui13 = "f0a45d"
+let s:gui14        = "a5e075"
+let g:tinted_gui14 = "a5e075"
+let s:gui15        = "4cd1e0"
+let g:tinted_gui15 = "4cd1e0"
+let s:gui16        = "4dc4ff"
+let g:tinted_gui16 = "4dc4ff"
+let s:gui17        = "de73ff"
+let g:tinted_gui17 = "de73ff"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#000000"
+  let g:terminal_color_1 =  "#e05561"
+  let g:terminal_color_2 =  "#8cc265"
+  let g:terminal_color_3 =  "#e6b965"
+  let g:terminal_color_4 =  "#4aa5f0"
+  let g:terminal_color_5 =  "#c162de"
+  let g:terminal_color_6 =  "#42b3c2"
+  let g:terminal_color_7 =  "#abb2bf"
+  let g:terminal_color_8 =  "#545862"
+  let g:terminal_color_9 =  "#ff616e"
+  let g:terminal_color_10 = "#a5e075"
+  let g:terminal_color_11 = "#f0a45d"
+  let g:terminal_color_12 = "#4dc4ff"
+  let g:terminal_color_13 = "#de73ff"
+  let g:terminal_color_14 = "#4cd1e0"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#000000",
+        \ "#e05561",
+        \ "#8cc265",
+        \ "#d18f52",
+        \ "#4aa5f0",
+        \ "#c162de",
+        \ "#42b3c2",
+        \ "#e6e6e6",
+        \ "#4f5666",
+        \ "#ff616e",
+        \ "#a5e075",
+        \ "#f0a45d",
+        \ "#4dc4ff",
+        \ "#de73ff",
+        \ "#4cd1e0",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-one-black"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-one-dark.vim
+++ b/colors/base24-one-dark.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: One Dark
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/one-dark.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "282c34"
+let g:tinted_gui00 = "282c34"
+let s:gui01        = "3f4451"
+let g:tinted_gui01 = "3f4451"
+let s:gui02        = "4f5666"
+let g:tinted_gui02 = "4f5666"
+let s:gui03        = "545862"
+let g:tinted_gui03 = "545862"
+let s:gui04        = "9196a1"
+let g:tinted_gui04 = "9196a1"
+let s:gui05        = "abb2bf"
+let g:tinted_gui05 = "abb2bf"
+let s:gui06        = "e6e6e6"
+let g:tinted_gui06 = "e6e6e6"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "e05561"
+let g:tinted_gui08 = "e05561"
+let s:gui09        = "d18f52"
+let g:tinted_gui09 = "d18f52"
+let s:gui0A        = "e6b965"
+let g:tinted_gui0A = "e6b965"
+let s:gui0B        = "8cc265"
+let g:tinted_gui0B = "8cc265"
+let s:gui0C        = "42b3c2"
+let g:tinted_gui0C = "42b3c2"
+let s:gui0D        = "4aa5f0"
+let g:tinted_gui0D = "4aa5f0"
+let s:gui0E        = "c162de"
+let g:tinted_gui0E = "c162de"
+let s:gui0F        = "bf4034"
+let g:tinted_gui0f = "bf4034"
+let s:gui10        = "21252b"
+let g:tinted_gui10 = "21252b"
+let s:gui11        = "181a1f"
+let g:tinted_gui11 = "181a1f"
+let s:gui12        = "ff616e"
+let g:tinted_gui12 = "ff616e"
+let s:gui13        = "f0a45d"
+let g:tinted_gui13 = "f0a45d"
+let s:gui14        = "a5e075"
+let g:tinted_gui14 = "a5e075"
+let s:gui15        = "4cd1e0"
+let g:tinted_gui15 = "4cd1e0"
+let s:gui16        = "4dc4ff"
+let g:tinted_gui16 = "4dc4ff"
+let s:gui17        = "de73ff"
+let g:tinted_gui17 = "de73ff"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#282c34"
+  let g:terminal_color_1 =  "#e05561"
+  let g:terminal_color_2 =  "#8cc265"
+  let g:terminal_color_3 =  "#e6b965"
+  let g:terminal_color_4 =  "#4aa5f0"
+  let g:terminal_color_5 =  "#c162de"
+  let g:terminal_color_6 =  "#42b3c2"
+  let g:terminal_color_7 =  "#abb2bf"
+  let g:terminal_color_8 =  "#545862"
+  let g:terminal_color_9 =  "#ff616e"
+  let g:terminal_color_10 = "#a5e075"
+  let g:terminal_color_11 = "#f0a45d"
+  let g:terminal_color_12 = "#4dc4ff"
+  let g:terminal_color_13 = "#de73ff"
+  let g:terminal_color_14 = "#4cd1e0"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#282c34",
+        \ "#e05561",
+        \ "#8cc265",
+        \ "#d18f52",
+        \ "#4aa5f0",
+        \ "#c162de",
+        \ "#42b3c2",
+        \ "#e6e6e6",
+        \ "#4f5666",
+        \ "#ff616e",
+        \ "#a5e075",
+        \ "#f0a45d",
+        \ "#4dc4ff",
+        \ "#de73ff",
+        \ "#4cd1e0",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-one-dark"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-one-light.vim
+++ b/colors/base24-one-light.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: One Light
+" Scheme author: FredHappyface (https://github.com/fredHappyface)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/one-light.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "e7e7e9"
+let g:tinted_gui00 = "e7e7e9"
+let s:gui01        = "dfdfe1"
+let g:tinted_gui01 = "dfdfe1"
+let s:gui02        = "cacace"
+let g:tinted_gui02 = "cacace"
+let s:gui03        = "a0a1a7"
+let g:tinted_gui03 = "a0a1a7"
+let s:gui04        = "696c77"
+let g:tinted_gui04 = "696c77"
+let s:gui05        = "383a42"
+let g:tinted_gui05 = "383a42"
+let s:gui06        = "202227"
+let g:tinted_gui06 = "202227"
+let s:gui07        = "090a0b"
+let g:tinted_gui07 = "090a0b"
+let s:gui08        = "ca1243"
+let g:tinted_gui08 = "ca1243"
+let s:gui09        = "c18401"
+let g:tinted_gui09 = "c18401"
+let s:gui0A        = "febb2a"
+let g:tinted_gui0A = "febb2a"
+let s:gui0B        = "50a14f"
+let g:tinted_gui0B = "50a14f"
+let s:gui0C        = "0184bc"
+let g:tinted_gui0C = "0184bc"
+let s:gui0D        = "4078f2"
+let g:tinted_gui0D = "4078f2"
+let s:gui0E        = "a626a4"
+let g:tinted_gui0E = "a626a4"
+let s:gui0F        = "986801"
+let g:tinted_gui0f = "986801"
+let s:gui10        = "f0f0f1"
+let g:tinted_gui10 = "f0f0f1"
+let s:gui11        = "fafafa"
+let g:tinted_gui11 = "fafafa"
+let s:gui12        = "ec2258"
+let g:tinted_gui12 = "ec2258"
+let s:gui13        = "f4a701"
+let g:tinted_gui13 = "f4a701"
+let s:gui14        = "6db76c"
+let g:tinted_gui14 = "6db76c"
+let s:gui15        = "01a7ef"
+let g:tinted_gui15 = "01a7ef"
+let s:gui16        = "709af5"
+let g:tinted_gui16 = "709af5"
+let s:gui17        = "d02fcd"
+let g:tinted_gui17 = "d02fcd"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#e7e7e9"
+  let g:terminal_color_1 =  "#ca1243"
+  let g:terminal_color_2 =  "#50a14f"
+  let g:terminal_color_3 =  "#febb2a"
+  let g:terminal_color_4 =  "#4078f2"
+  let g:terminal_color_5 =  "#a626a4"
+  let g:terminal_color_6 =  "#0184bc"
+  let g:terminal_color_7 =  "#383a42"
+  let g:terminal_color_8 =  "#a0a1a7"
+  let g:terminal_color_9 =  "#ec2258"
+  let g:terminal_color_10 = "#6db76c"
+  let g:terminal_color_11 = "#f4a701"
+  let g:terminal_color_12 = "#709af5"
+  let g:terminal_color_13 = "#d02fcd"
+  let g:terminal_color_14 = "#01a7ef"
+  let g:terminal_color_15 = "#090a0b"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#e7e7e9",
+        \ "#ca1243",
+        \ "#50a14f",
+        \ "#c18401",
+        \ "#4078f2",
+        \ "#a626a4",
+        \ "#0184bc",
+        \ "#202227",
+        \ "#cacace",
+        \ "#ec2258",
+        \ "#6db76c",
+        \ "#f4a701",
+        \ "#709af5",
+        \ "#d02fcd",
+        \ "#01a7ef",
+        \ "#090a0b",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-one-light"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-sparky.vim
+++ b/colors/base24-sparky.vim
@@ -1,0 +1,826 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Sparky
+" Scheme author: Leila Sother (https://github.com/mixcoac)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/sparky.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "072b31"
+let g:tinted_gui00 = "072b31"
+let s:gui01        = "00313c"
+let g:tinted_gui01 = "00313c"
+let s:gui02        = "003c46"
+let g:tinted_gui02 = "003c46"
+let s:gui03        = "003b49"
+let g:tinted_gui03 = "003b49"
+let s:gui04        = "00778b"
+let g:tinted_gui04 = "00778b"
+let s:gui05        = "f4f5f0"
+let g:tinted_gui05 = "f4f5f0"
+let s:gui06        = "f5f5f1"
+let g:tinted_gui06 = "f5f5f1"
+let s:gui07        = "ffffff"
+let g:tinted_gui07 = "ffffff"
+let s:gui08        = "ff585d"
+let g:tinted_gui08 = "ff585d"
+let s:gui09        = "ff8f1c"
+let g:tinted_gui09 = "ff8f1c"
+let s:gui0A        = "fbdd40"
+let g:tinted_gui0A = "fbdd40"
+let s:gui0B        = "78d64b"
+let g:tinted_gui0B = "78d64b"
+let s:gui0C        = "2dccd3"
+let g:tinted_gui0C = "2dccd3"
+let s:gui0D        = "4698cb"
+let g:tinted_gui0D = "4698cb"
+let s:gui0E        = "d59ed7"
+let g:tinted_gui0E = "d59ed7"
+let s:gui0F        = "9b704d"
+let g:tinted_gui0f = "9b704d"
+let s:gui10        = "4b4f54"
+let g:tinted_gui10 = "4b4f54"
+let s:gui11        = "212322"
+let g:tinted_gui11 = "212322"
+let s:gui12        = "ff7276"
+let g:tinted_gui12 = "ff7276"
+let s:gui13        = "f6eb61"
+let g:tinted_gui13 = "f6eb61"
+let s:gui14        = "8edd65"
+let g:tinted_gui14 = "8edd65"
+let s:gui15        = "00c1d5"
+let g:tinted_gui15 = "00c1d5"
+let s:gui16        = "69b3e7"
+let g:tinted_gui16 = "69b3e7"
+let s:gui17        = "f99fc9"
+let g:tinted_gui17 = "f99fc9"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#072b31"
+  let g:terminal_color_1 =  "#ff585d"
+  let g:terminal_color_2 =  "#78d64b"
+  let g:terminal_color_3 =  "#fbdd40"
+  let g:terminal_color_4 =  "#4698cb"
+  let g:terminal_color_5 =  "#d59ed7"
+  let g:terminal_color_6 =  "#2dccd3"
+  let g:terminal_color_7 =  "#f4f5f0"
+  let g:terminal_color_8 =  "#003b49"
+  let g:terminal_color_9 =  "#ff7276"
+  let g:terminal_color_10 = "#8edd65"
+  let g:terminal_color_11 = "#f6eb61"
+  let g:terminal_color_12 = "#69b3e7"
+  let g:terminal_color_13 = "#f99fc9"
+  let g:terminal_color_14 = "#00c1d5"
+  let g:terminal_color_15 = "#ffffff"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#072b31",
+        \ "#ff585d",
+        \ "#78d64b",
+        \ "#ff8f1c",
+        \ "#4698cb",
+        \ "#d59ed7",
+        \ "#2dccd3",
+        \ "#f5f5f1",
+        \ "#003c46",
+        \ "#ff7276",
+        \ "#8edd65",
+        \ "#f6eb61",
+        \ "#69b3e7",
+        \ "#f99fc9",
+        \ "#00c1d5",
+        \ "#ffffff",
+        \ ]
+endif
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-sparky"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/colors/base24-tokyo-night-dark.vim
+++ b/colors/base24-tokyo-night-dark.vim
@@ -1,0 +1,688 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: Tokyo Night Dark
+" Scheme author: Jamy Golden (https://github.com/JamyGolden)
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by tinted-shell scripts
+" User must set this variable in .vimrc
+"   let g:tinted_shell_path=path/to/shell/scripts
+if !has("gui_running")
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/base24-tokyo-night-dark.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "414868"
+let g:base24_gui00 = "414868"
+let s:gui01        = "4b5170"
+let g:base24_gui01 = "4b5170"
+let s:gui02        = "545c7e"
+let g:base24_gui02 = "545c7e"
+let s:gui03        = "565f89"
+let g:base24_gui03 = "565f89"
+let s:gui04        = "787c99"
+let g:base24_gui04 = "787c99"
+let s:gui05        = "9aa5ce"
+let g:base24_gui05 = "9aa5ce"
+let s:gui06        = "a9b1d6"
+let g:base24_gui06 = "a9b1d6"
+let s:gui07        = "cbd0e6"
+let g:base24_gui07 = "cbd0e6"
+let s:gui08        = "f7768e"
+let g:base24_gui08 = "f7768e"
+let s:gui09        = "e0af68"
+let g:base24_gui09 = "e0af68"
+let s:gui0A        = "ff9e64"
+let g:base24_gui0A = "ff9e64"
+let s:gui0B        = "9ece6a"
+let g:base24_gui0B = "9ece6a"
+let s:gui0C        = "73daca"
+let g:base24_gui0C = "73daca"
+let s:gui0D        = "7dcfff"
+let g:base24_gui0D = "7dcfff"
+let s:gui0E        = "bb9af7"
+let g:base24_gui0E = "bb9af7"
+let s:gui0F        = "c53b53"
+let s:gui10        = "24283b"
+let g:base24_gui10 = "24283b"
+let s:gui11        = "1a1b26"
+let g:base24_gui11 = "1a1b26"
+let s:gui12        = "ff007c"
+let g:base24_gui12 = "ff007c"
+let s:gui13        = "ff9e64"
+let g:base24_gui13 = "ff9e64"
+let s:gui14        = "9ece6a"
+let g:base24_gui14 = "9ece6a"
+let s:gui15        = "b4f9f8"
+let g:base24_gui15 = "b4f9f8"
+let s:gui16        = "2ac3de"
+let g:base24_gui16 = "2ac3de"
+let s:gui17        = "7aa2f7"
+let g:base24_gui17 = "7aa2f7"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
+let s:cterm05        = "07"
+let g:base24_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base24_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base24_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base24_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base24_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base24_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base24_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+  let s:cterm01        = "18"
+  let g:base24_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base24_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base24_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base24_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base24_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
+else
+  let s:cterm01        = "10"
+  let g:base24_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base24_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base24_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base24_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base24_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base24_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#414868"
+  let g:terminal_color_1 =  "#f7768e"
+  let g:terminal_color_2 =  "#9ece6a"
+  let g:terminal_color_3 =  "#ff9e64"
+  let g:terminal_color_4 =  "#7dcfff"
+  let g:terminal_color_5 =  "#bb9af7"
+  let g:terminal_color_6 =  "#73daca"
+  let g:terminal_color_7 =  "#9aa5ce"
+  let g:terminal_color_8 =  "#565f89"
+  let g:terminal_color_9 =  "#ff007c"
+  let g:terminal_color_10 = "#9ece6a"
+  let g:terminal_color_11 = "#ff9e64"
+  let g:terminal_color_12 = "#2ac3de"
+  let g:terminal_color_13 = "#7aa2f7"
+  let g:terminal_color_14 = "#b4f9f8"
+  let g:terminal_color_15 = "#cbd0e6"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#414868",
+        \ "#f7768e",
+        \ "#9ece6a",
+        \ "#e0af68",
+        \ "#7dcfff",
+        \ "#bb9af7",
+        \ "#73daca",
+        \ "#a9b1d6",
+        \ "#545c7e",
+        \ "#ff007c",
+        \ "#9ece6a",
+        \ "#ff9e64",
+        \ "#2ac3de",
+        \ "#7aa2f7",
+        \ "#b4f9f8",
+        \ "#cbd0e6",
+        \ ]
+endif
+if exists("base24_background_transparent") && base24_background_transparent == "1"
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base24-tokyo-night-dark"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,0 +1,817 @@
+" vi:syntax=vim
+
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
+" Scheme name: {{scheme-name}}
+" Scheme author: {{scheme-author}}
+" Template author: Tinted Theming (https://github.com/tinted-theming)
+
+" This enables the coresponding base16-shell script to run so that
+" :colorscheme works in terminals supported by base16-shell scripts
+" User must set this variable in .vimrc
+"   let g:base16_shell_path=base16-builder/output/shell/
+if !has("gui_running")
+  if exists("g:base16_shell_path")
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16/{{scheme-slug}}.sh"
+  endif
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base16/{{scheme-slug}}.sh"
+  endif
+endif
+
+" GUI color definitions
+let s:gui00        = "{{base00-hex}}"
+let g:tinted_gui00 = "{{base00-hex}}"
+let s:gui01        = "{{base01-hex}}"
+let g:tinted_gui01 = "{{base01-hex}}"
+let s:gui02        = "{{base02-hex}}"
+let g:tinted_gui02 = "{{base02-hex}}"
+let s:gui03        = "{{base03-hex}}"
+let g:tinted_gui03 = "{{base03-hex}}"
+let s:gui04        = "{{base04-hex}}"
+let g:tinted_gui04 = "{{base04-hex}}"
+let s:gui05        = "{{base05-hex}}"
+let g:tinted_gui05 = "{{base05-hex}}"
+let s:gui06        = "{{base06-hex}}"
+let g:tinted_gui06 = "{{base06-hex}}"
+let s:gui07        = "{{base07-hex}}"
+let g:tinted_gui07 = "{{base07-hex}}"
+let s:gui08        = "{{base08-hex}}"
+let g:tinted_gui08 = "{{base08-hex}}"
+let s:gui09        = "{{base09-hex}}"
+let g:tinted_gui09 = "{{base09-hex}}"
+let s:gui0A        = "{{base0A-hex}}"
+let g:tinted_gui0A = "{{base0A-hex}}"
+let s:gui0B        = "{{base0B-hex}}"
+let g:tinted_gui0B = "{{base0B-hex}}"
+let s:gui0C        = "{{base0C-hex}}"
+let g:tinted_gui0C = "{{base0C-hex}}"
+let s:gui0D        = "{{base0D-hex}}"
+let g:tinted_gui0D = "{{base0D-hex}}"
+let s:gui0E        = "{{base0E-hex}}"
+let g:tinted_gui0E = "{{base0E-hex}}"
+let s:gui0F        = "{{base0F-hex}}"
+let g:tinted_gui0F = "{{base0F-hex}}"
+
+" Legacy
+let g:base16_gui00 = "{{base00-hex}}"
+let g:base16_gui01 = "{{base01-hex}}"
+let g:base16_gui02 = "{{base02-hex}}"
+let g:base16_gui03 = "{{base03-hex}}"
+let g:base16_gui04 = "{{base04-hex}}"
+let g:base16_gui05 = "{{base05-hex}}"
+let g:base16_gui06 = "{{base06-hex}}"
+let g:base16_gui07 = "{{base07-hex}}"
+let g:base16_gui08 = "{{base08-hex}}"
+let g:base16_gui09 = "{{base09-hex}}"
+let g:base16_gui0A = "{{base0A-hex}}"
+let g:base16_gui0B = "{{base0B-hex}}"
+let g:base16_gui0C = "{{base0C-hex}}"
+let g:base16_gui0D = "{{base0D-hex}}"
+let g:base16_gui0E = "{{base0E-hex}}"
+let g:base16_gui0F = "{{base0F-hex}}"
+
+" Terminal color definitions
+let s:cterm00        = "00"
+let g:base16_cterm00 = "00"
+let s:cterm03        = "08"
+let g:base16_cterm03 = "08"
+let s:cterm05        = "07"
+let g:base16_cterm05 = "07"
+let s:cterm07        = "15"
+let g:base16_cterm07 = "15"
+let s:cterm08        = "01"
+let g:base16_cterm08 = "01"
+let s:cterm0A        = "03"
+let g:base16_cterm0A = "03"
+let s:cterm0B        = "02"
+let g:base16_cterm0B = "02"
+let s:cterm0C        = "06"
+let g:base16_cterm0C = "06"
+let s:cterm0D        = "04"
+let g:base16_cterm0D = "04"
+let s:cterm0E        = "05"
+let g:base16_cterm0E = "05"
+" `tinted_colorspace` variable is the preferred version but
+" `base16_colorspace` and `base16colorspace` continues to exist for legacy
+" reasons so we don't break any users' setup
+if (exists("tinted_colorspace") && tinted_colorspace == "256") || (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+  let s:cterm01        = "18"
+  let g:base16_cterm01 = "18"
+  let s:cterm02        = "19"
+  let g:base16_cterm02 = "19"
+  let s:cterm04        = "20"
+  let g:base16_cterm04 = "20"
+  let s:cterm06        = "21"
+  let g:base16_cterm06 = "21"
+  let s:cterm09        = "16"
+  let g:base16_cterm09 = "16"
+  let s:cterm0F        = "17"
+  let g:base16_cterm0F = "17"
+else
+  let s:cterm01        = "10"
+  let g:base16_cterm01 = "10"
+  let s:cterm02        = "11"
+  let g:base16_cterm02 = "11"
+  let s:cterm04        = "12"
+  let g:base16_cterm04 = "12"
+  let s:cterm06        = "13"
+  let g:base16_cterm06 = "13"
+  let s:cterm09        = "09"
+  let g:base16_cterm09 = "09"
+  let s:cterm0F        = "14"
+  let g:base16_cterm0F = "14"
+endif
+
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#{{base00-hex}}"
+  let g:terminal_color_1 =  "#{{base08-hex}}"
+  let g:terminal_color_2 =  "#{{base0B-hex}}"
+  let g:terminal_color_3 =  "#{{base0A-hex}}"
+  let g:terminal_color_4 =  "#{{base0D-hex}}"
+  let g:terminal_color_5 =  "#{{base0E-hex}}"
+  let g:terminal_color_6 =  "#{{base0C-hex}}"
+  let g:terminal_color_7 =  "#{{base05-hex}}"
+  let g:terminal_color_8 =  "#{{base03-hex}}"
+  let g:terminal_color_9 =  "#{{base08-hex}}"
+  let g:terminal_color_10 = "#{{base0B-hex}}"
+  let g:terminal_color_11 = "#{{base0A-hex}}"
+  let g:terminal_color_12 = "#{{base0D-hex}}"
+  let g:terminal_color_13 = "#{{base0E-hex}}"
+  let g:terminal_color_14 = "#{{base0C-hex}}"
+  let g:terminal_color_15 = "#{{base07-hex}}"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_5
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+elseif has("terminal")
+  let g:terminal_ansi_colors = [
+        \ "#{{base00-hex}}",
+        \ "#{{base08-hex}}",
+        \ "#{{base0B-hex}}",
+        \ "#{{base0A-hex}}",
+        \ "#{{base0D-hex}}",
+        \ "#{{base0E-hex}}",
+        \ "#{{base0C-hex}}",
+        \ "#{{base05-hex}}",
+        \ "#{{base03-hex}}",
+        \ "#{{base08-hex}}",
+        \ "#{{base0B-hex}}",
+        \ "#{{base0A-hex}}",
+        \ "#{{base0D-hex}}",
+        \ "#{{base0E-hex}}",
+        \ "#{{base0C-hex}}",
+        \ "#{{base07-hex}}",
+        \ ]
+endif
+" `base16_background_transparent` is a legacy property
+if (exists("base16_background_transparent") && base16_background_transparent == "1") || (exists("tinted_background_transparent") && tinted_background_transparent == "1")
+  let s:guibg = "NONE"
+  let s:ctermbg = "NONE"
+else
+  let s:guibg = s:gui00
+  let s:ctermbg = s:cterm00
+endif
+
+" Theme setup
+hi clear
+syntax reset
+let g:colors_name = "base16-{{scheme-slug}}"
+
+" Highlighting function
+" Optional variables are attributes and guisp
+function! g:Base16hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+  let l:attr = get(a:, 1, "")
+  let l:guisp = get(a:, 2, "")
+
+  " See :help highlight-guifg
+  let l:gui_special_names = ["NONE", "bg", "background", "fg", "foreground"]
+
+  if a:guifg != ""
+    if index(l:gui_special_names, a:guifg) >= 0
+      exec "hi " . a:group . " guifg=" . a:guifg
+    else
+      exec "hi " . a:group . " guifg=#" . a:guifg
+    endif
+  endif
+  if a:guibg != ""
+    if index(l:gui_special_names, a:guibg) >= 0
+      exec "hi " . a:group . " guibg=" . a:guibg
+    else
+      exec "hi " . a:group . " guibg=#" . a:guibg
+    endif
+  endif
+  if a:ctermfg != ""
+    exec "hi " . a:group . " ctermfg=" . a:ctermfg
+  endif
+  if a:ctermbg != ""
+    exec "hi " . a:group . " ctermbg=" . a:ctermbg
+  endif
+  if l:attr != ""
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
+  endif
+  if l:guisp != ""
+    if index(l:gui_special_names, l:guisp) >= 0
+      exec "hi " . a:group . " guisp=" . l:guisp
+    else
+      exec "hi " . a:group . " guisp=#" . l:guisp
+    endif
+  endif
+endfunction
+
+
+fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  call g:Base16hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+endfun
+
+" Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("Bold",          "", "", "", "", "bold", "")
+call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui08, s:ctermbg, s:cterm08, "", "")
+call <sid>hi("ErrorMsg",      s:gui08, s:guibg, s:cterm08, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui09, s:cterm01, s:cterm09, "none", "")
+call <sid>hi("Italic",        "", "", "", "", "italic", "")
+call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
+call <sid>hi("ModeMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("MoreMsg",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
+call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
+call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("TooLong",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
+call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
+call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
+call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
+call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("Cursor",        s:gui05, s:guibg, "", "", "inverse", "")
+call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("Whitespace",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("LineNr",        s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("SignColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
+call <sid>hi("StatusLine",    s:gui04, s:gui01, s:cterm04, s:cterm01, "none", "")
+call <sid>hi("StatusLineNC",  s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("VertSplit",     s:gui01, s:guibg, s:cterm01, s:ctermbg, "none", "")
+call <sid>hi("ColorColumn",   "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorColumn",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLine",    "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("CursorLineNr",  s:gui04, s:gui01, s:cterm04, s:cterm01, "bold", "")
+call <sid>hi("QuickFixLine",  "", s:gui01, "", s:cterm01, "none", "")
+call <sid>hi("PMenu",         s:gui06, s:gui01, s:cterm06, s:cterm01, "none", "")
+call <sid>hi("PMenuSel",      s:gui06, s:gui02, s:cterm06, s:cterm02, "", "")
+call <sid>hi("PMenuSbar",     "", s:gui03, "", s:cterm03, "", "")
+call <sid>hi("PMenuThumb",    "", s:gui04, "", s:cterm04, "", "")
+call <sid>hi("TabLine",       s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineFill",   s:gui03, s:gui01, s:cterm03, s:cterm01, "none", "")
+call <sid>hi("TabLineSel",    s:gui0B, s:gui01, s:cterm0B, s:cterm01, "none", "")
+
+" Standard syntax
+call <sid>hi("Boolean",      s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Character",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Comment",      s:gui03, "", s:cterm03, "", "italic", "")
+call <sid>hi("Conditional",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Constant",     s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Define",       s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Delimiter",    s:gui05, "", s:cterm05, "", "", "")
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("Float",        s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Function",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Identifier",   s:gui05, "", s:cterm05, "", "none", "")
+call <sid>hi("Include",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("Keyword",      s:gui0E, "", s:cterm0E, "", "none", "")
+call <sid>hi("Label",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Number",       s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("Operator",     s:gui0C, "", s:cterm0C, "", "none", "")
+call <sid>hi("PreProc",      s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Repeat",       s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("Special",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("SpecialChar",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("Statement",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("StorageClass", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("String",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("Structure",    s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Tag",          s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("Todo",         s:gui08, s:guibg, s:cterm08, s:ctermbg, "italic", "")
+call <sid>hi("Type",         s:gui0A, "", s:cterm0A, "", "none", "")
+call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "", "")
+
+" Treesitter
+if has("nvim-0.8.0")
+  call <sid>hi("@field",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@property",         s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@namespace",        s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@variable",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@variable.builtin", s:gui05, "", s:cterm05, "", "italic", "")
+  call <sid>hi("@text.reference",   s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
+
+  " Annotations & Attributes
+  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Booleans, Characters & Comments
+  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "italic", "")
+
+  " Conditionals, Constants & Debugging
+  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+
+  " Directives & Exceptions
+  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Floats & Functions
+  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+
+  " Imports, Operators & Returns
+  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Methods & Namespaces
+  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Numbers & Directives
+  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Repeats, Storage & Strings
+  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+
+  " Tags & Markup
+  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+
+  " More Markup
+  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+
+  " Comments & Types
+  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
+
+  " Nvim 0.10 migration
+  if has("nvim-0.10.0")
+    hi! link @parameter             @variable.parameter
+    hi! link @float                 @number.float
+    hi! link @symbol                @string.special.symbol
+    hi! link @string.regex          @string.regexp
+    hi! link @text.strong           @markup.strong
+    hi! link @text.emphasis         @markup.italic
+    hi! link @text.underline        @markup.underline
+    hi! link @text.strike           @markup.strikethrough
+    hi! link @text.title            @markup.heading
+    hi! link @text.quote            @markup.quote
+    hi! link @text.uri              @markup.link.url
+    hi! link @text.math             @markup.math
+    hi! link @text.environment      @markup.environment
+    hi! link @text.environment.name @markup.environment.name
+    hi! link @text.reference        @markup.link
+    hi! link @text.literal          @markup.raw
+    hi! link @text.literal.block    @markup.raw.block
+    hi! link @string.special        @markup.link.label
+    hi! link @punctuation.special   @markup.list
+
+    hi! link @method                @function.method
+    hi! link @method.call           @function.method.call
+    hi! link @text.todo             @comment.todo
+    hi! link @text.danger           @comment.error
+    hi! link @text.warning          @comment.warning
+    hi! link @text.note             @comment.hint
+    hi! link @text.note             @comment.info
+    hi! link @text.note             @comment.note
+    hi! link @text.note             @comment.ok
+    hi! link @text.diff.add         @diff.plus
+    hi! link @text.diff.delete      @diff.minus
+    hi! link @text.diff.change      @diff.delta
+    hi! link @text.uri              @string.special.url
+    hi! link @preproc               @keyword.directive
+    hi! link @storageclass          @keyword.storage
+    hi! link @define                @keyword.directive
+    hi! link @conditional           @keyword.conditional
+    hi! link @debug                 @keyword.debug
+    hi! link @exception             @keyword.exception
+    hi! link @include               @keyword.import
+    hi! link @repeat                @keyword.repeat
+  endif
+endif
+
+" Standard highlights to be used by plugins
+if has("patch-8.0.1038")
+  call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
+endif
+call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
+
+call <sid>hi("GitAddSign",           s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
+
+call <sid>hi("ErrorSign",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningSign",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("InfoSign",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("HintSign",     s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("OkSign",       s:gui0B, "", s:cterm0B, "", "", "")
+
+call <sid>hi("ErrorFloat",   s:gui08, s:gui01, s:cterm08, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui09, s:gui01, s:cterm09, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui0D, s:gui01, s:cterm0D, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui0C, s:gui01, s:cterm0C, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui0B, s:gui01, s:cterm0B, s:cterm01, "", "")
+
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm08, "underline", s:gui08)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm09, "underline", s:gui09)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm0D, "underline", s:gui0D)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm0C, "underline", s:gui0C)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm0B, "underline", s:gui0B)
+
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm08, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm0C, "undercurl", s:gui0C)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm0D, "undercurl", s:gui0D)
+call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
+
+call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
+call <sid>hi("ReferenceRead",   s:gui01, s:gui0B, s:cterm01, s:cterm0B, "", "")
+call <sid>hi("ReferenceWrite",  s:gui01, s:gui08, s:cterm01, s:cterm08, "", "")
+
+" C
+call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "", "")
+
+" C#
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "", "")
+
+" Clap
+hi! link ClapInput             ColorColumn
+hi! link ClapSpinner           ColorColumn
+hi! link ClapDisplay           Default
+hi! link ClapPreview           ColorColumn
+hi! link ClapCurrentSelection  CursorLine
+hi! link ClapNoMatchesFound    ErrorFloat
+
+" Coc
+hi! link CocErrorSign         ErrorSign
+hi! link CocWarningSign       WarningSign
+hi! link CocInfoSign          InfoSign
+hi! link CocHintSign          HintSign
+
+hi! link CocErrorFloat        ErrorFloat
+hi! link CocWarningFloat      WarningFloat
+hi! link CocInfoFloat         InfoFloat
+hi! link CocHintFloat         HintFloat
+
+hi! link CocErrorHighlight    ErrorHighlight
+hi! link CocWarningHighlight  WarningHighlight
+hi! link CocInfoHighlight     InfoHighlight
+hi! link CocHintHighlight     HintHighlight
+
+hi! link CocSem_angle             Keyword
+hi! link CocSem_annotation        Keyword
+hi! link CocSem_attribute         Type
+hi! link CocSem_bitwise           Keyword
+hi! link CocSem_boolean           Boolean
+hi! link CocSem_brace             Normal
+hi! link CocSem_bracket           Normal
+hi! link CocSem_builtinAttribute  Type
+hi! link CocSem_builtinType       Type
+hi! link CocSem_character         String
+hi! link CocSem_class             Structure
+hi! link CocSem_colon             Normal
+hi! link CocSem_comma             Normal
+hi! link CocSem_comment           Comment
+hi! link CocSem_comparison        Keyword
+hi! link CocSem_concept           Keyword
+hi! link CocSem_constParameter    Identifier
+hi! link CocSem_dependent         Keyword
+hi! link CocSem_dot               Keyword
+hi! link CocSem_enum              Structure
+hi! link CocSem_enumMember        Constant
+hi! link CocSem_escapeSequence    Type
+hi! link CocSem_event             Identifier
+hi! link CocSem_formatSpecifier   Type
+hi! link CocSem_function          Function
+hi! link CocSem_interface         Type
+hi! link CocSem_keyword           Keyword
+hi! link CocSem_label             Keyword
+hi! link CocSem_logical           Keyword
+hi! link CocSem_macro             Macro
+hi! link CocSem_method            Function
+hi! link CocSem_modifier          Keyword
+hi! link CocSem_namespace         Identifier
+hi! link CocSem_number            Number
+hi! link CocSem_operator          Operator
+hi! link CocSem_parameter         Identifier
+hi! link CocSem_parenthesis       Normal
+hi! link CocSem_property          Identifier
+hi! link CocSem_punctuation       Keyword
+hi! link CocSem_regexp            Type
+hi! link CocSem_selfKeyword       Constant
+hi! link CocSem_semicolon         Normal
+hi! link CocSem_string            String
+hi! link CocSem_struct            Structure
+hi! link CocSem_type              Type
+hi! link CocSem_typeAlias         Type
+hi! link CocSem_typeParameter     Type
+hi! link CocSem_unknown           Normal
+hi! link CocSem_variable          Identifier
+
+call <sid>hi("CocHighlightRead",   s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("CocHighlightText",   s:gui0A, s:gui01,  s:cterm0A, s:cterm01, "", "")
+call <sid>hi("CocHighlightWrite",  s:gui08, s:gui01,  s:cterm08, s:cterm01, "", "")
+call <sid>hi("CocListMode",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "bold", "")
+call <sid>hi("CocListPath",        s:gui01, s:gui0B,  s:cterm01, s:cterm0B, "", "")
+call <sid>hi("CocSessionsName",    s:gui05, "", s:cterm05, "", "", "")
+
+" CSS
+call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("cssColor",       s:gui0C, "", s:cterm0C, "", "", "")
+
+" CMP
+hi! link CmpItemAbbrDeprecated  Deprecated
+hi! link CmpItemAbbrMatch       SearchMatch
+hi! link CmpItemAbbrMatchFuzzy  SearchMatch
+hi! link CmpItemKindClass Type
+hi! link CmpItemKindColor Keyword
+hi! link CmpItemKindConstant Constant
+hi! link CmpItemKindConstructor Special
+hi! link CmpItemKindEnum Type
+hi! link CmpItemKindEnumMember Constant
+hi! link CmpItemKindEvent Identifier
+hi! link CmpItemKindField Character
+hi! link CmpItemKindFile Directory
+hi! link CmpItemKindFolder Directory
+hi! link CmpItemKindFunction Function
+hi! link CmpItemKindInterface Type
+hi! link CmpItemKindKeyword Keyword
+hi! link CmpItemKindMethod Function
+hi! link CmpItemKindModule Namespace
+hi! link CmpItemKindOperator Operator
+hi! link CmpItemKindProperty Identifier
+hi! link CmpItemKindReference Character
+hi! link CmpItemKindSnippet String
+hi! link CmpItemKindStruct Type
+hi! link CmpItemKindText Text
+hi! link CmpItemKindUnit Namespace
+hi! link CmpItemKindValue Comment
+hi! link CmpItemKindVariable Identifier
+
+if has("nvim-0.8.0")
+  hi! link CmpItemKindField @field
+  hi! link CmpItemKindProperty @property
+endif
+
+" Diff
+call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
+call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui0D, s:gui01,  s:cterm0D, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui0B, s:guibg,  s:cterm0B, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui08, s:guibg,  s:cterm08, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui0B, s:guibg,  s:cterm0B, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui0D, s:guibg,  s:cterm0D, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui08, s:guibg,  s:cterm08, s:ctermbg, "", "")
+
+" Git
+call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("gitcommitSummary",        s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("gitcommitHeader",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui09, "", s:cterm09, "", "bold", "")
+call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
+call <sid>hi("gitcommitSelectedFile",   s:gui0B, "", s:cterm0B, "", "bold", "")
+
+" GitGutter
+hi! link GitGutterAdd            GitAddSign
+hi! link GitGutterChange         GitChangeSign
+hi! link GitGutterDelete         GitDeleteSign
+hi! link GitGutterChangeDelete   GitChangeDeleteSign
+
+" indent-blankline (nvim)
+if has("nvim")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
+endif
+
+" HTML
+call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm0E, "", "italic", "")
+call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
+
+" JavaScript
+call <sid>hi("javaScript",        s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptBraces",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("javaScriptNumber",  s:gui09, "", s:cterm09, "", "", "")
+" pangloss/vim-javascript
+call <sid>hi("jsOperator",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsStatement",         s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsReturn",            s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsThis",              s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("jsClassDefinition",   s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsFunction",          s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsFuncName",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsFuncCall",          s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassFuncName",     s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("jsClassMethodType",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("jsRegexpString",      s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("jsGlobalObjects",     s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("mailQuoted3",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("mailQuoted4",  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("mailQuoted5",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailQuoted6",  s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("mailURL",      s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("mailEmail",    s:gui0D, "", s:cterm0D, "", "", "")
+
+" Markdown
+call <sid>hi("markdownCode",              s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownError",             s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
+call <sid>hi("markdownCodeBlock",         s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("markdownHeadingDelimiter",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Matchup
+call <sid>hi("MatchWord",  s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "underline", "")
+
+" NERDTree
+call <sid>hi("NERDTreeDirSlash",  s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
+
+" PHP
+call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
+
+" Python
+call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
+
+" Ruby
+call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")
+call <sid>hi("rubyConstant",                s:gui0A, "", s:cterm0A, "", "", "")
+call <sid>hi("rubyInterpolationDelimiter",  s:gui0F, "", s:cterm0F, "", "", "")
+call <sid>hi("rubyRegexp",                  s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("rubySymbol",                  s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("rubyStringDelimiter",         s:gui0B, "", s:cterm0B, "", "", "")
+
+" SASS
+call <sid>hi("sassidChar",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("sassClassChar",  s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("sassInclude",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixing",     s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("sassMixinName",  s:gui0D, "", s:cterm0D, "", "", "")
+
+" Signify
+hi! link SignifySignAdd    GitAddSign
+hi! link SignifySignChange GitChangeSign
+hi! link SignifySignDelete GitDeleteSign
+
+" Startify
+call <sid>hi("StartifyBracket",  s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyFile",     s:gui07, "", s:cterm07, "", "", "")
+call <sid>hi("StartifyFooter",   s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifyHeader",   s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("StartifyNumber",   s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("StartifyPath",     s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySection",  s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
+call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
+call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
+
+" LSP
+if has("nvim")
+  hi! link DiagnosticError  ErrorSign
+  hi! link DiagnosticWarn   WarningSign
+  hi! link DiagnosticInfo   InfoSign
+  hi! link DiagnosticHint   HintSign
+  hi! link DiagnosticOk     OkSign
+
+  hi! link DiagnosticFloatingError  ErrorFloat
+  hi! link DiagnosticFloatingWarn   WarningFloat
+  hi! link DiagnosticFloatingInfo   InfoFloat
+  hi! link DiagnosticFloatingHint   HintFloat
+  hi! link DiagnosticFloatingOk     OkFloat
+
+  hi! link DiagnosticUnderlineError  ErrorHighlight
+  hi! link DiagnosticUnderlineWarn   WarningHighlight
+  hi! link DiagnosticUnderlineInfo   InfoHighlight
+  hi! link DiagnosticUnderlineHint   HintHighlight
+  hi! link DiagnosticUnderlineOk     OkHighlight
+
+  hi! link DiagnosticsVirtualTextError    ErrorSign
+  hi! link DiagnosticsVirtualTextWarning  WarningSign
+  hi! link DiagnosticsVirtualTextInfo     InfoSign
+  hi! link DiagnosticsVirtualTextHint     HintSign
+  hi! link DiagnosticsVirtualTextOk       OkSign
+
+  " Remove untill endif on next nvim release
+  hi! link LspDiagnosticsSignError    ErrorSign
+  hi! link LspDiagnosticsSignWarning  WarningSign
+  hi! link LspDiagnosticsSignInfo     InfoSign
+  hi! link LspDiagnosticsSignHint     HintSign
+
+  hi! link LspDiagnosticsVirtualTextError    ErrorSign
+  hi! link LspDiagnosticsVirtualTextWarning  WarningSign
+  hi! link LspDiagnosticsVirtualTextInfo     InfoSign
+  hi! link LspDiagnosticsVirtualTextHint     HintSign
+
+  hi! link LspDiagnosticsFloatingError    ErrorFloat
+  hi! link LspDiagnosticsFloatingWarning  WarningFloat
+  hi! link LspDiagnosticsFloatingInfo     InfoFloat
+  hi! link LspDiagnosticsFloatingHint     HintFloat
+
+  hi! link LspDiagnosticsUnderlineError    ErrorHighlight
+  hi! link LspDiagnosticsUnderlineWarning  WarningHighlight
+  hi! link LspDiagnosticsUnderlineInfo     InfoHighlight
+  hi! link LspDiagnosticsUnderlineHint     HintHighlight
+
+  hi! link LspReferenceText   ReferenceText
+  hi! link LspReferenceRead   ReferenceRead
+  hi! link LspReferenceWrite  ReferenceWrite
+
+  "  https://neovim.io/doc/user/news-0.10.html
+  if has("nvim-0.10.0")
+    hi! link WinSeparator VertSplit
+    hi! link FloatBorder  WinSeparator
+    hi! link NormalFloat  Pmenu
+  endif
+endif
+
+" Java
+call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
+
+" Remove functions
+delf <sid>hi
+
+" Remove color variables
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,104 +1,136 @@
 " vi:syntax=vim
 
-" base16-vim (https://github.com/tinted-theming/base16-vim)
+" tinted-vim (https://github.com/tinted-theming/tinted-vim)
 " Scheme name: {{scheme-name}}
 " Scheme author: {{scheme-author}}
 " Template author: Tinted Theming (https://github.com/tinted-theming)
 
 " This enables the coresponding base16-shell script to run so that
-" :colorscheme works in terminals supported by base16-shell scripts
+" :colorscheme works in terminals supported by tinted-shell scripts
 " User must set this variable in .vimrc
-"   let g:base16_shell_path=base16-builder/output/shell/
+"   let g:tinted_shell_path=path/to/shell/scripts
 if !has("gui_running")
-  if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-{{scheme-slug}}.sh"
+  if exists("g:tinted_shell_path")
+    execute "silent !/bin/sh ".g:tinted_shell_path."/base24/{{scheme-slug}}.sh"
   endif
 endif
 
 " GUI color definitions
 let s:gui00        = "{{base00-hex}}"
-let g:base16_gui00 = "{{base00-hex}}"
+let g:tinted_gui00 = "{{base00-hex}}"
 let s:gui01        = "{{base01-hex}}"
-let g:base16_gui01 = "{{base01-hex}}"
+let g:tinted_gui01 = "{{base01-hex}}"
 let s:gui02        = "{{base02-hex}}"
-let g:base16_gui02 = "{{base02-hex}}"
+let g:tinted_gui02 = "{{base02-hex}}"
 let s:gui03        = "{{base03-hex}}"
-let g:base16_gui03 = "{{base03-hex}}"
+let g:tinted_gui03 = "{{base03-hex}}"
 let s:gui04        = "{{base04-hex}}"
-let g:base16_gui04 = "{{base04-hex}}"
+let g:tinted_gui04 = "{{base04-hex}}"
 let s:gui05        = "{{base05-hex}}"
-let g:base16_gui05 = "{{base05-hex}}"
+let g:tinted_gui05 = "{{base05-hex}}"
 let s:gui06        = "{{base06-hex}}"
-let g:base16_gui06 = "{{base06-hex}}"
+let g:tinted_gui06 = "{{base06-hex}}"
 let s:gui07        = "{{base07-hex}}"
-let g:base16_gui07 = "{{base07-hex}}"
+let g:tinted_gui07 = "{{base07-hex}}"
 let s:gui08        = "{{base08-hex}}"
-let g:base16_gui08 = "{{base08-hex}}"
+let g:tinted_gui08 = "{{base08-hex}}"
 let s:gui09        = "{{base09-hex}}"
-let g:base16_gui09 = "{{base09-hex}}"
+let g:tinted_gui09 = "{{base09-hex}}"
 let s:gui0A        = "{{base0A-hex}}"
-let g:base16_gui0A = "{{base0A-hex}}"
+let g:tinted_gui0A = "{{base0A-hex}}"
 let s:gui0B        = "{{base0B-hex}}"
-let g:base16_gui0B = "{{base0B-hex}}"
+let g:tinted_gui0B = "{{base0B-hex}}"
 let s:gui0C        = "{{base0C-hex}}"
-let g:base16_gui0C = "{{base0C-hex}}"
+let g:tinted_gui0C = "{{base0C-hex}}"
 let s:gui0D        = "{{base0D-hex}}"
-let g:base16_gui0D = "{{base0D-hex}}"
+let g:tinted_gui0D = "{{base0D-hex}}"
 let s:gui0E        = "{{base0E-hex}}"
-let g:base16_gui0E = "{{base0E-hex}}"
+let g:tinted_gui0E = "{{base0E-hex}}"
 let s:gui0F        = "{{base0F-hex}}"
-let g:base16_gui0F = "{{base0F-hex}}"
+let g:tinted_gui0f = "{{base0F-hex}}"
+let s:gui10        = "{{base10-hex}}"
+let g:tinted_gui10 = "{{base10-hex}}"
+let s:gui11        = "{{base11-hex}}"
+let g:tinted_gui11 = "{{base11-hex}}"
+let s:gui12        = "{{base12-hex}}"
+let g:tinted_gui12 = "{{base12-hex}}"
+let s:gui13        = "{{base13-hex}}"
+let g:tinted_gui13 = "{{base13-hex}}"
+let s:gui14        = "{{base14-hex}}"
+let g:tinted_gui14 = "{{base14-hex}}"
+let s:gui15        = "{{base15-hex}}"
+let g:tinted_gui15 = "{{base15-hex}}"
+let s:gui16        = "{{base16-hex}}"
+let g:tinted_gui16 = "{{base16-hex}}"
+let s:gui17        = "{{base17-hex}}"
+let g:tinted_gui17 = "{{base17-hex}}"
 
 " Terminal color definitions
 let s:cterm00        = "00"
-let g:base16_cterm00 = "00"
-let s:cterm03        = "08"
-let g:base16_cterm03 = "08"
+let g:base24_cterm00 = "00"
+let s:cterm03        = "09"
+let g:base24_cterm03 = "09"
 let s:cterm05        = "07"
-let g:base16_cterm05 = "07"
+let g:base24_cterm05 = "07"
 let s:cterm07        = "15"
-let g:base16_cterm07 = "15"
+let g:base24_cterm07 = "15"
 let s:cterm08        = "01"
-let g:base16_cterm08 = "01"
+let g:base24_cterm08 = "01"
 let s:cterm0A        = "03"
-let g:base16_cterm0A = "03"
+let g:base24_cterm0A = "03"
 let s:cterm0B        = "02"
-let g:base16_cterm0B = "02"
+let g:base24_cterm0B = "02"
 let s:cterm0C        = "06"
-let g:base16_cterm0C = "06"
+let g:base24_cterm0C = "06"
 let s:cterm0D        = "04"
-let g:base16_cterm0D = "04"
+let g:base24_cterm0D = "04"
 let s:cterm0E        = "05"
-let g:base16_cterm0E = "05"
-" `base16_colorspace` variable is the preferred version but
-" `base16colorspace` continues to exist for legacy reasons so we don't
-" break any users' setup
-if (exists("base16_colorspace") && base16_colorspace == "256") || (exists("base16colorspace") && base16colorspace == "256")
+let g:base24_cterm0E = "05"
+
+" `base16_colorspace` and `base16colorspace` are legacy properties and 
+" exist to keep existing setups from breaking
+if exists("tinted_colorspace") && tinted_colorspace == "256"
   let s:cterm01        = "18"
-  let g:base16_cterm01 = "18"
+  let g:base24_cterm01 = "18"
   let s:cterm02        = "19"
-  let g:base16_cterm02 = "19"
+  let g:base24_cterm02 = "19"
   let s:cterm04        = "20"
-  let g:base16_cterm04 = "20"
+  let g:base24_cterm04 = "20"
   let s:cterm06        = "21"
-  let g:base16_cterm06 = "21"
+  let g:base24_cterm06 = "21"
   let s:cterm09        = "16"
-  let g:base16_cterm09 = "16"
+  let g:base24_cterm09 = "16"
   let s:cterm0F        = "17"
-  let g:base16_cterm0F = "17"
+  let g:base24_cterm0F = "17"
+  let s:cterm10        = "13"
+  let g:base24_cterm10 = "13"
+  let s:cterm11        = "13"
+  let g:base24_cterm11 = "13"
+  let s:cterm12        = "09"
+  let g:base24_cterm12 = "09"
+  let s:cterm13        = "11"
+  let g:base24_cterm13 = "11"
+  let s:cterm14        = "10"
+  let g:base24_cterm14 = "10"
+  let s:cterm15        = "14"
+  let g:base24_cterm15 = "14"
+  let s:cterm16        = "12"
+  let g:base24_cterm16 = "12"
+  let s:cterm17        = "13"
+  let g:base24_cterm17 = "13"
 else
   let s:cterm01        = "10"
-  let g:base16_cterm01 = "10"
+  let g:base24_cterm01 = "10"
   let s:cterm02        = "11"
-  let g:base16_cterm02 = "11"
+  let g:base24_cterm02 = "11"
   let s:cterm04        = "12"
-  let g:base16_cterm04 = "12"
+  let g:base24_cterm04 = "12"
   let s:cterm06        = "13"
-  let g:base16_cterm06 = "13"
+  let g:base24_cterm06 = "13"
   let s:cterm09        = "09"
-  let g:base16_cterm09 = "09"
+  let g:base24_cterm09 = "09"
   let s:cterm0F        = "14"
-  let g:base16_cterm0F = "14"
+  let g:base24_cterm0F = "14"
 endif
 
 " Neovim terminal colours
@@ -112,12 +144,12 @@ if has("nvim")
   let g:terminal_color_6 =  "#{{base0C-hex}}"
   let g:terminal_color_7 =  "#{{base05-hex}}"
   let g:terminal_color_8 =  "#{{base03-hex}}"
-  let g:terminal_color_9 =  "#{{base08-hex}}"
-  let g:terminal_color_10 = "#{{base0B-hex}}"
-  let g:terminal_color_11 = "#{{base0A-hex}}"
-  let g:terminal_color_12 = "#{{base0D-hex}}"
-  let g:terminal_color_13 = "#{{base0E-hex}}"
-  let g:terminal_color_14 = "#{{base0C-hex}}"
+  let g:terminal_color_9 =  "#{{base12-hex}}"
+  let g:terminal_color_10 = "#{{base14-hex}}"
+  let g:terminal_color_11 = "#{{base13-hex}}"
+  let g:terminal_color_12 = "#{{base16-hex}}"
+  let g:terminal_color_13 = "#{{base17-hex}}"
+  let g:terminal_color_14 = "#{{base15-hex}}"
   let g:terminal_color_15 = "#{{base07-hex}}"
   let g:terminal_color_background = g:terminal_color_0
   let g:terminal_color_foreground = g:terminal_color_5
@@ -130,22 +162,22 @@ elseif has("terminal")
         \ "#{{base00-hex}}",
         \ "#{{base08-hex}}",
         \ "#{{base0B-hex}}",
-        \ "#{{base0A-hex}}",
+        \ "#{{base09-hex}}",
         \ "#{{base0D-hex}}",
         \ "#{{base0E-hex}}",
         \ "#{{base0C-hex}}",
-        \ "#{{base05-hex}}",
-        \ "#{{base03-hex}}",
-        \ "#{{base08-hex}}",
-        \ "#{{base0B-hex}}",
-        \ "#{{base0A-hex}}",
-        \ "#{{base0D-hex}}",
-        \ "#{{base0E-hex}}",
-        \ "#{{base0C-hex}}",
+        \ "#{{base06-hex}}",
+        \ "#{{base02-hex}}",
+        \ "#{{base12-hex}}",
+        \ "#{{base14-hex}}",
+        \ "#{{base13-hex}}",
+        \ "#{{base16-hex}}",
+        \ "#{{base17-hex}}",
+        \ "#{{base15-hex}}",
         \ "#{{base07-hex}}",
         \ ]
 endif
-if exists("base16_background_transparent") && base16_background_transparent == "1"
+if exists("tinted_background_transparent") && tinted_background_transparent == "1"
   let s:guibg = "NONE"
   let s:ctermbg = "NONE"
 else
@@ -156,11 +188,11 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "base16-{{scheme-slug}}"
+let g:colors_name = "base24-{{scheme-slug}}"
 
 " Highlighting function
 " Optional variables are attributes and guisp
-function! g:Base16hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+function! g:Base24hi(group, guifg, guibg, ctermfg, ctermbg, ...)
   let l:attr = get(a:, 1, "")
   let l:guisp = get(a:, 2, "")
 
@@ -201,7 +233,7 @@ endfunction
 
 
 fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
-  call g:Base16hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
+  call g:Base24hi(a:group, a:guifg, a:guibg, a:ctermfg, a:ctermbg, a:attr, a:guisp)
 endfun
 
 " Vim editor colors
@@ -209,12 +241,12 @@ call <sid>hi("Normal",        s:gui05, s:guibg, s:cterm05, s:ctermbg, "", "")
 call <sid>hi("Bold",          "", "", "", "", "bold", "")
 call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
 call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
-call <sid>hi("Error",         s:guibg, s:gui08, s:ctermbg, s:cterm08, "", "")
-call <sid>hi("ErrorMsg",      s:gui08, s:guibg, s:cterm08, s:ctermbg, "", "")
-call <sid>hi("Exception",     s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("Error",         s:guibg, s:gui12, s:ctermbg, s:cterm12, "", "")
+call <sid>hi("ErrorMsg",      s:gui12, s:guibg, s:cterm12, s:ctermbg, "", "")
+call <sid>hi("Exception",     s:gui12, "", s:cterm12, "", "", "")
 call <sid>hi("FoldColumn",    s:gui03, s:guibg, s:cterm03, s:ctermbg, "", "")
 call <sid>hi("Folded",        s:gui02, s:guibg, s:cterm02, s:ctermbg, "", "")
-call <sid>hi("IncSearch",     s:gui01, s:gui09, s:cterm01, s:cterm09, "none", "")
+call <sid>hi("IncSearch",     s:gui01, s:gui13, s:cterm01, s:cterm13, "none", "")
 call <sid>hi("Italic",        "", "", "", "", "italic", "")
 call <sid>hi("Macro",         s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("MatchParen",    "", s:gui03, "", s:cterm03,  "", "")
@@ -224,11 +256,11 @@ call <sid>hi("Question",      s:gui0D, "", s:cterm0D, "", "", "")
 call <sid>hi("Search",        s:gui01, s:gui0A, s:cterm01, s:cterm0A,  "", "")
 call <sid>hi("Substitute",    s:gui01, s:gui0A, s:cterm01, s:cterm0A, "none", "")
 call <sid>hi("SpecialKey",    s:gui03, "", s:cterm03, "", "", "")
-call <sid>hi("TooLong",       s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("TooLong",       s:gui12, "", s:cterm12, "", "", "")
 call <sid>hi("Underlined",    "", "", "", "", "underline", "fg")
 call <sid>hi("Visual",        "", s:gui02, "", s:cterm02, "", "")
 call <sid>hi("VisualNOS",     s:gui08, "", s:cterm08, "", "", "")
-call <sid>hi("WarningMsg",    s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("WarningMsg",    s:gui12, "", s:cterm12, "", "", "")
 call <sid>hi("WildMenu",      s:guibg, s:gui05, s:ctermbg, s:cterm05, "", "")
 call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
 call <sid>hi("Conceal",       s:gui0D, s:guibg, s:cterm0D, s:ctermbg, "", "")
@@ -296,84 +328,84 @@ if has("nvim-0.8.0")
   call <sid>hi("@text.uri",         s:gui08, "", s:cterm08, "", "italic", "")
 
   " Annotations & Attributes
-  call <sid>hi("@annotation",                          s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@attribute",                           s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@annotation",               s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@attribute",                s:gui0D, "", s:cterm0D, "", "", "")
 
   " Booleans, Characters & Comments
-  call <sid>hi("@boolean",                             s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@character",                           s:gui08, "", s:cterm08, "", "", "")
-  call <sid>hi("@character.special",                   s:gui0F, "", s:cterm0F, "", "", "")
-  call <sid>hi("@comment",                             s:gui03, "", s:cterm03, "", "italic", "")
+  call <sid>hi("@boolean",                  s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@character",                s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@character.special",        s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@comment",                  s:gui03, "", s:cterm03, "", "", "")
 
   " Conditionals, Constants & Debugging
-  call <sid>hi("@keyword.conditional",                 s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@constant",                            s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@constant.builtin",                    s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@constant.macro",                      s:gui08, "", s:cterm08, "", "", "")
-  call <sid>hi("@keyword.debug",                       s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.conditional",      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@constant",                 s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.builtin",         s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@constant.macro",           s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@keyword.debug",            s:gui08, "", s:cterm08, "", "", "")
 
   " Directives & Exceptions
-  call <sid>hi("@keyword.directive.define",            s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@keyword.exception",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.directive.define", s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.exception",        s:gui0E, "", s:cterm0E, "", "", "")
 
   " Floats & Functions
-  call <sid>hi("@number.float",                        s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@function",                            s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("@function.builtin",                    s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("@function.call",                       s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("@function.macro",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@number.float",             s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@function",                 s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.builtin",         s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.call",            s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.macro",           s:gui08, "", s:cterm08, "", "", "")
 
   " Imports, Operators & Returns
-  call <sid>hi("@keyword.import",                      s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@keyword.coroutine",                   s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@keyword.operator",                    s:gui05, "", s:cterm05, "", "", "")
-  call <sid>hi("@keyword.return",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.import",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.coroutine",        s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.operator",         s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@keyword.return",           s:gui0E, "", s:cterm0E, "", "", "")
 
   " Methods & Namespaces
-  call <sid>hi("@function.method",                     s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("@function.method.call",                s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("@namespace.builtin",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@function.method",          s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@function.method.call",     s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@namespace.builtin",        s:gui0E, "", s:cterm0E, "", "", "")
 
   " Numbers & Directives
-  call <sid>hi("@none",                                s:gui05, "", s:cterm05, "", "", "")
-  call <sid>hi("@number",                              s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@keyword.directive",                   s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@none",                     s:gui05, "", s:cterm05, "", "", "")
+  call <sid>hi("@number",                   s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@keyword.directive",        s:gui0E, "", s:cterm0E, "", "", "")
 
   " Repeats, Storage & Strings
-  call <sid>hi("@keyword.repeat",                      s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@keyword.storage",                     s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@string",                              s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@keyword.repeat",           s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@keyword.storage",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@string",                   s:gui0B, "", s:cterm0B, "", "", "")
 
   " Tags & Markup
-  call <sid>hi("@markup.link.label",                   s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.link.label.symbol",            s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@tag",                                 s:gui08, "", s:cterm08, "", "", "")
-  call <sid>hi("@tag.attribute",                       s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@tag.delimiter",                       s:gui0F, "", s:cterm0F, "", "", "")
+  call <sid>hi("@markup.link.label",        s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.label.symbol", s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag",                      s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@tag.attribute",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@tag.delimiter",            s:gui0F, "", s:cterm0F, "", "", "")
 
   " More Markup
-  call <sid>hi("@markup",                              s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.environment",                  s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.environment.name",             s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.raw",                          s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@markup.math",                         s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.strong",                       s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.emphasis",                     s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.strikethrough",                s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.underline",                    s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.heading",                      s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@markup",                   s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment",       s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.environment.name",  s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.raw",               s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@markup.math",              s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strong",            s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.emphasis",          s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.strikethrough",     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.underline",         s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.heading",           s:gui0D, "", s:cterm0D, "", "", "")
 
   " Comments & Types
-  call <sid>hi("@comment.note",                        s:gui03, "", s:cterm03, "", "", "")
-  call <sid>hi("@comment.error",                       s:gui08, "", s:cterm08, "", "", "")
-  call <sid>hi("@comment.hint",                        s:gui0B, "", s:cterm0B, "", "", "")
-  call <sid>hi("@comment.info",                        s:gui0D, "", s:cterm0D, "", "", "")
-  call <sid>hi("@comment.warning",                     s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@comment.todo",                        s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@markup.link.url",                     s:gui09, "", s:cterm09, "", "", "")
-  call <sid>hi("@type",                                s:gui0A, "", s:cterm0A, "", "", "")
-  call <sid>hi("@type.definition",                     s:gui0E, "", s:cterm0E, "", "", "")
-  call <sid>hi("@type.qualifier",                      s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@comment.note",             s:gui03, "", s:cterm03, "", "", "")
+  call <sid>hi("@comment.error",            s:gui08, "", s:cterm08, "", "", "")
+  call <sid>hi("@comment.hint",             s:gui0B, "", s:cterm0B, "", "", "")
+  call <sid>hi("@comment.info",             s:gui0D, "", s:cterm0D, "", "", "")
+  call <sid>hi("@comment.warning",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@comment.todo",             s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@markup.link.url",          s:gui09, "", s:cterm09, "", "", "")
+  call <sid>hi("@type",                     s:gui0A, "", s:cterm0A, "", "", "")
+  call <sid>hi("@type.definition",          s:gui0E, "", s:cterm0E, "", "", "")
+  call <sid>hi("@type.qualifier",           s:gui0E, "", s:cterm0E, "", "", "")
 
   " Nvim 0.10 migration
   if has("nvim-0.10.0")
@@ -421,39 +453,38 @@ if has("nvim-0.8.0")
   endif
 endif
 
-
 " Standard highlights to be used by plugins
 if has("patch-8.0.1038")
   call <sid>hi("Deprecated",   "", "", "", "", "strikethrough", "")
 endif
 call <sid>hi("SearchMatch",  s:gui0C, "", s:cterm0C, "", "", "")
 
-call <sid>hi("GitAddSign",           s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("GitAddSign",           s:gui14, "", s:cterm14, "", "", "")
 call <sid>hi("GitChangeSign",        s:gui04, "", s:cterm04, "", "", "")
-call <sid>hi("GitDeleteSign",        s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("GitDeleteSign",        s:gui12, "", s:cterm12, "", "", "")
 call <sid>hi("GitChangeDeleteSign",  s:gui04, "", s:cterm04, "", "", "")
 
-call <sid>hi("ErrorSign",    s:gui08, "", s:cterm08, "", "", "")
-call <sid>hi("WarningSign",  s:gui09, "", s:cterm09, "", "", "")
-call <sid>hi("InfoSign",     s:gui0D, "", s:cterm0D, "", "", "")
-call <sid>hi("HintSign",     s:gui0C, "", s:cterm0C, "", "", "")
-call <sid>hi("OkSign",       s:gui0B, "", s:cterm0B, "", "", "")
+call <sid>hi("ErrorSign",    s:gui12, "", s:cterm12, "", "", "")
+call <sid>hi("WarningSign",  s:gui13, "", s:cterm13, "", "", "")
+call <sid>hi("InfoSign",     s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("HintSign",     s:gui15, "", s:cterm15, "", "", "")
+call <sid>hi("OkSign",       s:gui14, "", s:cterm14, "", "", "")
 
-call <sid>hi("ErrorFloat",   s:gui08, s:gui01, s:cterm08, s:cterm01, "", "")
-call <sid>hi("WarningFloat", s:gui09, s:gui01, s:cterm09, s:cterm01, "", "")
-call <sid>hi("InfoFloat",    s:gui0D, s:gui01, s:cterm0D, s:cterm01, "", "")
-call <sid>hi("HintFloat",    s:gui0C, s:gui01, s:cterm0C, s:cterm01, "", "")
-call <sid>hi("OkFloat",      s:gui0B, s:gui01, s:cterm0B, s:cterm01, "", "")
+call <sid>hi("ErrorFloat",   s:gui12, s:gui01, s:cterm12, s:cterm01, "", "")
+call <sid>hi("WarningFloat", s:gui13, s:gui01, s:cterm13, s:cterm01, "", "")
+call <sid>hi("InfoFloat",    s:gui16, s:gui01, s:cterm16, s:cterm01, "", "")
+call <sid>hi("HintFloat",    s:gui15, s:gui01, s:cterm15, s:cterm01, "", "")
+call <sid>hi("OkFloat",      s:gui14, s:gui01, s:cterm14, s:cterm01, "", "")
 
-call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm08, "underline", s:gui08)
-call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm09, "underline", s:gui09)
-call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm0D, "underline", s:gui0D)
-call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm0C, "underline", s:gui0C)
-call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm0B, "underline", s:gui0B)
+call <sid>hi("ErrorHighlight",   "", "", s:ctermbg, s:cterm12, "underline", s:gui12)
+call <sid>hi("WarningHighlight", "", "", s:ctermbg, s:cterm13, "underline", s:gui13)
+call <sid>hi("InfoHighlight",    "", "", s:ctermbg, s:cterm16, "underline", s:gui16)
+call <sid>hi("HintHighlight",    "", "", s:ctermbg, s:cterm15, "underline", s:gui15)
+call <sid>hi("OkHighlight",      "", "", s:ctermbg, s:cterm14, "underline", s:gui14)
 
-call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm08, "undercurl", s:gui08)
-call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm0C, "undercurl", s:gui0C)
-call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm0D, "undercurl", s:gui0D)
+call <sid>hi("SpellBad",     "", "", s:ctermbg, s:cterm12, "undercurl", s:gui08)
+call <sid>hi("SpellLocal",   "", "", s:ctermbg, s:cterm15, "undercurl", s:gui15)
+call <sid>hi("SpellCap",     "", "", s:ctermbg, s:cterm16, "undercurl", s:gui16)
 call <sid>hi("SpellRare",    "", "", s:ctermbg, s:cterm0E, "undercurl", s:gui0E)
 
 call <sid>hi("ReferenceText",   s:gui01, s:gui0A, s:cterm01, s:cterm0A, "", "")
@@ -594,15 +625,15 @@ if has("nvim-0.8.0")
 endif
 
 " Diff
-call <sid>hi("DiffAdd",      s:gui0B, s:gui01,  s:cterm0B, s:cterm01, "", "")
+call <sid>hi("DiffAdd",      s:gui14, s:gui01,  s:cterm14, s:cterm01, "", "")
 call <sid>hi("DiffChange",   s:gui05, s:gui01,  s:cterm05, s:cterm01, "", "")
 call <sid>hi("DiffDelete",   s:gui02, s:guibg,  s:cterm02, s:ctermbg, "", "")
-call <sid>hi("DiffText",     s:gui0D, s:gui01,  s:cterm0D, s:cterm01, "", "")
-call <sid>hi("DiffAdded",    s:gui0B, s:guibg,  s:cterm0B, s:ctermbg, "", "")
-call <sid>hi("DiffFile",     s:gui08, s:guibg,  s:cterm08, s:ctermbg, "", "")
-call <sid>hi("DiffNewFile",  s:gui0B, s:guibg,  s:cterm0B, s:ctermbg, "", "")
-call <sid>hi("DiffLine",     s:gui0D, s:guibg,  s:cterm0D, s:ctermbg, "", "")
-call <sid>hi("DiffRemoved",  s:gui08, s:guibg,  s:cterm08, s:ctermbg, "", "")
+call <sid>hi("DiffText",     s:gui16, s:gui01,  s:cterm16, s:cterm01, "", "")
+call <sid>hi("DiffAdded",    s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffFile",     s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
+call <sid>hi("DiffNewFile",  s:gui14, s:guibg,  s:cterm14, s:ctermbg, "", "")
+call <sid>hi("DiffLine",     s:gui16, s:guibg,  s:cterm16, s:ctermbg, "", "")
+call <sid>hi("DiffRemoved",  s:gui12, s:guibg,  s:cterm12, s:ctermbg, "", "")
 
 " Git
 call <sid>hi("gitcommitOverflow",       s:gui08, "", s:cterm08, "", "", "")
@@ -611,11 +642,11 @@ call <sid>hi("gitcommitComment",        s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("gitcommitUntracked",      s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("gitcommitDiscarded",      s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("gitcommitSelected",       s:gui03, "", s:cterm03, "", "", "")
-call <sid>hi("gitcommitHeader",         s:gui0E, "", s:cterm0E, "", "", "")
-call <sid>hi("gitcommitSelectedType",   s:gui0D, "", s:cterm0D, "", "", "")
-call <sid>hi("gitcommitUnmergedType",   s:gui0D, "", s:cterm0D, "", "", "")
-call <sid>hi("gitcommitDiscardedType",  s:gui0D, "", s:cterm0D, "", "", "")
-call <sid>hi("gitcommitBranch",         s:gui09, "", s:cterm09, "", "bold", "")
+call <sid>hi("gitcommitHeader",         s:gui17, "", s:cterm17, "", "", "")
+call <sid>hi("gitcommitSelectedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitUnmergedType",   s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitDiscardedType",  s:gui16, "", s:cterm16, "", "", "")
+call <sid>hi("gitcommitBranch",         s:gui13, "", s:cterm13, "", "bold", "")
 call <sid>hi("gitcommitUntrackedFile",  s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("gitcommitUnmergedFile",   s:gui08, "", s:cterm08, "", "bold", "")
 call <sid>hi("gitcommitDiscardedFile",  s:gui08, "", s:cterm08, "", "bold", "")
@@ -629,12 +660,12 @@ hi! link GitGutterChangeDelete   GitChangeDeleteSign
 
 " indent-blankline (nvim)
 if has("nvim")
-  call <sid>hi("@ibl.indent.char.1",s:gui01, "", s:cterm01, "", "", "")
+  call <sid>hi("@ibl.indent.char", s:gui01, "", s:cterm01, "", "", "")
 endif
 
 " HTML
 call <sid>hi("htmlBold",    s:gui05, "", s:cterm0A, "", "bold", "")
-call <sid>hi("htmlItalic",  s:gui05, "", s:cterm0E, "", "italic", "")
+call <sid>hi("htmlItalic",  s:gui05, "", s:cterm17, "", "italic", "")
 call <sid>hi("htmlEndTag",  s:gui05, "", s:cterm05, "", "", "")
 call <sid>hi("htmlTag",     s:gui05, "", s:cterm05, "", "", "")
 
@@ -776,7 +807,6 @@ if has("nvim")
   hi! link LspReferenceText   ReferenceText
   hi! link LspReferenceRead   ReferenceRead
   hi! link LspReferenceWrite  ReferenceWrite
-
   "  https://neovim.io/doc/user/news-0.10.html
   if has("nvim-0.10.0")
     hi! link WinSeparator VertSplit
@@ -792,5 +822,5 @@ call <sid>hi("javaOperator", s:gui0D, "", s:cterm0D, "", "", "")
 delf <sid>hi
 
 " Remove color variables
-unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg
-unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg
+unlet s:gui00 s:gui01 s:gui02 s:gui03 s:gui04 s:gui05 s:gui06 s:gui07 s:gui08 s:gui09 s:gui0A s:gui0B s:gui0C s:gui0D s:gui0E s:gui0F s:guibg s:gui10 s:gui11 s:gui12 s:gui13 s:gui14 s:gui15 s:gui16 s:gui17
+unlet s:cterm00 s:cterm01 s:cterm02 s:cterm03 s:cterm04 s:cterm05 s:cterm06 s:cterm07 s:cterm08 s:cterm09 s:cterm0A s:cterm0B s:cterm0C s:cterm0D s:cterm0E s:cterm0F s:ctermbg s:cterm10 s:cterm11 s:cterm12 s:cterm13 s:cterm14 s:cterm15 s:cterm16 s:cterm17

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,3 +1,7 @@
-default: 
-    extension: .vim
-    output: colors
+base16:
+    filename: colors/{{ scheme-system }}-{{ scheme-slug }}.vim
+    supported-systems: [base16]
+
+base24:
+    filename: colors/{{ scheme-system }}-{{ scheme-slug }}.vim
+    supported-systems: [base24]


### PR DESCRIPTION
## Description

- Add Base24 template support and rename repo to tinted-vim
- Require PRs to include built files in separate commit

## Checklist

- [x] I have included the built files `./colors/*.vim` in a separate commit and followed [the build instructions](https://github.com/tinted-theming/tinted-vim/blob/main/CONTRIBUTING.md)
- [x] I have confirmed that my changes produce no regressions after building