### PR TITLE
Fix diff related highlights

### DIFF
--- a/templates/tinted-vim.mustache
+++ b/templates/tinted-vim.mustache
@@ -228,7 +228,7 @@ call <sid>hi('Directory',     s:gui0D, '', s:cterm0D, '', '', '')
 call <sid>hi('DiffAdd',       '', s:gui01,  '', s:cterm01, '', '')
 call <sid>hi('DiffChange',    '', s:gui01,  '', s:cterm01, '', '')
 call <sid>hi('DiffDelete',    s:gui03, s:guibg,  s:cterm03, s:ctermbg, '', '')
-call <sid>hi('DiffText',      '', s:gui03,  '', s:cterm03, '', '')
+call <sid>hi('DiffText',      '', s:gui02,  '', s:cterm02, '', '')
 
 call <sid>hi('EndOfBuffer',   s:guibg, s:guibg, s:ctermbg, s:ctermbg, '', '')
 call <sid>hi('ErrorMsg',      s:gui08, '', s:cterm08, '', '', '')
@@ -613,10 +613,10 @@ call <sid>hi('gitcommitDiscardedFile', s:gui08, '', s:cterm08, '', 'bold', '')
 call <sid>hi('gitcommitSelectedFile',  s:gui0B, '', s:cterm0B, '', 'bold', '')
 
 " Gitsigns
-call <sid>hi('GitSignsAddInline',           s:gui14, s:gui03, s:cterm14, s:cterm03, '', '')
-call <sid>hi('GitSignsChangeInline',        s:gui16, s:gui03, s:cterm16, s:cterm03, '', '')
-call <sid>hi('GitSignsDeleteLnInline',      s:gui12, s:gui03, s:cterm12, s:cterm03, '', '')
-call <sid>hi('GitSignsDeleteVirtLnInline',  s:gui16, s:gui03, s:cterm16, s:cterm03, '', '')
+call <sid>hi('GitSignsAddInline',           s:gui14, s:gui02, s:cterm14, s:cterm02, '', '')
+call <sid>hi('GitSignsChangeInline',        s:gui16, s:gui02, s:cterm16, s:cterm02, '', '')
+call <sid>hi('GitSignsDeleteLnInline',      s:gui12, s:gui02, s:cterm12, s:cterm02, '', '')
+call <sid>hi('GitSignsDeleteVirtLnInline',  s:gui16, s:gui02, s:cterm16, s:cterm02, '', '')
 call <sid>hi('GitSignsDeleteVirtLn',        s:gui05, s:gui02, s:cterm05, s:cterm02, '', '')
 
 " HTML


### PR DESCRIPTION
They did clash with comments.

## Checklist

- [x] I have **NOT** included the built files `./colors/*.vim` in this
  PR since the bot will build the files on merge to `main`
- [x] I have confirmed that my changes produce no regressions after building
