### PR TITLE
Check both(?) legacy properties

### DIFF
--- a/templates/tinted-vim.mustache
+++ b/templates/tinted-vim.mustache
@@ -69,7 +69,7 @@ let s:cterm17  = '{{#base17-hex}}13{{/base17-hex}}{{^base17-hex}}05{{/base17-hex
 
 " base16_colorspace` and `base16colorspace` are legacy properties and
 " exist to keep existing setups from breaking
-if (exists('base16colorspace') && base16_colorspace !=? '256') || (exists('tinted_colorspace') && tinted_colorspace !=? '256')
+if (exists('base16_colorspace') && base16_colorspace !=? '256') || (exists('base16colorspace') && base16colorspace !=? '256') || (exists('tinted_colorspace') && tinted_colorspace !=? '256')
   " We have only 16 colors so define fallbacks for codes > 15
   let s:cterm01 = s:cterm00
   let s:cterm02 = s:cterm03


### PR DESCRIPTION
## Description

Both `base16_colorspace` _and_ `base16colorspace` must be checked for existence _and_ value

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


## Checklist

- [x] I have **NOT** included the built files `./colors/*.vim` in this
  PR since the bot will build the files on merge to `main`
- [x] I have confirmed that my changes produce no regressions after building
