### PR TITLE
Improve rust and markdown

### DIFF
--- a/colors/base16-3024.vim
+++ b/colors/base16-3024.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-apathy.vim
+++ b/colors/base16-apathy.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-apprentice.vim
+++ b/colors/base16-apprentice.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ashes.vim
+++ b/colors/base16-ashes.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-cave-light.vim
+++ b/colors/base16-atelier-cave-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-cave.vim
+++ b/colors/base16-atelier-cave.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-dune-light.vim
+++ b/colors/base16-atelier-dune-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-dune.vim
+++ b/colors/base16-atelier-dune.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-estuary-light.vim
+++ b/colors/base16-atelier-estuary-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-estuary.vim
+++ b/colors/base16-atelier-estuary.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-forest-light.vim
+++ b/colors/base16-atelier-forest-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-forest.vim
+++ b/colors/base16-atelier-forest.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-heath-light.vim
+++ b/colors/base16-atelier-heath-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-heath.vim
+++ b/colors/base16-atelier-heath.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-lakeside-light.vim
+++ b/colors/base16-atelier-lakeside-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-lakeside.vim
+++ b/colors/base16-atelier-lakeside.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-plateau-light.vim
+++ b/colors/base16-atelier-plateau-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-plateau.vim
+++ b/colors/base16-atelier-plateau.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-savanna-light.vim
+++ b/colors/base16-atelier-savanna-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-savanna.vim
+++ b/colors/base16-atelier-savanna.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-seaside-light.vim
+++ b/colors/base16-atelier-seaside-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-seaside.vim
+++ b/colors/base16-atelier-seaside.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-sulphurpool-light.vim
+++ b/colors/base16-atelier-sulphurpool-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atelier-sulphurpool.vim
+++ b/colors/base16-atelier-sulphurpool.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-atlas.vim
+++ b/colors/base16-atlas.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ayu-dark.vim
+++ b/colors/base16-ayu-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ayu-light.vim
+++ b/colors/base16-ayu-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ayu-mirage.vim
+++ b/colors/base16-ayu-mirage.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-aztec.vim
+++ b/colors/base16-aztec.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-bespin.vim
+++ b/colors/base16-bespin.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-bathory.vim
+++ b/colors/base16-black-metal-bathory.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-burzum.vim
+++ b/colors/base16-black-metal-burzum.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-dark-funeral.vim
+++ b/colors/base16-black-metal-dark-funeral.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-gorgoroth.vim
+++ b/colors/base16-black-metal-gorgoroth.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-immortal.vim
+++ b/colors/base16-black-metal-immortal.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-khold.vim
+++ b/colors/base16-black-metal-khold.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-marduk.vim
+++ b/colors/base16-black-metal-marduk.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-mayhem.vim
+++ b/colors/base16-black-metal-mayhem.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-nile.vim
+++ b/colors/base16-black-metal-nile.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal-venom.vim
+++ b/colors/base16-black-metal-venom.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-black-metal.vim
+++ b/colors/base16-black-metal.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-blueforest.vim
+++ b/colors/base16-blueforest.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-blueish.vim
+++ b/colors/base16-blueish.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-brewer.vim
+++ b/colors/base16-brewer.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-bright.vim
+++ b/colors/base16-bright.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-brogrammer.vim
+++ b/colors/base16-brogrammer.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-brushtrees-dark.vim
+++ b/colors/base16-brushtrees-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-brushtrees.vim
+++ b/colors/base16-brushtrees.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-caroline.vim
+++ b/colors/base16-caroline.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-catppuccin-frappe.vim
+++ b/colors/base16-catppuccin-frappe.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-catppuccin-latte.vim
+++ b/colors/base16-catppuccin-latte.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-catppuccin-macchiato.vim
+++ b/colors/base16-catppuccin-macchiato.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-catppuccin-mocha.vim
+++ b/colors/base16-catppuccin-mocha.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-chalk.vim
+++ b/colors/base16-chalk.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-circus.vim
+++ b/colors/base16-circus.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-classic-dark.vim
+++ b/colors/base16-classic-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-classic-light.vim
+++ b/colors/base16-classic-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-codeschool.vim
+++ b/colors/base16-codeschool.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-colors.vim
+++ b/colors/base16-colors.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-cupcake.vim
+++ b/colors/base16-cupcake.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-cupertino.vim
+++ b/colors/base16-cupertino.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-da-one-black.vim
+++ b/colors/base16-da-one-black.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-da-one-gray.vim
+++ b/colors/base16-da-one-gray.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-da-one-ocean.vim
+++ b/colors/base16-da-one-ocean.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-da-one-paper.vim
+++ b/colors/base16-da-one-paper.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-da-one-sea.vim
+++ b/colors/base16-da-one-sea.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-da-one-white.vim
+++ b/colors/base16-da-one-white.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-danqing-light.vim
+++ b/colors/base16-danqing-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-danqing.vim
+++ b/colors/base16-danqing.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-darcula.vim
+++ b/colors/base16-darcula.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-darkmoss.vim
+++ b/colors/base16-darkmoss.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-darktooth.vim
+++ b/colors/base16-darktooth.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-darkviolet.vim
+++ b/colors/base16-darkviolet.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-decaf.vim
+++ b/colors/base16-decaf.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-deep-oceanic-next.vim
+++ b/colors/base16-deep-oceanic-next.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-default-dark.vim
+++ b/colors/base16-default-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-default-light.vim
+++ b/colors/base16-default-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-dirtysea.vim
+++ b/colors/base16-dirtysea.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-dracula.vim
+++ b/colors/base16-dracula.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-edge-dark.vim
+++ b/colors/base16-edge-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-edge-light.vim
+++ b/colors/base16-edge-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-eighties.vim
+++ b/colors/base16-eighties.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-embers-light.vim
+++ b/colors/base16-embers-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-embers.vim
+++ b/colors/base16-embers.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-emil.vim
+++ b/colors/base16-emil.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-equilibrium-dark.vim
+++ b/colors/base16-equilibrium-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-equilibrium-gray-dark.vim
+++ b/colors/base16-equilibrium-gray-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-equilibrium-gray-light.vim
+++ b/colors/base16-equilibrium-gray-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-equilibrium-light.vim
+++ b/colors/base16-equilibrium-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-eris.vim
+++ b/colors/base16-eris.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-espresso.vim
+++ b/colors/base16-espresso.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-eva-dim.vim
+++ b/colors/base16-eva-dim.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-eva.vim
+++ b/colors/base16-eva.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-evenok-dark.vim
+++ b/colors/base16-evenok-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-everforest-dark-hard.vim
+++ b/colors/base16-everforest-dark-hard.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-everforest.vim
+++ b/colors/base16-everforest.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-flat.vim
+++ b/colors/base16-flat.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-framer.vim
+++ b/colors/base16-framer.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-fruit-soda.vim
+++ b/colors/base16-fruit-soda.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gigavolt.vim
+++ b/colors/base16-gigavolt.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-github.vim
+++ b/colors/base16-github.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-google-dark.vim
+++ b/colors/base16-google-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-google-light.vim
+++ b/colors/base16-google-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gotham.vim
+++ b/colors/base16-gotham.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-grayscale-dark.vim
+++ b/colors/base16-grayscale-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-grayscale-light.vim
+++ b/colors/base16-grayscale-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-greenscreen.vim
+++ b/colors/base16-greenscreen.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruber.vim
+++ b/colors/base16-gruber.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-dark-hard.vim
+++ b/colors/base16-gruvbox-dark-hard.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-dark-medium.vim
+++ b/colors/base16-gruvbox-dark-medium.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-dark-pale.vim
+++ b/colors/base16-gruvbox-dark-pale.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-dark-soft.vim
+++ b/colors/base16-gruvbox-dark-soft.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-light-hard.vim
+++ b/colors/base16-gruvbox-light-hard.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-light-medium.vim
+++ b/colors/base16-gruvbox-light-medium.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-light-soft.vim
+++ b/colors/base16-gruvbox-light-soft.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-material-dark-hard.vim
+++ b/colors/base16-gruvbox-material-dark-hard.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-material-dark-medium.vim
+++ b/colors/base16-gruvbox-material-dark-medium.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-material-dark-soft.vim
+++ b/colors/base16-gruvbox-material-dark-soft.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-material-light-hard.vim
+++ b/colors/base16-gruvbox-material-light-hard.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-material-light-medium.vim
+++ b/colors/base16-gruvbox-material-light-medium.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-gruvbox-material-light-soft.vim
+++ b/colors/base16-gruvbox-material-light-soft.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-hardcore.vim
+++ b/colors/base16-hardcore.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-harmonic16-dark.vim
+++ b/colors/base16-harmonic16-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-harmonic16-light.vim
+++ b/colors/base16-harmonic16-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-heetch-light.vim
+++ b/colors/base16-heetch-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-heetch.vim
+++ b/colors/base16-heetch.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-helios.vim
+++ b/colors/base16-helios.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-hopscotch.vim
+++ b/colors/base16-hopscotch.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-horizon-dark.vim
+++ b/colors/base16-horizon-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-horizon-light.vim
+++ b/colors/base16-horizon-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-humanoid-dark.vim
+++ b/colors/base16-humanoid-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-humanoid-light.vim
+++ b/colors/base16-humanoid-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ia-dark.vim
+++ b/colors/base16-ia-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ia-light.vim
+++ b/colors/base16-ia-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-icy.vim
+++ b/colors/base16-icy.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-irblack.vim
+++ b/colors/base16-irblack.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-isotope.vim
+++ b/colors/base16-isotope.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-jabuti.vim
+++ b/colors/base16-jabuti.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-kanagawa.vim
+++ b/colors/base16-kanagawa.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-katy.vim
+++ b/colors/base16-katy.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-kimber.vim
+++ b/colors/base16-kimber.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-lime.vim
+++ b/colors/base16-lime.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-macintosh.vim
+++ b/colors/base16-macintosh.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-marrakesh.vim
+++ b/colors/base16-marrakesh.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-materia.vim
+++ b/colors/base16-materia.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-material-darker.vim
+++ b/colors/base16-material-darker.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-material-lighter.vim
+++ b/colors/base16-material-lighter.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-material-palenight.vim
+++ b/colors/base16-material-palenight.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-material-vivid.vim
+++ b/colors/base16-material-vivid.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-material.vim
+++ b/colors/base16-material.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-measured-dark.vim
+++ b/colors/base16-measured-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-measured-light.vim
+++ b/colors/base16-measured-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-mellow-purple.vim
+++ b/colors/base16-mellow-purple.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-mexico-light.vim
+++ b/colors/base16-mexico-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-mocha.vim
+++ b/colors/base16-mocha.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-monokai.vim
+++ b/colors/base16-monokai.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-moonlight.vim
+++ b/colors/base16-moonlight.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-mountain.vim
+++ b/colors/base16-mountain.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-nebula.vim
+++ b/colors/base16-nebula.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-nord-light.vim
+++ b/colors/base16-nord-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-nord.vim
+++ b/colors/base16-nord.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-nova.vim
+++ b/colors/base16-nova.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-ocean.vim
+++ b/colors/base16-ocean.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-oceanicnext.vim
+++ b/colors/base16-oceanicnext.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-one-light.vim
+++ b/colors/base16-one-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-onedark-dark.vim
+++ b/colors/base16-onedark-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-onedark.vim
+++ b/colors/base16-onedark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-outrun-dark.vim
+++ b/colors/base16-outrun-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-oxocarbon-dark.vim
+++ b/colors/base16-oxocarbon-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-oxocarbon-light.vim
+++ b/colors/base16-oxocarbon-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-pandora.vim
+++ b/colors/base16-pandora.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-papercolor-dark.vim
+++ b/colors/base16-papercolor-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-papercolor-light.vim
+++ b/colors/base16-papercolor-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-paraiso.vim
+++ b/colors/base16-paraiso.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-pasque.vim
+++ b/colors/base16-pasque.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-phd.vim
+++ b/colors/base16-phd.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-pico.vim
+++ b/colors/base16-pico.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-pinky.vim
+++ b/colors/base16-pinky.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-pop.vim
+++ b/colors/base16-pop.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-porple.vim
+++ b/colors/base16-porple.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-precious-dark-eleven.vim
+++ b/colors/base16-precious-dark-eleven.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-precious-dark-fifteen.vim
+++ b/colors/base16-precious-dark-fifteen.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-precious-light-warm.vim
+++ b/colors/base16-precious-light-warm.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-precious-light-white.vim
+++ b/colors/base16-precious-light-white.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-primer-dark-dimmed.vim
+++ b/colors/base16-primer-dark-dimmed.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-primer-dark.vim
+++ b/colors/base16-primer-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-primer-light.vim
+++ b/colors/base16-primer-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-purpledream.vim
+++ b/colors/base16-purpledream.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-qualia.vim
+++ b/colors/base16-qualia.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-railscasts.vim
+++ b/colors/base16-railscasts.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-rebecca.vim
+++ b/colors/base16-rebecca.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-rose-pine-dawn.vim
+++ b/colors/base16-rose-pine-dawn.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-rose-pine-moon.vim
+++ b/colors/base16-rose-pine-moon.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-rose-pine.vim
+++ b/colors/base16-rose-pine.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-saga.vim
+++ b/colors/base16-saga.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-sagelight.vim
+++ b/colors/base16-sagelight.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-sakura.vim
+++ b/colors/base16-sakura.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-sandcastle.vim
+++ b/colors/base16-sandcastle.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-selenized-black.vim
+++ b/colors/base16-selenized-black.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-selenized-dark.vim
+++ b/colors/base16-selenized-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-selenized-light.vim
+++ b/colors/base16-selenized-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-selenized-white.vim
+++ b/colors/base16-selenized-white.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-seti.vim
+++ b/colors/base16-seti.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-shades-of-purple.vim
+++ b/colors/base16-shades-of-purple.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-shadesmear-dark.vim
+++ b/colors/base16-shadesmear-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-shadesmear-light.vim
+++ b/colors/base16-shadesmear-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-shapeshifter.vim
+++ b/colors/base16-shapeshifter.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-silk-dark.vim
+++ b/colors/base16-silk-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-silk-light.vim
+++ b/colors/base16-silk-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-snazzy.vim
+++ b/colors/base16-snazzy.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-solarflare-light.vim
+++ b/colors/base16-solarflare-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-solarflare.vim
+++ b/colors/base16-solarflare.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-solarized-dark.vim
+++ b/colors/base16-solarized-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-solarized-light.vim
+++ b/colors/base16-solarized-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-spaceduck.vim
+++ b/colors/base16-spaceduck.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-spacemacs.vim
+++ b/colors/base16-spacemacs.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-sparky.vim
+++ b/colors/base16-sparky.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-standardized-dark.vim
+++ b/colors/base16-standardized-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-standardized-light.vim
+++ b/colors/base16-standardized-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-stella.vim
+++ b/colors/base16-stella.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-still-alive.vim
+++ b/colors/base16-still-alive.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-summercamp.vim
+++ b/colors/base16-summercamp.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-summerfruit-dark.vim
+++ b/colors/base16-summerfruit-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-summerfruit-light.vim
+++ b/colors/base16-summerfruit-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-synth-midnight-dark.vim
+++ b/colors/base16-synth-midnight-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-synth-midnight-light.vim
+++ b/colors/base16-synth-midnight-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tango.vim
+++ b/colors/base16-tango.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tarot.vim
+++ b/colors/base16-tarot.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tender.vim
+++ b/colors/base16-tender.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-terracotta-dark.vim
+++ b/colors/base16-terracotta-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-terracotta.vim
+++ b/colors/base16-terracotta.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-city-dark.vim
+++ b/colors/base16-tokyo-city-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-city-light.vim
+++ b/colors/base16-tokyo-city-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-city-terminal-dark.vim
+++ b/colors/base16-tokyo-city-terminal-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-city-terminal-light.vim
+++ b/colors/base16-tokyo-city-terminal-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-dark.vim
+++ b/colors/base16-tokyo-night-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-light.vim
+++ b/colors/base16-tokyo-night-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-moon.vim
+++ b/colors/base16-tokyo-night-moon.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-storm.vim
+++ b/colors/base16-tokyo-night-storm.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-terminal-dark.vim
+++ b/colors/base16-tokyo-night-terminal-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-terminal-light.vim
+++ b/colors/base16-tokyo-night-terminal-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyo-night-terminal-storm.vim
+++ b/colors/base16-tokyo-night-terminal-storm.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyodark-terminal.vim
+++ b/colors/base16-tokyodark-terminal.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tokyodark.vim
+++ b/colors/base16-tokyodark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tomorrow-night-eighties.vim
+++ b/colors/base16-tomorrow-night-eighties.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tomorrow-night.vim
+++ b/colors/base16-tomorrow-night.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tomorrow.vim
+++ b/colors/base16-tomorrow.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-tube.vim
+++ b/colors/base16-tube.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-twilight.vim
+++ b/colors/base16-twilight.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-unikitty-dark.vim
+++ b/colors/base16-unikitty-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-unikitty-light.vim
+++ b/colors/base16-unikitty-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-unikitty-reversible.vim
+++ b/colors/base16-unikitty-reversible.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-uwunicorn.vim
+++ b/colors/base16-uwunicorn.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-vesper.vim
+++ b/colors/base16-vesper.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-vice.vim
+++ b/colors/base16-vice.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-vulcan.vim
+++ b/colors/base16-vulcan.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-10-light.vim
+++ b/colors/base16-windows-10-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-10.vim
+++ b/colors/base16-windows-10.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-95-light.vim
+++ b/colors/base16-windows-95-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-95.vim
+++ b/colors/base16-windows-95.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-highcontrast-light.vim
+++ b/colors/base16-windows-highcontrast-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-highcontrast.vim
+++ b/colors/base16-windows-highcontrast.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-nt-light.vim
+++ b/colors/base16-windows-nt-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-windows-nt.vim
+++ b/colors/base16-windows-nt.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-woodland.vim
+++ b/colors/base16-woodland.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-xcode-dusk.vim
+++ b/colors/base16-xcode-dusk.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-zenbones.vim
+++ b/colors/base16-zenbones.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base16-zenburn.vim
+++ b/colors/base16-zenburn.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-brogrammer.vim
+++ b/colors/base24-brogrammer.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-catppuccin-frappe.vim
+++ b/colors/base24-catppuccin-frappe.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-catppuccin-latte.vim
+++ b/colors/base24-catppuccin-latte.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-catppuccin-macchiato.vim
+++ b/colors/base24-catppuccin-macchiato.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-catppuccin-mocha.vim
+++ b/colors/base24-catppuccin-mocha.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-chalk.vim
+++ b/colors/base24-chalk.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-deep-oceanic-next.vim
+++ b/colors/base24-deep-oceanic-next.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-dracula.vim
+++ b/colors/base24-dracula.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-espresso.vim
+++ b/colors/base24-espresso.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-flat.vim
+++ b/colors/base24-flat.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-framer.vim
+++ b/colors/base24-framer.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-github.vim
+++ b/colors/base24-github.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-hardcore.vim
+++ b/colors/base24-hardcore.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-one-black.vim
+++ b/colors/base24-one-black.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-one-dark.vim
+++ b/colors/base24-one-dark.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-one-light.vim
+++ b/colors/base24-one-light.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/colors/base24-sparky.vim
+++ b/colors/base24-sparky.vim
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')

--- a/templates/tinted-vim.mustache
+++ b/templates/tinted-vim.mustache
@@ -340,7 +340,7 @@ call <sid>hi('Typedef',        s:gui0A, '', s:cterm0A, '', 'none', '')
 
 call <sid>hi('Special',        s:gui0C, '', s:cterm0C, '', 'none', '')
 call <sid>hi('SpecialChar',    s:gui0A, '', s:cterm0A, '', 'none', '')
-call <sid>hi('Tag',            s:gui08, '', s:cterm08, '', 'none', '')
+call <sid>hi('Tag',            s:gui09, '', s:cterm09, '', 'none', '')
 call <sid>hi('Delimiter',      s:gui05, '', s:cterm05, '', 'none', '')
 call <sid>hi('SpecialComment', s:gui0A, '', s:cterm0A, '', 'italic', '')
 
@@ -420,7 +420,7 @@ if has('nvim-0.8.0')
   hi! link @keyword.type Keyword
   hi! link @keyword.modifier Repeat
   hi! link @keyword.repeat Repeat
-  hi! link @keyword.return Repeat
+  hi! link @keyword.return Keyword
   hi! link @keyword.debug Debug
   hi! link @keyword.exception Exception
 
@@ -451,9 +451,9 @@ if has('nvim-0.8.0')
   hi! link @markup.quote String
   hi! link @markup.math Special
 
-  hi! link @markup.link Operator
-  hi! link @markup.link.label Tag
-  hi! link @markup.link.url @string.special.url
+  call <sid>hi('@markup.link',  s:gui08, '', s:cterm08, '', '', '')
+  hi! link @markup.link.label   @markup.link
+  hi! link @markup.link.url     Identifier
 
   call <sid>hi('@markup.raw',   s:gui04, '', s:cterm04, '', '', '')
   hi! link @markup.raw.block Identifier
@@ -466,10 +466,10 @@ if has('nvim-0.8.0')
   hi! link @diff.minus Removed
   hi! link @diff.delta Changed
 
-  hi! link @tag Tag
-  call <sid>hi('@tag.builtin',   s:gui08, '', s:cterm08, '', 'italic', '')
-  call <sid>hi('@tag.attribute', s:gui09, '', s:cterm09, '', 'italic', '')
-  hi! link @tag.delimiter Delimiter
+  hi! link @tag                 Tag
+  call <sid>hi('@tag.builtin',  s:gui09, '', s:cterm09, '', 'italic', '')
+  hi! link @tag.attribute       Special
+  hi! link @tag.delimiter       Delimiter
 
 
   " LSP Semantic Token
@@ -517,22 +517,22 @@ if has('nvim-0.8.0')
   hi! link @lsp.type.selfKeyword.rust               @variable.builtin
   hi! link @lsp.type.selfTypeKeyword.rust           @type.builtin
 
-  call <sid>hi('@lsp.mod.attribute',    '', '', '', '', 'italic', '')
+  call <sid>hi('@lsp.mod.attribute',                '', '', '', '', 'italic', '')
   hi! link @lsp.mod.controlFlow                     @keyword.repeat
-  hi! link @lsp.mod.intraDocLink.rust               @string.special.url
+  hi! link @lsp.mod.intraDocLink.rust               @markup.link
 
-  hi! link @lsp.typemod.generic.injected            @variable
-  hi! link @lsp.typemod.operator.controlFlow        @operator
-  hi! link @lsp.typemod.function.associated.Rust    @function.method
+  hi! link @lsp.typemod.generic.injected.rust       @variable
+  hi! link @lsp.typemod.operator.controlFlow.rust   @operator
+  hi! link @lsp.typemod.function.associated.rust    @function.method
 
   " LUA
-  hi! link @lsp.typemod.keyword.documentation.lua @tag
+  hi! link @lsp.typemod.keyword.documentation.lua   @tag
 
   " Markdown
   hi! link @lsp.type.class.markdown @lsp
 
 
-  " LSP non syntax
+  " LSP not syntax
 
   hi! link LspReferenceText Search
   call <sid>hi('LspReferenceRead',  s:gui01, s:gui14, s:cterm01, s:cterm14, '', '')


### PR DESCRIPTION
Links should be always red (08) and tags are now orange (09).

## Checklist

- [X] I have included the built files `./colors/*.vim` in a separate commit and followed [the build instructions](https://github.com/tinted-theming/tinted-vim/blob/main/CONTRIBUTING.md)
- [X] I have confirmed that my changes produce no regressions after building
